### PR TITLE
BRC-132: SSM addressing note for subtree data

### DIFF
--- a/transactions/0132.md
+++ b/transactions/0132.md
@@ -47,6 +47,13 @@ Scope selection follows the `GroupBeacon` pattern defined in BRC-129. Operators
 select one or more scopes via the `-announce-scope` flag on listening
 components.
 
+Addresses are shown in ASM (`FF0x`) form; under SSM, substitute the `FF3x`
+prefix per [BRC-129](./0129.md) (`FF3E::B:FFFB` for inter-domain scope, SSM-only
+per RFC 8815). The frame format and NACK/fragmentation paths are unchanged.
+Under SSM, receivers `(S,G)`-join using the subtree-data source (the emitting
+proxy, `senderIPv6`); the source set is distributed per BRC-129 (data-plane
+sources via the shard manifest).
+
 ### Frame Header Format (92 bytes)
 
 The BRC-132 header is layout-identical to the BRC-124 header. All infrastructure


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

BRC-132 gave ASM-only addresses for the subtree-data announce group. Adds a note that under SSM addresses take the `FF3x` form (inter-domain SSM-only per RFC 8815), receivers `(S,G)`-join the subtree-data source (the emitting proxy, `senderIPv6`), and the data-plane source set is distributed via the shard manifest per BRC-129; frame and NACK/fragmentation paths are unchanged.
