### PR TITLE
BRC-134: SSM addressing note for anchor

### DIFF
--- a/transactions/0134.md
+++ b/transactions/0134.md
@@ -52,6 +52,14 @@ reach all geographically distributed subscribers. The group index `0xFFFE` is in
 the reserved control-plane range and never overlaps with data-plane shard groups
 (maximum shard group index is `0x0FFF` for `shard_bits=12`).
 
+The address is shown in ASM form (`FF0E::B:FFFE`), intra-domain only under RFC
+8815; inter-domain and geographically distributed delivery uses the SSM address
+`FF3E::B:FFFE` (see [BRC-129](./0129.md)). The frame format and NACK path are
+unchanged. Anchors are user-submitted, so under SSM their source set (the
+emitting proxies, `senderIPv6`) is broader than the miner-only block and
+coinbase sources; receivers `(S,G)`-join `0xFFFE` per the source set distributed
+per BRC-129.
+
 ### Frame Header Format (92 bytes)
 
 The BRC-134 header is **layout-identical** to BRC-124. Infrastructure components
@@ -109,5 +117,6 @@ BRC-124 shard frames:
 
 - [BRC-124: Multicast Transaction Frame Format](./0124.md) — base header layout
   reused by BRC-134
+- [BRC-129: Multicast Group Address Assignments](./0129.md) — SSM/ASM addressing, scopes, and `(S,G)` source discovery
 - [BRC-133: Coinbase Transaction Delivery](./0133.md) — another control-group
   transaction type using BRC-131


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

BRC-134 delivers anchor frames on the global `GroupBlockBroadcast` group and stresses geographically distributed reach, but gave only the ASM address `FF0E::B:FFFE` (RFC 8815 forbids inter-domain ASM). Adds a note that inter-domain delivery uses the SSM form `FF3E::B:FFFE` (per BRC-129), and that because anchors are user-submitted their SSM source set is broader than the miner-only block/coinbase sources. Adds a BRC-129 reference.
