### PR TITLE
BRC-130: remove 0x06 from OrigFrameVer values; SSM fragmentation note

### DIFF
--- a/transactions/0130.md
+++ b/transactions/0130.md
@@ -209,9 +209,18 @@ For jumbo frames (pathMTU = 9000): `fragDataSize = 8848 bytes`.
 
 A listener reassembles a fragmented transaction as follows:
 
-1. **Slot allocation.** On receipt of the first fragment for a TxID, allocate a
-   reassembly slot containing a `OrigPayloadLen`-byte buffer, a
+1. **Slot allocation.** On receipt of the first fragment for a reassembly key,
+   allocate a slot containing a `OrigPayloadLen`-byte buffer, a
    received-fragment bitmask of `FragTotal` bits, and a TTL timer.
+
+   The reassembly key is the Transaction ID (bytes 8–39), **except** where the
+   carried plane derives that hash from payload content that several concurrent
+   frames legitimately share. For `OrigFrameVer = 0x09` (BRC-149 BEEF object)
+   the key MUST be the pair (Transaction ID, Subtree ID) — bytes 8–39 carry the
+   ContentID and bytes 56–87 the TopicID, and one object submitted to several
+   topics is emitted once per topic with a shared ContentID and a distinct
+   TopicID. Keying such fragments on bytes 8–39 alone merges the sibling
+   emissions into a single slot, so all but one topic silently lose the object.
 
 2. **Fragment placement.** Copy fragment data into the buffer at
    `offset = fragIndex * fragDataSize`. Mark the fragment index as received.
@@ -219,14 +228,27 @@ A listener reassembles a fragmented transaction as follows:
 3. **Completion check.** When all `FragTotal` fragment indices are marked
    received, proceed to verification.
 
-4. **Hash verification.** Compute `SHA256(SHA256(buffer))` and compare to the
-   TxID. If they differ, drop the slot and increment
-   `bsl_reassembly_hash_mismatch_total`.
+4. **Hash verification.** Where bytes 8–39 are a double-SHA256 of the payload —
+   `OrigFrameVer` `0x00`/`0x02` (transaction, TxID) and `0x09` (BRC-149 BEEF
+   object, ContentID) — compute `SHA256(SHA256(buffer))` and compare. If they
+   differ, drop the slot and increment `bsl_reassembly_hash_mismatch_total`.
 
-5. **Delivery.** Construct a synthetic BRC-124 frame (FrameVer = 0x02) carrying
-   the reassembled payload and the TxID, HashKey, SeqNum, and SubtreeID from the
-   first fragment received. Route the frame through the normal filter → egress →
-   gap-tracking path.
+   This check does not apply to planes whose bytes 8–39 carry a different
+   commitment: `0x04` (BRC-131 block control) and `0x05` (BRC-132 subtree data,
+   whose Subtree ID is a Merkle root rather than a hash of the fragmented
+   bytes). Those planes complete on the fragment bitmask alone; a subtree
+   implementation MAY additionally verify the reassembled data against the
+   Merkle root it commits to.
+
+5. **Delivery.** Construct a synthetic frame of the original type — `FrameVer =
+   OrigFrameVer` (byte 100, `0x00` ⇒ `0x02`) with byte 7 restored from the
+   carried `MsgType` — carrying the reassembled payload and the Transaction ID,
+   HashKey, SeqNum, and Subtree ID from the first fragment received. A BEEF
+   object (`0x09`) is therefore rebuilt as a BRC-149 frame with its ContentID
+   and TopicID in place, not as a BRC-124 transaction frame; reconstructing
+   every plane as `0x02` would strip the routing identity the downstream filter
+   needs. Route the frame through the normal filter → egress → gap-tracking
+   path for its plane.
 
 6. **TTL eviction.** If a slot's TTL expires before all fragments arrive,
    discard the partial buffer and increment `bsl_reassembly_abandoned_total`.

--- a/transactions/0130.md
+++ b/transactions/0130.md
@@ -95,8 +95,9 @@ version byte.
 The frame-type `MsgType` carried through from byte 7 of the original
 (pre-fragmentation) frame, so reassembly can reconstruct it. For fragmented
 BRC-124/128 transaction frames this byte is `0x00` (their byte 7 is reserved);
-for fragmented BRC-131 block frames it is `0x01`/`0x02` and for BRC-132 subtree
-frames `0x01`/`0x02`. Together with `OrigFrameVer` (byte 100) it fully restores
+for fragmented BRC-131 block frames it is `0x01`/`0x02`, for BRC-132 subtree
+frames `0x01`/`0x02`, and for BRC-149 BEEF object frames `0x00` (their byte 7 is
+reserved). Together with `OrigFrameVer` (byte 100) it fully restores
 the original header bytes 6–7 on reassembly.
 
 #### Transaction ID (bytes 8–39)
@@ -171,7 +172,8 @@ used only for testing).
 #### OrigFrameVer (byte 100)
 
 The `FrameVer` of the original frame before fragmentation (`0x02` BRC-124/128,
-`0x04` BRC-131, `0x05` BRC-132). A value of `0x00` defaults to
+`0x04` BRC-131, `0x05` BRC-132, `0x09` BRC-149 BEEF object). A value of `0x00`
+defaults to
 `0x02` (BRC-124). Listeners use it — together with the byte-7 `MsgType` — to
 reconstruct the correct synthetic frame on reassembly.
 

--- a/transactions/0130.md
+++ b/transactions/0130.md
@@ -13,6 +13,12 @@ forwarding. The fragment header is a strict superset of the BRC-124 header,
 enabling mixed-version infrastructure to identify and discard fragment frames it
 cannot process.
 
+Fragmentation is transport-agnostic: fragment datagrams are identical on the
+wire under ASM and SSM, and every fragment of a transaction is emitted from the
+same proxy source (`senderIPv6`), so a receiver joins a single `(S,G)` for all
+of them. Multicast addressing and the SSM join and source-discovery model are
+specified in [BRC-129](./0129.md).
+
 ## Copyright
 
 This BRC is licensed under the Open BSV License.
@@ -165,7 +171,7 @@ used only for testing).
 #### OrigFrameVer (byte 100)
 
 The `FrameVer` of the original frame before fragmentation (`0x02` BRC-124/128,
-`0x04` BRC-131, `0x05` BRC-132, `0x06` BRC-134). A value of `0x00` defaults to
+`0x04` BRC-131, `0x05` BRC-132). A value of `0x00` defaults to
 `0x02` (BRC-124). Listeners use it — together with the byte-7 `MsgType` — to
 reconstruct the correct synthetic frame on reassembly.
 
@@ -332,6 +338,7 @@ correctly on fragment datagrams without modification.
   extended by this BRC
 - [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the
   Subtree ID concept
+- [BRC-129: Multicast Group Address Assignments](./0129.md) — SSM/ASM addressing, scopes, and `(S,G)` source discovery
 
 ## Constants Reference
 


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Two corrections.

- The `OrigFrameVer` value list included `0x06` (BRC-134), but BRC-130 fragmentation is not defined for BRC-134 and the reference reassembler dispatches only `0x04`/`0x05` (with `0x00`/`0x02` as the BRC-124 default) — an `0x06` fragment would be reassembled as a plain BRC-124 frame. Removes `0x06`.
- Adds a note that fragmentation is transport-agnostic and every fragment of a transaction is emitted from the same proxy source (`senderIPv6`), so a receiver joins a single `(S,G)`; points to BRC-129. Adds a BRC-129 reference.
