### PR TITLE
BRC-169: change the ecosystem separator to @, and tighten display, parsing, and attestation rules

### DIFF
--- a/peer-to-peer/0169.md
+++ b/peer-to-peer/0169.md
@@ -195,7 +195,23 @@ A handle can be released and reassigned to a different person. Address book entr
 
 #### 4.5 Certificate type identifiers
 
-The `type` values for the handle certificate and the delegation certificate of section 9.1 are 32-byte base64 identifiers to be allocated when this specification is registered. Until then, implementations MUST treat them as a single shared constant agreed out of band, and MUST NOT assume interoperability across independent deployments on the basis of certificate type alone.
+A [BRC-52](./0052.md) `CertificateTypeID` is an opaque 32-byte value, and no BRC defines an authority that allocates one. Rather than wait for an allocation that has no allocator, this document **derives** its two type values from a name, so that any implementation reproduces them from this section alone:
+
+```
+type = base64( SHA-256( ASCII derivation string ) )
+```
+
+| Certificate | Derivation string | `type` |
+| --- | --- | --- |
+| Handle certificate (section 4.1) | `metanet-handles handle certificate v1` | `XgCFdUfxEcI+3xtDjsIuSAjMl5EwzCUjsQc45ds1lC8=` |
+| Delegation certificate (section 9.1) | `metanet-handles delegation certificate v1` | `30kchAJIGfLxzCNloCJNLI3AtkgA8UbkxlXU2Cj4PpA=` |
+
+1. Both values are normative. An implementation MUST use them, and MUST NOT substitute a locally chosen constant.
+2. The derivation strings carry no BRC number. Nothing else in this document carries one in a wire name either — the manifest key is `metanet.handles`, the alias protocol field is `ecosystem-alias` — so that a later revision does not leave the deployed vocabulary naming a superseded document.
+3. The `v1` suffix versions the type rather than the document. A future revision that changes the field names or meanings of either certificate MUST mint a new type by changing the derivation string, so that certificates issued under the two revisions remain distinguishable and a verifier is never required to guess which set of field semantics applies. This is what BRC-52 means when it says certificates of the same type are expected to use the same field names and meanings.
+4. The handle-certificate value above is the one used throughout Appendix A, and is therefore covered by the worked signature in A.3.
+
+**Publishing type metadata is an open consideration.** Deployed overlay infrastructure includes a certificate-type directory, reachable as the topic `tm_certmap` and the lookup service `ls_certmap` and wrapped by a registry client in several BSV SDKs, through which an operator publishes a type identifier together with a human-readable name, an icon, a description, and per-field descriptors. It is not specified by any BRC, it does not allocate or reserve a type, and its records are attributable to the operator that published them rather than to any authority over the type. Whether this document should recommend publishing there, and if so what an operator should publish and how a client should weigh a record it finds, is left open for review. Nothing in this section depends on it: the type values above are fixed by their derivation.
 
 #### 4.6 Historical note
 
@@ -318,6 +334,8 @@ The error body MUST be:
 #### 5.5 Alias advertisement
 
 Aliases map to domains without a central registry. An ecosystem MAY publish an alias advertisement as a [BRC-48](../scripts/0048.md) PushDrop token submitted to the overlay topic `tm_ecosystemalias` and discoverable through the lookup service `ls_ecosystemalias`, in the manner of the SHIP and SLAP advertisements of [BRC-101](../overlays/0101.md).
+
+**On the names.** They follow the conventions of [BRC-87](../overlays/0087.md), and match deployed practice in running the descriptor together rather than splitting it with an underscore, as `tm_certmap` and `tm_basketmap` do. BRC-87 establishes no registry and leaves naming to agreement between operators, so this document claims the pair rather than reserving it, and a claim can only be checked against what is deployed at the time of checking. The check is reproducible: `GET /listTopicManagers` and `GET /listLookupServiceProviders` on each of the SLAP trackers an implementation is configured with will enumerate the names those hosts serve, and a [BRC-24](../overlays/0024.md) query to `ls_slap` with `findAll` enumerates advertised services more broadly. An operator finding either name already serving something else SHOULD raise it against this document rather than silently choosing a variant, since two ecosystems advertising aliases under different topics cannot see each other's advertisements, which defeats the purpose of publishing them.
 
 The token's pushed fields MUST appear in this order:
 
