### PR TITLE
BRC-135: correct emitter HashKey group index to 0xFFFA; SSM egress note

### DIFF
--- a/transactions/0135.md
+++ b/transactions/0135.md
@@ -65,6 +65,13 @@ The egress group-id is set independently of the fabric group-id. This ensures
 BRC-135 frames reach only downstream consumers, not peer fabric subscribers or
 retry endpoints on the ingress fabric.
 
+The egress address is shown in ASM (`FF05`) form; under SSM, substitute the
+`FF3x` prefix per [BRC-129](./0129.md). The frame format is unchanged. The
+frame's source is the emitter (`emitterIPv6`), which stamps its own identity, so
+downstream consumers `(S,G)`-join per emitter. Under SSM the multi-emitter
+reliability pattern uses distinct per-emitter sources (or VRRP active-standby);
+anycast or shared-source emission is not supported (BRC-129).
+
 ### Frame Header Format (92 bytes)
 
 The BRC-135 header is layout-identical to BRC-124. All infrastructure components
@@ -78,7 +85,7 @@ All multi-byte integers are big-endian.
 | 6      | 1    | —         | Frame Version | 0x07 — BRC-135 block header                               |
 | 7      | 1    | —         | Reserved      | 0x00                                                      |
 | 8      | 32   | 8-byte    | BlockHash     | SHA256d of the 80-byte block header (internal byte order) |
-| 40     | 8    | 8-byte    | HashKey       | XXH64(emitterIPv6 ∥ 0xFFFE ∥ zeros); stamped by emitter   |
+| 40     | 8    | 8-byte    | HashKey       | XXH64(emitterIPv6 ∥ 0xFFFA ∥ zeros); stamped by emitter   |
 | 48     | 8    | 8-byte    | SeqNum        | Monotonic per-emitter counter; stamped by emitter         |
 | 56     | 32   | 8-byte    | LayoutPad32   | All zeros (no subtree scope for block headers)            |
 | 88     | 4    | —         | PayloadLen    | 0x00000050 (80 = fixed block header size, uint32 BE)      |
@@ -121,12 +128,12 @@ same block.
 A stable per-emitter flow identifier computed as:
 
 ```
-HashKey = XXH64(emitterIPv6 [16 bytes] ∥ 0x0000FFFE [4 bytes BE] ∥ zeros [32 bytes])
+HashKey = XXH64(emitterIPv6 [16 bytes] ∥ 0x0000FFFA [4 bytes BE] ∥ zeros [32 bytes])
 ```
 
-The `0xFFFE` group index is `GroupBlockBroadcast`, the same control-plane index
-used by BRC-131/133/134. The 32 zero bytes correspond to the absent SubtreeID.
-The HashKey is constant for the lifetime of the emitter process.
+The `0xFFFA` group index is `GroupBlockHeader`, the emitter multicast egress
+channel (see the group table above). The 32 zero bytes correspond to the absent
+SubtreeID. The HashKey is constant for the lifetime of the emitter process.
 
 A value of `0` indicates the field is unset.
 


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Two items.

- Corrects the emitter `HashKey` ingredient from `0x0000FFFE` (`GroupBlockBroadcast`) to `0x0000FFFA` (`GroupBlockHeader`) — the egress channel the frame is actually sent on, matching the rest of the spec (the Multicast Group section) and the reference implementation.
- Adds an SSM note: the egress address takes the `FF3x` form under SSM, the source is the emitter (`emitterIPv6`), and the multi-emitter reliability pattern must use distinct per-emitter sources or VRRP active-standby — anycast/shared-source emission is not supported under SSM (per BRC-129).
