### PR TITLE
BRC-126: ACK repair confirmation; correct retransmit-mode flag names, beacon-scope values and ADVERT fan-out; SSM source-discovery note

### DIFF
--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -282,7 +282,7 @@ transaction source, and assigned a preference within each tier.
 
 | Tier   | Meaning                                            |
 | ------ | -------------------------------------------------- |
-| `0`    | Same AS as `bitcoin-shard-proxy` (source-adjacent) |
+| `0`    | Same AS as the ingress proxy (source-adjacent)     |
 | `1`    | One AS boundary from source                        |
 | `N`    | N AS hops from source                              |
 | `0xFF` | Static seed (no beacon received; lowest priority)  |
@@ -339,8 +339,9 @@ listener advances to the next position.
 ### Beacon Scopes
 
 Three scope bytes are defined for the ADVERT wire format. The reference
-implementation's `-beacon-scope` flag accepts `site`, `global`, or `both` (sends
-to site + global simultaneously):
+implementation's `-beacon-scope` flag accepts `site`, `org`, `global`, `both`,
+or `all` (`both` and `all` are equivalent: the ADVERT is sent to the site, org,
+and global beacon groups simultaneously):
 
 | Scope           | Scope byte | Beacon group   | Use case                                            |
 | --------------- | ---------- | -------------- | --------------------------------------------------- |
@@ -348,8 +349,16 @@ to site + global simultaneously):
 | Org (`0x08`)    | `0x08`     | `FF08::B:FFFD` | Organisation-wide discovery for multi-site AS       |
 | Global (`0x0E`) | `0x0E`     | `FF0E::B:FFFD` | Inter-AS discovery via MP-BGP MVPN / MSDP           |
 
+Beacon group addresses are shown in ASM (`FF0x`) form. Under SSM, substitute the
+`FF3x` prefix per [BRC-129](./0129.md) (`FF35::B:FFFD` site, `FF3E::B:FFFD`
+global; inter-domain scope is SSM-only per RFC 8815). Because beacon groups are
+control-plane, their source — the emitting retry endpoint — cannot be discovered
+from within the group; SSM receivers `(S,G)`-join using the per-group bootstrap
+source lists defined in BRC-129, not via ADVERT. The ADVERT and NACK wire
+formats are unchanged across modes.
+
 Scope byte `0xFF` is used in ADVERT datagrams when the sender intends to cover
-both site and global simultaneously (sends two ADVERTs). Listeners parse the
+site, org, and global simultaneously (sends three ADVERTs). Listeners parse the
 scope byte from each individual datagram.
 
 To cover multiple scopes, run separate endpoint instances each configured with a
