### PR TITLE
BRC-127: SSM addressing and source-discovery note

### DIFF
--- a/transactions/0127.md
+++ b/transactions/0127.md
@@ -59,6 +59,14 @@ Operators MAY override the IANA group-id (`0x000B`) via the `-mc-group-id`
 configuration flag for private deployments; the resulting addresses change
 accordingly.
 
+Announce-group addresses are shown in ASM (`FF0x`) form; under SSM, substitute
+the `FF3x` prefix per [BRC-129](./0129.md) (`FF3E::B:FFFC` for inter-domain
+scope, which is SSM-only per RFC 8815). The datagram format is unchanged. This
+is a control-plane group whose source — the announcing block assembler — is not
+discoverable from within the group, so SSM listeners `(S,G)`-join using the
+bootstrap source lists defined in BRC-129; these are the same source addresses a
+listener may configure in the include filter (see [Sender Filtering](#sender-filtering)).
+
 ### SubtreeGroupAnnounce Wire Format (`MsgType 0x30`) — 64 bytes
 
 | Offset | Size | Field         | Description                                                   |
@@ -177,3 +185,4 @@ A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6          // GroupID (128-bit)
 
 - [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame
   format; defines `SubtreeID`
+- [BRC-129: Multicast Group Address Assignments](./0129.md) — SSM/ASM addressing, scopes, and `(S,G)` source discovery


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

BRC-127 described its control-plane announce group with ASM-only addresses and a bare "join the group" model. Adds a note that under SSM addresses take the `FF3x` form (inter-domain SSM-only per RFC 8815) and that listeners `(S,G)`-join the announcing block-assembler source via BRC-129 bootstrap source lists — the same source addresses already used by the spec's sender include-filter. Adds a BRC-129 reference. No wire-format change.
