### PR TITLE
BRC-129: correct free-space index count

### DIFF
--- a/transactions/0129.md
+++ b/transactions/0129.md
@@ -143,7 +143,7 @@ the multicast address.
 
 ### Free Space and Specialty Transmission Domains
 
-Indices `0x1000`–`0xF7FF` (56,832 indices) are unassigned and reserved for
+Indices `0x1000`–`0xF7FF` (59,392 indices) are unassigned and reserved for
 future use. This range accommodates future expansion of the shard group space,
 as well as specialty transmission domains for purpose-specific multicast
 services that are not general-purpose transaction sharding. No current protocol


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Corrects the index count of the unassigned band `0x1000`–`0xF7FF` from 56,832 to 59,392 (`0xF7FF − 0x1000 + 1`, equivalently `65536 − 4096 shard − 2048 control`). One-word arithmetic fix; no normative behavior changes.
