### PR TITLE
BRC-124: SSM transport note; remove stale proxy binary name

### DIFF
--- a/transactions/0124.md
+++ b/transactions/0124.md
@@ -4,7 +4,7 @@ Jeff Harris (jeff@lightweb.net)
 
 ## Abstract
 
-This BRC specifies the wire format for transporting BSV transactions over IPv6 multicast and TCP/UDP unicast. The format extends the legacy BRC-12 frame with additional fields for flow identification, sequence tracking, and subtree identification. All fields are 8-byte aligned for efficient memory access on 64-bit architectures.
+This BRC specifies the wire format for transporting BSV transactions over IPv6 multicast and TCP/UDP unicast. The format extends the legacy BRC-12 frame with additional fields for flow identification, sequence tracking, and subtree identification. All fields are 8-byte aligned for efficient memory access on 64-bit architectures. The frame is transport-agnostic: the on-wire bytes are identical under Any-Source (ASM) and Source-Specific (SSM) multicast. Multicast group addressing, scopes, and the SSM `(S,G)` join and source-discovery model are specified in [BRC-129](./0129.md); the frame's source is the emitting proxy (`senderIPv6`, the first `HashKey` ingredient).
 
 ## Copyright
 
@@ -75,7 +75,7 @@ HashKey = XXH64(senderIPv6 [16B] ∥ groupIdx [4B BE] ∥ subtreeID [32B])
 
 The 52-byte hash input combines the sender's IPv6 address, the derived multicast group index, and the subtree identifier to produce an 8-byte key that is constant for all frames in a flow. This enables per-flow gap tracking, NACK dispatch, and cache lookup without carrying the full 52 bytes in every frame.
 
-This field is stamped in-place by the ingress proxy (`bitcoin-shard-proxy`) before multicast forwarding. Senders (generators) set it to `0`; a value of `0` indicates the frame has not been stamped and gap tracking is skipped.
+This field is stamped in-place by the ingress proxy before multicast forwarding. Senders (generators) set it to `0`; a value of `0` indicates the frame has not been stamped and gap tracking is skipped.
 
 #### SeqNum (bytes 48–55)
 
@@ -175,6 +175,7 @@ E3E1F3E8                                                          // Network Mag
 - [BRC-12: Raw Transaction Format](./0012.md) — Payload format for transaction data
 - [BRC-74: BSV Unified Merkle Path (BUMP) Format](./0074.md) — Merkle proof format used for transaction verification
 - [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the Subtree ID concept referenced in this frame format
+- [BRC-129: Multicast Group Address Assignments](./0129.md) — SSM/ASM addressing, scopes, and `(S,G)` source discovery
 
 ## Constants Reference
 


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

BRC-124 named the ingress proxy by a binary name (`bitcoin-shard-proxy`) that does not exist in the reference implementation, and carried no transport-mode context. Removes the stale name and adds a note that the frame is transport-agnostic — the on-wire bytes are identical under ASM and SSM — pointing to BRC-129 for SSM `(S,G)` addressing/source-discovery and naming the frame's source (the emitting proxy, `senderIPv6`). Adds a BRC-129 reference.
