### PR TITLE
BRC-133: SSM addressing note for coinbase

### DIFF
--- a/transactions/0133.md
+++ b/transactions/0133.md
@@ -46,6 +46,13 @@ The group index `0xFFFE` is in the reserved control-plane range and never
 overlaps with data-plane shard groups (maximum shard group index is `0x0FFF` for
 `shard_bits=12`).
 
+The address is shown in ASM form (`FF0E::B:FFFE`), intra-domain only under RFC
+8815; inter-domain delivery uses the SSM address `FF3E::B:FFFE` (see
+[BRC-129](./0129.md)). The frame format and NACK path are unchanged. Coinbase
+and block-announce frames are separate flows but share the same egress source
+(the emitting proxy, `senderIPv6`), so SSM receivers `(S,G)`-join `0xFFFE` once;
+block-broadcast sources are distributed per BRC-129.
+
 ### Wire Format
 
 Coinbase transactions are carried as BRC-131 frames (FrameVer `0x04`) with
@@ -112,5 +119,6 @@ same `FF0E::B:FFFE` multicast destination.
 
 - [BRC-124: Multicast Transaction Frame Format](./0124.md) — base header layout
   reused by BRC-131
+- [BRC-129: Multicast Group Address Assignments](./0129.md) — SSM/ASM addressing, scopes, and `(S,G)` source discovery
 - [BRC-134: Chained Anchor Transaction Frames](./0134.md) — another
   control-group transaction type


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

BRC-133 delivers coinbase frames on the global `GroupBlockBroadcast` group with an ASM-only address `FF0E::B:FFFE`. Adds a note that inter-domain delivery uses the SSM form `FF3E::B:FFFE` (per BRC-129), and that coinbase and block-announce frames — though separate flows — share the same egress source, so SSM receivers `(S,G)`-join `0xFFFE` once. Adds a BRC-129 reference.