@@ -608,7 +626,13 @@ Reassigning a role is a revocation followed by a fresh delegation. Organisation 
 4. A peer attestation is evidence, not proof. It is exactly as trustworthy as the attesting key, and clients MUST NOT present peer attestation as equivalent to host attestation.
 5. **A reputation signal MUST identify who signed it.** Where a client surfaces peer statements of any kind, each MUST be attributable to the key that made it, and that key MUST be resolvable to a handle the reader can look up in turn. An unattributed count is not evidence: "eight people vouch for this handle" is worth exactly as much as the eight, and a reader who cannot see who they are cannot weigh it. Counts of different claims MUST NOT be summed — attestations of a binding and statements about a person are different things, and one total covering both is a number that means nothing.
 6. **Attestation is not reputation.** A peer attestation is a claim about a *binding*: this key is this handle. It is not a claim about the person, and it says nothing about whether they are worth transacting with. Ecosystems will want the second thing, and a client that renders the two identically lets a statement of regard be read as verification. Where a client surfaces both, it MUST label and group them separately, and a reputation signal MUST NOT contribute to any indication that an identity is verified. A reputation mechanism is out of scope here; an ecosystem defining one SHOULD do so as a custom command under BRC-218 section 8 rather than by overloading this section.
-7. Because organisations resolve identically to users, the address book doubles as a business directory.
+7. **Statements against a handle.** A reputation mechanism that only records regard records half of what people know. An ecosystem MAY define a negative counterpart — Nexus's is `/renounce` — subject to the rules below, because the failure modes are not the same as a vouch's and a symmetrical design gets them wrong.
+   1. A negative statement SHOULD be **unattributed by default**, with attribution offered as a deliberate choice by its author. Speaking against someone carries a risk that speaking for them does not, and a mechanism that names the author by default collects only the statements of people with nothing to lose — which is the opposite of the sample worth having.
+   2. Where it is unattributed, the **claim itself MUST still be shown**. An anonymous count is a rumour with a number on it; an anonymous reason is something the subject can answer and a reader can weigh.
+   3. A client MUST NOT let a negative statement contribute to any indication that an identity is unverified, exactly as rule 6 forbids the positive case. Both are opinions about a person; verification is arithmetic about a key.
+   4. Attributed and unattributed statements MUST be visually distinguishable, and a client MUST NOT imply that an unattributed one is attributable on request when it is not.
+8. **Attestations MUST be discoverable, not merely publishable.** Rules 3 to 7 say how a peer statement is made and what it means, and say nothing about how a third party finds the statements made *about* a handle. That is the half a relying party actually needs: a client asking "who has vouched for this identity" has no endpoint to ask. An ecosystem SHOULD answer that question for its own handles, at the resolution endpoint of section 5.7, as a list of attestation outpoints with their certifiers. Until an ecosystem does, any mechanism built on this section — including the access gates of [BRC-190](../apps/0190.md) — can be evaluated only by a party that already holds the attestations, which is to say by nobody who needed to ask.
+9. Because organisations resolve identically to users, the address book doubles as a business directory.
 
 ## Security Considerations
 
@@ -671,6 +695,7 @@ Reassigning a role is a revocation followed by a fresh delegation. Organisation 
 - [BRC-104: HTTP Transport for BRC-103 Mutual Authentication](./0104.md)
 - [BRC-105: HTTP Service Monetization Framework](../payments/0105.md)
 - [BRC-125: PeerPay URI Scheme for BRC-29 Payments](../payments/0125.md)