@@ -466,6 +475,7 @@ E3E1F3E8                                  // Network Magic
   data within BRC-124 frames
 - [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame
   format; defines `HashKey`, `SeqNum`, and `Subtree ID` stamped by the proxy
+- [BRC-129: Multicast Group Address Assignments](./0129.md) — SSM/ASM addressing, scopes, and `(S,G)` source discovery
 
 ---
 

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -231,6 +231,17 @@ dispatched. On receipt, the listener cancels the gap entry immediately.
 The listener uses the `SeqNum` echo to confirm the gap entry matches before
 cancelling it.
 
+**Repair confirmation.** An ACK asserts that a retransmit was *dispatched*, not
+that it was *delivered*, so the `Flags` byte determines whether the listener may
+close the gap. On an ACK with `0x02` (unicast sent) the listener MUST NOT cancel
+the gap entry: it MUST wait for the retransmitted frame itself and, if the frame
+does not arrive, MUST resume escalation as though the attempt had timed out. This
+matters because the retransmit can be lost on the same path that dropped the
+original. An ACK without `0x02` conveys no such confirmation channel, so a
+listener MAY cancel on the ACK alone, accepting that a lost retransmit will not be
+retried; deployments that require repair to be verifiable SHOULD therefore enable
+unicast retransmit.
+
 ---
 
 ### THROTTLED Response (`MsgType 0x13`) — 16 bytes
@@ -316,13 +327,19 @@ listener advances to the next position.
       │    └── THROTTLED ──► hold for the hinted backoff; retry the SAME endpoint;
       │                      do NOT escalate, do NOT count as a recovery failure
       │
-      └── ACK ──► gap entry cancelled; done
+      ├── ACK (no 0x02) ──► gap entry cancelled; done
+      └── ACK (0x02 unicast sent) ──► await frame ──► FILLED
+                                   └── timeout ──► advance endpoint
 
   Any state ──► FILLED (multicast repair arrived via data plane)
                gap entry cancelled; in-flight NACK socket times out harmlessly
 ```
 
-- **ACK received:** Cancel gap entry. No further NACKs sent for this gap.
+- **ACK received, `Flags` without `0x02`:** Cancel gap entry. No further NACKs
+  sent for this gap (the repair is trusted, not confirmed).
+- **ACK received with `0x02` (unicast sent):** Do NOT cancel. Await the
+  retransmitted frame; on arrival the gap is FILLED, and on timeout resume
+  escalation from the next endpoint.
 - **MISS received:** Advance to next endpoint at same tier by Preference; if
   tier exhausted, move to next tier; retry immediately.
 - **Timeout:** Apply exponential backoff (capped at `nack-backoff-max`); retry
@@ -377,8 +394,8 @@ Retransmit behavior is controlled by flags on the retry endpoint:
 
 | Flag                    | Default | Effect                                             |
 | ----------------------- | ------- | -------------------------------------------------- |
-| `-retransmit-multicast` | `true`  | Retransmit frame to original multicast shard group |
-| `-retransmit-unicast`   | `false` | Retransmit frame unicast to NACK source            |
+| `-beacon-flags-multicast` | `true`  | Retransmit frame to original multicast shard group |
+| `-beacon-flags-unicast`   | `false` | Retransmit frame unicast to NACK source            |
 | `-suppress-miss`        | `false` | Do not send MISS response on cache miss            |
 | `-suppress-ack`         | `false` | Do not send ACK response on cache hit              |
 
@@ -386,8 +403,11 @@ Retransmit behavior is controlled by flags on the retry endpoint:
 
 - **On-fabric (default):** `-retransmit-multicast=true` — all listeners on the
   fabric receive the retransmit simultaneously.
-- **Edge / unicast:** `-retransmit-unicast=true -retransmit-multicast=false` —
-  for listeners not on the multicast fabric.
+- **Edge / unicast:** `-beacon-flags-unicast=true
+  -beacon-flags-multicast=false` — for listeners not on the multicast fabric, and
+  wherever repair must be *confirmed* rather than trusted (see *Repair
+  confirmation* above). A multicast retransmit is also delivered to every listener
+  in the group, including those that observed no loss.
 - **High-volume:** `-suppress-ack=true` — reduces per-frame ACK traffic; MISS
   responses are preserved for escalation correctness.
 

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -218,7 +218,8 @@ endpoint (no backoff delay).
 ### ACK Response (`MsgType 0x12`) — 16 bytes
 
 Sent unicast to the NACK source when the frame was found and retransmit
-dispatched. On receipt, the listener cancels the gap entry immediately.
+dispatched. Whether the listener may cancel the gap on receipt depends on the
+`Flags` byte — see *Repair confirmation* below.
 
 | Offset | Size | Field    | Description                                                    |
 | ------ | ---- | -------- | -------------------------------------------------------------- |
@@ -392,16 +393,16 @@ never evicted.
 
 Retransmit behavior is controlled by flags on the retry endpoint:
 
-| Flag                    | Default | Effect                                             |
-| ----------------------- | ------- | -------------------------------------------------- |
-| `-beacon-flags-multicast` | `true`  | Retransmit frame to original multicast shard group |
-| `-beacon-flags-unicast`   | `false` | Retransmit frame unicast to NACK source            |
-| `-suppress-miss`        | `false` | Do not send MISS response on cache miss            |
-| `-suppress-ack`         | `false` | Do not send ACK response on cache hit              |
+| Flag                       | Default | Effect                                             |
+| -------------------------- | ------- | -------------------------------------------------- |
+| `-beacon-flags-multicast`  | `true`  | Retransmit frame to original multicast shard group |
+| `-beacon-flags-unicast`    | `false` | Retransmit frame unicast to NACK source            |
+| `-suppress-miss`           | `false` | Do not send MISS response on cache miss            |
+| `-suppress-ack`            | `false` | Do not send ACK response on cache hit              |
 
 **Deployment profiles:**
 
-- **On-fabric (default):** `-retransmit-multicast=true` — all listeners on the
+- **On-fabric (default):** `-beacon-flags-multicast=true` — all listeners on the
   fabric receive the retransmit simultaneously.
 - **Edge / unicast:** `-beacon-flags-unicast=true
   -beacon-flags-multicast=false` — for listeners not on the multicast fabric, and


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Corrects the ADVERT beacon documentation and adds SSM context.

- The `-beacon-scope` flag accepts `site`, `org`, `global`, `both`, and `all` (the spec listed only `site`/`global`/`both`); `both` and `all` are equivalent.
- Scope byte `0xFF` fans out to three ADVERTs (site + org + global), not two.
- Removes the stale `bitcoin-shard-proxy` binary name from the beacon tier table.
- Adds an SSM note: beacon addresses take the `FF3x` form under SSM (inter-domain is SSM-only per RFC 8815), and because beacon groups are control-plane their source (the retry endpoint) is discovered via per-group bootstrap source lists, not from within the group. Adds a BRC-129 reference.
