### PR TITLE
BRC-128: SSM transport note

### DIFF
--- a/transactions/0128.md
+++ b/transactions/0128.md
@@ -148,6 +148,10 @@ BRC-128 frames are fully compatible with the existing multicast infrastructure:
   BRC-124 frames. The cache indexes by `(HashKey, SeqNum)`, not payload content.
 - **Downstream consumers** — applications that receive forwarded frames inspect
   payload bytes 4–9 to determine whether to parse as BRC-12 raw or BRC-30 EF.
+- **Transport** — BRC-128 frames are byte-identical on the wire under ASM and
+  SSM. Multicast addressing, scopes, and the SSM `(S,G)` join and
+  source-discovery model are inherited from [BRC-124](./0124.md) and specified
+  in [BRC-129](./0129.md); the source is the emitting proxy (`senderIPv6`).
 
 BRC-124 (BRC-12 payload) and BRC-128 (BRC-30 EF payload) frames can be
 intermixed on the same multicast group without conflict.
@@ -238,3 +242,4 @@ Note that the headers are byte-identical; only the payload differs.
   Subtree ID concept referenced in the frame header
 - [BRC-124: Multicast Transaction Frame Format](./0124.md) — Header format
   reused by this specification
+- [BRC-129: Multicast Group Address Assignments](./0129.md) — SSM/ASM addressing, scopes, and `(S,G)` source discovery


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

BRC-128 (the Extended Format payload variant) carried no transport-mode note. Adds a Compatibility bullet stating BRC-128 frames are byte-identical on the wire under ASM and SSM, inheriting addressing and the SSM `(S,G)`/source-discovery model from BRC-124 and BRC-129, with the source being the emitting proxy (`senderIPv6`). Adds a BRC-129 reference.