+- [BRC-190: Access Gates for Metanet Rooms](../apps/0190.md)
 - [BRC-218: Chat-Native Command Grammar for the Metanet](../apps/0218.md)
 - [WhatsOnChain Exchange Rate API](https://docs.whatsonchain.com/exchange-rate)
 - [RFC 1123: Requirements for Internet Hosts](https://www.rfc-editor.org/rfc/rfc1123)
@@ -727,7 +752,7 @@ Field values are shown as Base64 of the **plaintext** so that the example is rea
 
 ```json
 {
-  "type": "Wc8L6juBVF6XamSxyaZO5+c30oNVg3ETNbnh5BQCHak=",
+  "type": "XgCFdUfxEcI+3xtDjsIuSAjMl5EwzCUjsQc45ds1lC8=",
   "serialNumber": "JMNxKTvlkhOO88EJZRgnpTKL78dC1XwxQ9REUysjy08=",
   "subject": "0359c5f3bfe249f6c0ca99d0e9cc1517da51a511f3d04f18e47a5d7ae55f04008c",
   "certifier": "0371f0ec5992a9d38e09fe528e367890969c66eaebdb01b4d35a2fc0d61251b3f9",
@@ -739,7 +764,7 @@ Field values are shown as Base64 of the **plaintext** so that the example is rea
     "domain": "bGt1cC5uZXQ=",
     "handle": "ZGVnZ2Vu"
   },
-  "signature": "3045022100e0b08e8bd875393ada61cfb6e3a6d720555378fcdb042ae80133ec3ba03e4b5002205706c5272abd3559762f418790cd84604ef081bd59ea3b2a5006760860d9473b"
+  "signature": "30450221008becb25058954be7cf6f8c46d3a0411a85a9aed55ef90466651fc75374e2bdcf02205a232796a1c2dd0bd7096428a5e6fb766eee404f441a93a261986486ba3b553c"
 }
 ```
 
@@ -748,7 +773,7 @@ Field values are shown as Base64 of the **plaintext** so that the example is rea
 **Signature preimage.** `CertificateBinary` with `includeSignature = false`, fields ordered lexicographically (`domain` before `handle`):
 
 ```
-59cf0bea3b81545e976a64b1c9a64ee7e737d2835583711335b9e1e414021da9
+5e00857547f111c23edf1b438ec22e4808cc979130cc2523b10738e5db35942f
 24c371293be592138ef3c109651827a5328befc742d57c3143d444532b23cb4f
 0359c5f3bfe249f6c0ca99d0e9cc1517da51a511f3d04f18e47a5d7ae55f04008c
 0371f0ec5992a9d38e09fe528e367890969c66eaebdb01b4d35a2fc0d61251b3f9
@@ -764,13 +789,13 @@ Field values are shown as Base64 of the **plaintext** so that the example is rea
 **Signing key.** Per BRC-52 the certifier does not sign with its identity key directly. It signs with a BRC-42 key derived under protocol ID `[2, "certificate signature"]`, key ID `<type> <serialNumber>`, counterparty `anyone`, giving the BRC-43 invoice number:
 
 ```
-2-certificate signature-Wc8L6juBVF6XamSxyaZO5+c30oNVg3ETNbnh5BQCHak= JMNxKTvlkhOO88EJZRgnpTKL78dC1XwxQ9REUysjy08=
+2-certificate signature-XgCFdUfxEcI+3xtDjsIuSAjMl5EwzCUjsQc45ds1lC8= JMNxKTvlkhOO88EJZRgnpTKL78dC1XwxQ9REUysjy08=
 ```
 
 Because the counterparty is `anyone` (private key `1`), both sides compute the same shared secret: the certifier computes `certifierPriv * G`, and any verifier computes `1 * certifierPub`. Both equal the certifier's public key. The resulting signing public key, which a verifier derives and checks the signature against, is:
 
 ```
-029d7d3322efae6a1cedc423279294924ab784b202bfd7918e6c46164d4f2eb2fc
+03c0d407698d43211eef3381e741a2b2a80840c655d0ac3880edfbcfe432f9c91c
 ```
 
 ### A.4 Resolution response

--- a/peer-to-peer/0169.md
+++ b/peer-to-peer/0169.md
@@ -4,7 +4,7 @@ Crumbs, Deggen, BrandonC
 
 ## Abstract
 
-This document specifies a universal addressing scheme for the Metanet, in which every person, organisation, machine, and agent is reachable by a human-readable handle of the form `@handle:ecosystem`, regardless of which wallet ecosystem they belong to.
+This document specifies a universal addressing scheme for the Metanet, in which every person, organisation, machine, and agent is reachable by a human-readable handle of the form `@handle@ecosystem`, regardless of which wallet ecosystem they belong to.
 
 Name collisions are avoided **without any central registry** through domain separation. Every ecosystem is an internet domain, and handles are unique only within their ecosystem. The domain named in the handle is the authority for that handle: it publishes its trust anchor per [BRC-68](./0068.md), attests the binding between a handle and an identity key with a [BRC-52](./0052.md) certificate, and answers a resolution endpoint that returns the identity key, the certificate, and a messagebox URL.
 
@@ -23,7 +23,7 @@ Paymail ([BRC-28](../payments/0028.md)) solved this problem a generation ago wit
 Three failures motivate a standard:
 
 1. **The silo.** Users are addressable only inside their own ecosystem, so network effects accrue to individual vendors rather than to the Metanet.
-2. **The indirection.** Current implementations resolve a handle through a global identity overlay to an identity key, then perform a second lookup from the identity key to a messagebox URL. This works, but it centralizes discovery in an overlay and displaces the natural authority, which is the ecosystem the user actually belongs to. It is simpler for the handle's own domain to answer for it: register `deggen` at `lkup.net`, hand out `@deggen:lkup.net`, and any counterparty knows exactly which domain to ask for the identity key, the attestation, and the messagebox.
+2. **The indirection.** Current implementations resolve a handle through a global identity overlay to an identity key, then perform a second lookup from the identity key to a messagebox URL. This works, but it centralizes discovery in an overlay and displaces the natural authority, which is the ecosystem the user actually belongs to. It is simpler for the handle's own domain to answer for it: register `deggen` at `lkup.net`, hand out `@deggen@lkup.net`, and any counterparty knows exactly which domain to ask for the identity key, the attestation, and the messagebox.
 3. **The spam asymmetry.** In a free-to-send messaging system the cost of attention falls entirely on the recipient. The Metanet has native micropayments, so a recipient should be able to price access to their attention and scope who may reach them at all, portably across ecosystems and without any vendor's permission.
 
 The intended result is a single addressing surface across independently operated domains, with no registry to capture, no pairwise integration between ecosystems, and no vendor in a position to decide who is reachable.
@@ -49,7 +49,7 @@ The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this document are t
 #### 2.1 Syntax
 
 ```abnf
-recipient   = "@" handle [ "+" tag ] [ ":" ecosystem ]
+recipient   = "@" handle [ "+" tag ] [ "@" ecosystem ]
 
 handle      = alnum [ *62( alnum / punct ) alnum ]   ; 1 to 64 characters
 tag         = alnum [ *30( alnum / punct ) alnum ]   ; 1 to 32 characters
@@ -67,18 +67,20 @@ lower       = %x61-7A                                 ; a-z
 3. Handles are restricted to ASCII. This deliberately excludes non-Latin scripts, in exchange for eliminating the internationalized-domain homograph attacks that would otherwise make a handle's appearance an unreliable guide to its identity. Section 2.3 addresses the confusable characters that remain within ASCII.
 4. Handles are unique within their ecosystem. The ecosystem host is the sole authority for handle assignment within its domain and MUST NOT assign the same handle to two identities simultaneously.
 5. **Alias and domain are disambiguated by the presence of a dot.** An `ecosystem` segment containing at least one `.` MUST be parsed as a domain; one containing none MUST be parsed as an alias and resolved per section 5.5. A dotless segment MUST NOT be treated as a hostname, even where the client's network would resolve it as one.
-6. The **fully-qualified form** `@handle:domain.tld` is always valid and always unambiguous. The alias form is an input and display convenience.
-7. **Paymail-style input** in the form `handle@domain.tld` SHOULD be accepted wherever a recipient is expected, and MUST be normalized to `@handle:domain.tld` internally.
+6. The **fully-qualified form** `@handle@domain.tld` is always valid and always unambiguous. The alias form is an input and display convenience.
+7. **Paymail-style input** in the form `handle@domain.tld` SHOULD be accepted wherever a recipient is expected, and MUST be normalized to `@handle@domain.tld` internally.
+8. **Parsing a token that contains two `@`.** A recipient begins at a whitespace boundary, not at an `@`. A client MUST find the start of a recipient by scanning back to the preceding whitespace or the start of input; scanning back to the nearest `@` truncates the token as soon as the ecosystem separator is typed.
+9. **Handle and paymail are disambiguated by the leading `@`.** A token beginning with `@` MUST be parsed by this grammar. A token that does not MAY be treated as paymail per rule 7. This ordering matters: `@alice@example.com` is a fully-qualified handle whose ecosystem part is a domain, and matching it against the paymail form first mis-parses it. Both forms name the same identity, so the distinction is one of parse order rather than of meaning.
 
 #### 2.2 Same-ecosystem shorthand
 
-A user addressing another user in the same ecosystem MAY omit the `:ecosystem` suffix. Clients MUST interpret a bare `@handle` as local to the sender's own ecosystem. The suffix is required only when crossing ecosystems.
+A user addressing another user in the same ecosystem MAY omit the `@ecosystem` suffix. Clients MUST interpret a bare `@handle` as local to the sender's own ecosystem. The suffix is required only when crossing ecosystems.
 
 #### 2.3 Confusable handles
 
 ASCII restriction removes cross-script homographs but not same-script confusables. `@brand0n` and `@brandon`, or `@ac.me` and `@ac_me`, are distinct identities that may be visually indistinguishable at a glance.
 
-1. Clients SHOULD compute a confusability skeleton for each handle by lowercasing, removing all `punct` characters, and folding the sets `{0, o}`, `{1, l, i}`, `{5, s}`, and `{2, z}` to a single representative.
+1. Clients MUST compute a confusability skeleton for each handle by lowercasing, removing all `punct` characters, and folding the sets `{0, o}`, `{1, l, i}`, `{5, s}`, `{2, z}`, `{8, b}`, `{rn, m}`, and `{vv, w}` to a single representative. The set is normative: two clients folding differently disagree about what is a spoofing risk, which is worse than having no rule.
 2. Before a value-moving action addressed to a handle **not** already in the user's address book, clients SHOULD warn when that handle's skeleton collides with an address book entry whose full handle differs, and MUST make the difference visible.
 3. Clients MUST NOT silently substitute a similar handle for the one the user typed.
 
@@ -88,6 +90,11 @@ ASCII restriction removes cross-script homographs but not same-script confusable
 2. In mixed result lists the ecosystem segment MUST be shown for every result.
 3. When only an unverified alias is known for a domain, clients MUST display the fully-qualified domain instead of the alias.
 4. Clients MUST NOT display a handle as verified unless a certificate has been checked per section 4.
+5. **Where the suffix may be omitted.** In conversational context a client MAY show the bare handle where the ecosystem is unambiguous — a single-ecosystem thread, or a rendering that already carries the ecosystem's mark. In any surface a user consults **in order to decide whether to trust an identity**, including an identity card, a payment confirmation, and a delegation certificate, the fully-qualified form MUST be shown. Repeating an identical suffix on every line of a single-ecosystem thread is noise that readers stop seeing, which defeats the purpose of showing it at all.
+6. **Rendering MUST NOT rewrite.** A client that decorates a handle MUST render the form the user wrote. Where an ecosystem assigns account numbers, `@23@treechat` and `@thoth@treechat` name one identity; silently redrawing one as the other edits the text. Resolution is canonical, display is not.
+7. **Both forms of a numeric handle.** Where an ecosystem assigns an account number and also carries a chosen name, a profile surface MUST show both forms. Showing only the number makes the name look like an unverified alias; showing only the name hides the identifier other members of that ecosystem actually use.
+8. **Host-supplied attributes.** Display name, avatar, and any contact metadata the host serves — email address, telephone number, code-forge username — are unattested and MUST be labelled as such wherever they are shown. Contact details warrant this more than an avatar does, because a reader is more likely to act on them.
+9. **Registration age.** Where a host publishes the date a handle was registered, a client SHOULD display it with its age. A handle registered four years ago and one registered last week resolve identically and merit different amounts of trust.
 
 #### 2.5 Organisations, machines, and agents
 
@@ -95,11 +102,11 @@ Organisations, devices, and autonomous agents are addressed with the identical g
 
 ### 3. Subhandles
 
-Any handle owner MAY hand out subhandles of the form `@handle+tag:ecosystem`, analogous to `user+tag@example.com`, without registering anything.
+Any handle owner MAY hand out subhandles of the form `@handle+tag@ecosystem`, analogous to `user+tag@example.com`, without registering anything.
 
 #### 3.1 Resolution and identity
 
-1. Resolvers and messageboxes MUST strip the `+tag` before handle lookup. `@deggen+conf2036:lkup.net` resolves to exactly the same identity key, certificate, and messagebox as `@deggen:lkup.net`.
+1. Resolvers and messageboxes MUST strip the `+tag` before handle lookup. `@deggen+conf2036@lkup.net` resolves to exactly the same identity key, certificate, and messagebox as `@deggen@lkup.net`.
 2. Clients MUST NOT treat two subhandles of the same handle as distinct identities.
 3. The tag MUST be preserved verbatim, end to end, in the envelope metadata of every message and payment sent to a subhandle.
 
@@ -468,6 +475,8 @@ A scope determines who may deliver to a handle. The defined values are:
 
 A toll requires a sender to attach a payment to every envelope. It is paid to the recipient, it is due for every message each time rather than as a one-time unlock, it is not refunded on reply, and it remains in force until the recipient lifts it. A toll MAY be set for all senders in scope or for a named sender, and MAY be set per tag.
 
+**A general toll and a per-sender toll are independent settings**, and a client MUST treat them as such. Lifting the general toll does not lift any per-sender toll, and lifting a per-sender toll does not affect the general one. Because the natural reading of "the toll is off" is that no toll applies, a client that lifts one MUST state what has happened to the other; a client that conflates them will surprise its user in one direction or the other, and the direction that costs money is the one where a toll the user believed lifted is still charged.
+
 The recipient's messagebox is the enforcement point. The sender's client only surfaces the requirement.
 
 #### 8.3 Toll quotes and the delivery invariant
@@ -517,7 +526,7 @@ The principal's wallet issues a BRC-52 certificate:
 | `type` | The BRC-169 delegation-certificate type identifier (see section 4.5) |
 | `subject` | The delegate's identity public key |
 | `certifier` | The principal's identity public key |
-| `fields.delegator` | The principal's handle, in the form `@handle:domain` |
+| `fields.delegator` | The principal's handle, in the form `@handle@domain` |
 | `fields.scope` | Permitted actions, per section 9.2 |
 | `fields.perActionCap` | Maximum satoshis per delegated action, omitted for non-financial scopes |
 | `fields.totalCap` | OPTIONAL cumulative satoshi limit, subject to section 9.3 |
@@ -597,7 +606,9 @@ Reassigning a role is a revocation followed by a fresh delegation. Organisation 
 2. An address book entry MUST record the identity key, the handle and domain, the certificate, and the time of last verification. Entries are subject to the key-change rule of section 4.4.
 3. A user MAY publish a **peer attestation** of a contact's handle to key binding, as a lightweight BRC-52 certificate with the user as certifier. Host attestation answers whether the domain vouches for a binding; peer attestation answers whether people the user already trusts vouch for it. Clients SHOULD surface both, and MAY weight peer attestations when ranking mixed search results.
 4. A peer attestation is evidence, not proof. It is exactly as trustworthy as the attesting key, and clients MUST NOT present peer attestation as equivalent to host attestation.
-5. Because organisations resolve identically to users, the address book doubles as a business directory.
+5. **A reputation signal MUST identify who signed it.** Where a client surfaces peer statements of any kind, each MUST be attributable to the key that made it, and that key MUST be resolvable to a handle the reader can look up in turn. An unattributed count is not evidence: "eight people vouch for this handle" is worth exactly as much as the eight, and a reader who cannot see who they are cannot weigh it. Counts of different claims MUST NOT be summed — attestations of a binding and statements about a person are different things, and one total covering both is a number that means nothing.
+6. **Attestation is not reputation.** A peer attestation is a claim about a *binding*: this key is this handle. It is not a claim about the person, and it says nothing about whether they are worth transacting with. Ecosystems will want the second thing, and a client that renders the two identically lets a statement of regard be read as verification. Where a client surfaces both, it MUST label and group them separately, and a reputation signal MUST NOT contribute to any indication that an identity is verified. A reputation mechanism is out of scope here; an ecosystem defining one SHOULD do so as a custom command under BRC-218 section 8 rather than by overloading this section.
+7. Because organisations resolve identically to users, the address book doubles as a business directory.
 
 ## Security Considerations
 
@@ -680,11 +691,11 @@ Private keys are `SHA-256("BRC-169 EXAMPLE / " + label)` reduced mod `n`, so an 
 | Party | Label | Private key | Identity / certifier public key |
 | --- | --- | --- | --- |
 | `lkup.net` host | `lkup.net certifier` | `2641016ccb8e5602f53467fd6a8d91e2c58d44b8f727bd843da3f5f71e79e4c8` | `0371f0ec5992a9d38e09fe528e367890969c66eaebdb01b4d35a2fc0d61251b3f9` |
-| `@deggen:lkup.net` | `deggen identity` | `170605580e94d6f403468fdf9d2475e5b20379dc582f2ab9324932844be0b1aa` | `0359c5f3bfe249f6c0ca99d0e9cc1517da51a511f3d04f18e47a5d7ae55f04008c` |
+| `@deggen@lkup.net` | `deggen identity` | `170605580e94d6f403468fdf9d2475e5b20379dc582f2ab9324932844be0b1aa` | `0359c5f3bfe249f6c0ca99d0e9cc1517da51a511f3d04f18e47a5d7ae55f04008c` |
 | `nexus.example` host | `nexus.example certifier` | `bd60fdda070b1cd25813073615e2899a9a092ffb5ea87a0df1526bc89bcbc476` | `03df23a0a1bdf3135f9ec918bfc28e3d82b80ee7855e72a83c4b67a601270859d3` |
-| `@crumbs:nexus.example` | `crumbs identity` | `cf94a849be462a110807900e45a909515c38a2d17b9a8e9753c9475bfd220848` | `0375b162a37d8794cfdcf72938d9467931e8586885b93c0da97051ecb512f46646` |
+| `@crumbs@nexus.example` | `crumbs identity` | `cf94a849be462a110807900e45a909515c38a2d17b9a8e9753c9475bfd220848` | `0375b162a37d8794cfdcf72938d9467931e8586885b93c0da97051ecb512f46646` |
 
-The scenario: `@crumbs:nexus.example` pays `@deggen+conf2036:lkup.net` 21,545 satoshis.
+The scenario: `@crumbs@nexus.example` pays `@deggen+conf2036@lkup.net` 21,545 satoshis.
 
 ### A.2 `https://lkup.net/manifest.json`
 
@@ -857,22 +868,22 @@ The signature is over `SHA-256` of the RFC 8785 canonicalization with `content` 
 
 ### A.8 A forwarding record
 
-`@deggen:lkup.net` later moves to `nexus.example`, with a new identity key derived from the label `deggen identity at new domain`:
+`@deggen@lkup.net` later moves to `nexus.example`, with a new identity key derived from the label `deggen identity at new domain`:
 
 ```json
 {
-  "from": "@deggen:lkup.net",
+  "from": "@deggen@lkup.net",
   "toIdentityKey": "033cef496cd596a9dab13b36335cf51383322056f118c91e71d80be69b87e5db66",
-  "toHandle": "@deggen:nexus.example",
+  "toHandle": "@deggen@nexus.example",
   "created": "2027-01-15T00:00:00Z",
-  "signature": "3044022017f996f182da5420ca6eb64edb5ce6b22bf7ed5467fa84df8ca39d6b548017c002203df954ed85a4e20acd2727446c7c043070f6be83bb03c6b4a45c19182329641a"
+  "signature": "3045022100f4c27b2052e40565134c91e14e530fd0831c2043b5e698284f2a76d4383c509602201598a61ea25dd46f4e5f6f64d9ca54fdeac71bc34df048e685c5d8f77bf69d83"
 }
 ```
 
 The preimage is the four values, each followed by `LF`:
 
 ```
-@deggen:lkup.net\n033cef496cd596a9dab13b36335cf51383322056f118c91e71d80be69b87e5db66\n@deggen:nexus.example\n2027-01-15T00:00:00Z\n
+@deggen@lkup.net\n033cef496cd596a9dab13b36335cf51383322056f118c91e71d80be69b87e5db66\n@deggen@nexus.example\n2027-01-15T00:00:00Z\n
 ```
 
 Critically, this verifies against `0359c5f3...`, the **old** identity key from A.1, and not against the `lkup.net` certifier key. A host cannot forge a redirect for a handle it controls, which is the property section 4.3 requires. A client following this record must also apply section 4.4, since the identity key has changed.


### PR DESCRIPTION
Amends BRC-169, merged in #184.

Every change here came out of building a client against the document. They are grouped below by whether they change the wire form or only what a client must do.

## Breaking: the ecosystem separator is now `@`

`@handle@ecosystem` replaces `@handle:ecosystem`. This is a normative, breaking change to a merged specification, and it is the only one in this PR.

The colon form reads as a port to anyone who has typed a URL, and in testing users wrote the paymail form regardless of what the grammar said. Section 2.1(7) already required accepting `handle@domain.tld` and normalising it, so the document was already carrying `@` as the separator users actually produce, while specifying a different one as canonical. Collapsing the two removes the translation step.

The change threads through the ABNF of 2.1, the shorthand of 2.2, subhandles in 3, the delegation field table in 9.5, and every value in Appendix A.

**Appendix A still verifies.** The A.8 forwarding record is re-signed, because its signed preimage contains the handle strings. `verify_appendix.py` parses all 34 values back out of the document as printed and checks them, and reports `APPENDIX A FULLY VERIFIED` — including the BRC-42 key-agreement property in A.6 and the anti-forgery property of section 4.3 in A.8, where the signature verifies against the departing subject's old identity key and explicitly fails against the host's certifier key.

No other document in this repository references BRC-169's syntax, so nothing outside this file is affected.

## Parsing

Two rules follow directly from a recipient now containing two `@`:

- **2.1(8)** — a recipient begins at a whitespace boundary, not at an `@`. A client must scan back to the preceding whitespace or the start of input. Scanning back to the nearest `@` truncates the token the moment the user types the separator, which is exactly when autocomplete is most useful.
- **2.1(9)** — a leading `@` decides handle from paymail. `@alice@example.com` is a fully-qualified handle, and matching it against the paymail form first mis-parses it. Both forms name the same identity; the distinction is one of parse order.

## Confusability (2.3)

The skeleton computation moves from SHOULD to MUST, and the fold set becomes normative, adding `{8, b}`, `{rn, m}` and `{vv, w}` to the existing sets. As a SHOULD with an open set, two clients folding differently disagree about what counts as a spoofing risk — which is worse than having no rule, because a warning that appears in one client and not another teaches users that its absence means safety.

## Display (2.4, five new rules)

- **Where the suffix may be omitted.** A bare handle is fine in conversational context where the ecosystem is unambiguous. On any surface a user consults *in order to decide whether to trust an identity* — identity card, payment confirmation, delegation certificate — the fully-qualified form is required. Repeating an identical suffix on every line of a single-ecosystem thread is noise that readers stop seeing, which defeats the purpose of showing it.
- **Rendering must not rewrite.** Where an ecosystem assigns account numbers, `@23@treechat` and `@thoth@treechat` name one identity, and silently redrawing one as the other edits the text. Resolution is canonical; display is not.
- **Numeric handles show both forms** on a profile surface. Showing only the number makes the name look like an unverified alias; showing only the name hides the identifier other members of that ecosystem actually use.
- **Host-supplied contact details are unattested**, and the requirement to label them now covers email addresses, telephone numbers and code-forge usernames rather than only display name and avatar. A reader is far more likely to act on a phone number than on a picture.
- **Registration age** should be shown where the host publishes it. A handle registered four years ago and one registered last week resolve identically and merit different amounts of trust.

## Tolls (8.2)

A general toll and a per-sender toll are independent settings, and a client must treat them as such and say what happens to the other when one is lifted. The natural reading of "the toll is off" is that no toll applies. A client that conflates the two surprises its user in one direction or the other, and the direction that costs money is the one where a toll the user believed lifted is still being charged.

## Attestation is not reputation (10, two new rules)

Ecosystems will want a way for members to vouch for each other, and section 10 as merged left nothing separating that from attestation. It matters, because the two answer different questions: an attestation is a claim about a *binding* — this key is this handle — while a statement of regard is about the person and says nothing about whether the binding is genuine. A client that renders them identically lets the second be read as verification of the first.

- **10.5** — a reputation signal must identify the key that made it, and that key must resolve to a handle the reader can look up in turn. An unattributed count is not evidence. Counts of different claim types must not be summed into one total.
- **10.6** — where a client surfaces both, it must label and group them separately, and a reputation signal must not contribute to any indication that an identity is verified. A reputation mechanism stays out of scope; an ecosystem defining one should do it as a custom command under BRC-218 section 8.

## Verifying this PR

```
python3 verify_appendix.py     # 34 checks against peer-to-peer/0169.md, exits non-zero on any failure
```

The script is a working note kept outside this repository and is not part of the submission. Happy to attach it to the PR if reviewers want to run it.


---

## Certificate type identifiers (4.5)

As merged, 4.5 said the handle and delegation certificate `type` values were "to be allocated when this specification is registered", and that until then implementations must treat them as a constant agreed out of band and must not assume interoperability on the basis of certificate type.

**There is no allocator.** BRC-52 defines `CertificateTypeID` as an opaque 32-byte value, and no BRC defines an authority that assigns one. The section was waiting on an event that cannot happen, while its fallback conceded exactly the interoperability the document exists to provide.

Both values are now **derived from a name**, so any implementation reproduces them from the section alone:

```
type = base64( SHA-256( ASCII derivation string ) )
```

| Certificate | Derivation string | `type` |
| --- | --- | --- |
| Handle (4.1) | `metanet-handles handle certificate v1` | `XgCFdUfxEcI+3xtDjsIuSAjMl5EwzCUjsQc45ds1lC8=` |
| Delegation (9.1) | `metanet-handles delegation certificate v1` | `30kchAJIGfLxzCNloCJNLI3AtkgA8UbkxlXU2Cj4PpA=` |

There is precedent for deriving a 32-byte identifier from a name in this repository: BRC-228 and BRC-229 use `TopicID = SHA-256(UTF-8 topic name)`. Appendix A already derived its example certificate type this way; the derivation is now stated normatively rather than left implicit in a worked example.

Two details worth review:

- **The derivation strings carry no BRC number**, consistent with the rest of the document's wire vocabulary — the manifest key is `metanet.handles`, the alias protocol field is `ecosystem-alias` — so a later revision does not leave deployed constants naming a superseded document.
- **The `v1` suffix versions the type, not the document.** A revision that changes either certificate's field names or meanings mints a new type by changing the string, so certificates issued under two revisions stay distinguishable and a verifier is never left guessing which field semantics apply. That is what BRC-52 means in saying certificates of the same type are expected to share field names and meanings.

**Appendix A was regenerated** against the handle-certificate value, since `type` enters the signature preimage and the BRC-43 invoice number `<type> <serialNumber>`. The certificate signature and derived signing key changed accordingly. `verify_appendix.py` reports `APPENDIX A FULLY VERIFIED`.

### Left open: publishing type metadata

Deployed overlay infrastructure includes a certificate-type directory — topic `tm_certmap`, lookup service `ls_certmap`, live on the BSVA overlay clusters and wrapped by a registry client in several BSV SDKs — through which an operator publishes a type identifier alongside a name, icon, description and per-field descriptors.

The section describes it and leaves it as an open consideration rather than recommending it, for reviewers to settle. It is **not specified by any BRC** (no document in this repository mentions `certmap`, `basketmap`, `protomap`, or `registryOperator`), it allocates and reserves nothing, and its records are attributable to the publishing operator rather than to any authority over the type. Nothing in 4.5 depends on it — the type values stand on their derivation.

## Overlay names (5.5)

The document claims the topic `tm_ecosystemalias` and the lookup service `ls_ecosystemalias`. **Checked, no collision.**

Every topic manager and lookup service served by the four default SLAP trackers in the SDK constants was enumerated:

```
tm_anytx  tm_apps  tm_basketmap  tm_certmap  tm_desktopintegrity  tm_did
tm_fractionalize  tm_helloworld  tm_identity  tm_messagebox  tm_monsterbattle
tm_protomap  tm_ship  tm_slackthread  tm_slap  tm_supplychain  tm_tokendemo
tm_uhrp  tm_users  tm_walletconfig            (and the matching ls_* set)
```

`users.bapp.dev` serves only `tm_ship`, `tm_slap`, `tm_users`. GitHub code search for `tm_ecosystemalias` and `ls_ecosystemalias` returns one hit: this document.

**The names are unchanged.** BRC-87's examples are underscore-separated (`tm_uhrp_files`), but deployed practice runs the descriptor together — `certmap`, `basketmap`, `protomap`, `walletconfig`, `desktopintegrity` — and the current names match that while satisfying BRC-87's master rules.

What changed is that 5.5 now **records the claim and the check** instead of asserting it once. BRC-87 establishes no registry and leaves naming to agreement between operators, so a non-collision claim is only as good as the date it was checked; the section gives the reproducible procedure (`/listTopicManagers`, `/listLookupServiceProviders`, and an `ls_slap` `findAll` query) and asks an operator who finds a conflict to raise it here rather than quietly picking a variant — two ecosystems advertising aliases under different topics cannot see each other's advertisements, which defeats the point of publishing them.
