### PR TITLE
BRC-131: SSM inter-domain addressing note for block broadcast

### DIFF
--- a/transactions/0131.md
+++ b/transactions/0131.md
@@ -168,6 +168,13 @@ The global scope (`FF0E`) ensures block announcements cross site boundaries. The
 group index `0xFFFE` is in the reserved control-plane range and is never used as
 a shard group for any `shard_bits` ≤ 12.
 
+The address is shown in ASM form (`FF0E::B:FFFE`), which under RFC 8815 is
+intra-domain only; inter-domain delivery across site boundaries uses the SSM
+address `FF3E::B:FFFE` (see [BRC-129](./0129.md)). The frame format, `HashKey`,
+`SeqNum`, and NACK path are unchanged across modes. Under SSM, receivers
+`(S,G)`-join using the block-announce source (the emitting proxy, `senderIPv6`);
+block-broadcast sources are distributed per BRC-129.
+
 ### Sequence Tracking and Retransmission
 
 BRC-131 frames use the same XXH64 hash-chain sequencing as BRC-124:


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

BRC-131 states block announcements "cross site boundaries" but gave only the ASM address `FF0E::B:FFFE`, which RFC 8815 forbids inter-domain. Adds a note that inter-domain delivery uses the SSM form `FF3E::B:FFFE` (per BRC-129), names the source receivers `(S,G)`-join (the emitting proxy, `senderIPv6`), and confirms the frame format, HashKey, SeqNum, and NACK path are unchanged across modes.
