### PR TITLE
Brc 230 231 1sat

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ BRC | Standard
 227  | [Frictionless On-Chain Onboarding via Pre-Funded Claimable Tokens](./apps/0227.md)
 228  | [Multicast Shard Domain Partitioning and the BEEF Object Plane](./transactions/0228.md)
 229  | [Multicast BEEF Object Frame Format](./transactions/0229.md)
+230  | [1Sat Ordinals Basket Profile for BRC-46 / BRC-100](./tokens/0230.md)
+231  | [1Sat Provenance Remittance for Basket `1sat`](./tokens/0231.md)
 
 ## License
 

--- a/tokens/0230.md
+++ b/tokens/0230.md
@@ -1,0 +1,196 @@
+# BRC-230: 1Sat Ordinals Basket Profile for BRC-46 / BRC-100
+
+Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
+
+## Abstract
+
+This BRC defines the **application basket profile** for 1Sat Ordinals under [BRC-46](../wallet/0046.md) / [BRC-100](../wallet/0100.md). It reserves the basket name `1sat`, specifies eligibility of outputs placed in that basket, documents the tag vocabulary and [BRC-37](../outpoints/0037.md) `customInstructions` schema used for display and remittance, and describes normative hold / list / transfer / import flows via existing wallet interface methods.
+
+It does **not** redefine 1Sat Ordinals origin theory. Offline tip→origin proof is specified in the companion [BRC-231](./0231.md).
+
+## Motivation
+
+[BRC-37](../outpoints/0037.md) deliberately leaves `customInstructions` semantics to the named basket. [BRC-46](../wallet/0046.md) enables token-like tracking in baskets but does not define a 1Sat profile. Without a shared basket name and metadata contract, wallets cannot reliably:
+
+1. Hold the same inscription UTXOs in a common basket.
+2. List and filter collectables for apps and UI.
+3. Transfer a 1-sat tip while preserving origin claims for the receiver.
+4. Import historical ordinals via `internalizeAction` with interoperable remittance.
+
+Existing deployments (including HandCash Desktop) already use basket `1sat` with overlapping tags and JSON instructions. This BRC records that convention so independent wallets can interoperate without trusting a single vendor.
+
+## Specification
+
+### Basket identifier
+
+* The basket name is the UTF-8 string `1sat`.
+* Per [BRC-46](../wallet/0046.md), wallet implementations normalize basket identifiers by trimming whitespace and lowercasing. After normalization, conforming use of this profile MUST use exactly `1sat`.
+* This identifier does **not** use the [BRC-99](../wallet/0099.md) reserved `p ` prefix. It is a standard application basket under BRC-46 permissioning (grant / deny access to the basket as a whole, unless a future `p `-scheme supersedes that for assets).
+
+### Eligibility
+
+An output SHOULD be placed in basket `1sat` only when **all** of the following hold:
+
+1. `satoshis === 1`.
+2. The output is intended as a 1Sat Ordinals tip (a 1-satoshi UTXO in an inscription ownership chain), per [1Sat Ordinals](https://docs.1satordinals.com).
+3. The sender or importer reasonably believes the tip belongs to a 1Sat *origin* (the first 1-sat outpoint carrying a valid first `ord` envelope on that sat).
+
+Wallets MUST NOT place ordinary payment change or multi-sat outputs into `1sat` merely to attach ordinal-looking tags.
+
+Outputs that fail eligibility MAY still appear if a buggy sender used the basket; receivers SHOULD treat such outputs as malformed for this profile and MUST NOT present them as verified inscriptions solely because of basket membership.
+
+### Outpoint encoding
+
+* BRC-100 wire `outpoint` fields use **dot** form: `txid.vout` (see BRC-100 / [BRC-36](../outpoints/0036.md) practice).
+* 1Sat Ordinals / OrdFS commonly use **underscore** form: `txid_vout`.
+* Conforming implementations MUST treat `txid.vout` and `txid_vout` as the same outpoint when `txid` is 64 hex chars and `vout` is a non-negative decimal integer.
+* Inside this profile’s `customInstructions` object, `origin` SHOULD use underscore form for consistency with 1Sat indexers. Tags MAY use either form after the `origin:` prefix; readers MUST normalize before comparison.
+
+### Tags
+
+Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hints. They are **non-authoritative for asset identity**.
+
+| Tag | Requirement | Meaning |
+|-----|-------------|---------|
+| `ordinal` | SHOULD on conforming transfers and imports | Marks the output as an ordinal/inscription tip under this profile. |
+| `origin:<outpoint>` | SHOULD when origin is known | Claimed inscription origin (`dot` or `underscore` form). |
+| `name:<string>` | MAY | Short display name (implementations SHOULD truncate to ≤ 80 UTF-8 code units when writing). |
+| `app:<string>` | MAY | Creator / application id for filtering (SHOULD truncate to ≤ 40). |
+| `collection:<id>` / `collectionId:<id>` | MAY | Collection filter keys (synonyms). |
+| `creator:<id>` / `author:<id>` | MAY | Creator filter keys (synonyms of / complements to `app:`). |
+
+Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md) / BRC-46 spirit). Tag query via `listOutputs` uses existing `tags` / `tagQueryMode` fields.
+
+### Custom instructions ([BRC-37](../outpoints/0037.md))
+
+When present for basket `1sat`, `customInstructions` MUST be a **UTF-8 JSON object serialized as a string** (matching BRC-37 examples). Conforming writers SHOULD emit:
+
+```json
+{
+  "origin": "<txid_vout>",
+  "name": "<display name>",
+  "app": "<optional creator/app id>",
+  "provenance": { }
+}
+```
+
+| Field | Type | Requirement | Meaning |
+|-------|------|-------------|---------|
+| `origin` | string | SHOULD | Claimed origin outpoint (underscore form preferred). |
+| `name` | string | MAY | Display name. |
+| `app` | string | MAY | Creator / application id. |
+| `provenance` | object | SHOULD on transfer when available | Provenance remittance; schema and verification rules are defined only in [BRC-231](./0231.md). |
+
+Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers that do not understand `provenance` MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)).
+
+#### Claims vs proof
+
+* `origin`, `name`, `app`, and all tags are **claims**.
+* A wallet MUST NOT treat a claimed `origin` as proven solely because it appears in tags or `customInstructions`.
+* Proven tip→origin binding is defined by [BRC-231](./0231.md). When that remittance is absent or fails verification, the wallet MUST treat identity as **unproven** and SHOULD avoid presenting sender-supplied `name` / `app` as authoritative for that tip.
+
+### Hold and list
+
+Applications list held tips with BRC-100 `listOutputs`:
+
+```json
+{
+  "basket": "1sat",
+  "includeTags": true,
+  "includeCustomInstructions": true
+}
+```
+
+Optional `tags` / `tagQueryMode` filters apply as in BRC-46. Wallets MAY require basket permission per BRC-46 / BRC-100 before returning outputs.
+
+### Transfer (send)
+
+A conforming transfer of a held `1sat` tip SHOULD use BRC-100 `createAction` with:
+
+1. An **input** spending the current tip outpoint (`satoshis === 1`).
+2. An **output** with `satoshis: 1`, `basket: "1sat"`, tags per this profile, and `customInstructions` as above.
+3. Prefer supplying `inputBEEF` / AtomicBEEF for the spent tip when available ([BRC-62](../transactions/0062.md), [BRC-95](../transactions/0095.md)) so the new owner can validate the spend graph.
+4. Action `labels` MAY include `1sat` for activity filtering; labels are non-normative for asset identity.
+
+Example (non-normative shape):
+
+```json
+{
+  "description": "Send Collectable",
+  "labels": ["1sat"],
+  "inputs": [{ "outpoint": "<tip txid.vout>", "inputDescription": "1sat collectable" }],
+  "outputs": [{
+    "lockingScript": "<recipient P2PKH or other 1-sat lock>",
+    "satoshis": 1,
+    "outputDescription": "Collectable transfer",
+    "basket": "1sat",
+    "tags": ["ordinal", "origin:<txid.vout>", "name:Example"],
+    "customInstructions": "{\"origin\":\"<txid_vout>\",\"name\":\"Example\",\"provenance\":{}}"
+  }]
+}
+```
+
+Senders SHOULD attach [BRC-231](./0231.md) provenance remittance when they can build a valid package. Senders that cannot prove origin MUST NOT present the transfer as a verified inscription transfer; they MAY still move the 1-sat UTXO, but receivers will treat identity as unproven.
+
+### Import / receive (`internalizeAction`)
+
+To place an existing tip into basket `1sat`, use BRC-100 `internalizeAction` with protocol `basket insertion` ([BRC-46](../wallet/0046.md)):
+
+```json
+{
+  "tx": "<AtomicBEEF bytes for the tip transaction>",
+  "description": "Import 1Sat ordinal",
+  "labels": ["1sat"],
+  "outputs": [{
+    "outputIndex": 0,
+    "protocol": "basket insertion",
+    "insertionRemittance": {
+      "basket": "1sat",
+      "tags": ["ordinal", "origin:<txid.vout>"],
+      "customInstructions": "{\"origin\":\"<txid_vout>\",\"name\":\"Example\"}"
+    }
+  }]
+}
+```
+
+`insertionRemittance.customInstructions` follows the same schema as transfer. Provenance MAY be omitted on import when the importer verifies origin by other means before insertion; once transferred onward, senders SHOULD attach provenance for the new tip.
+
+### Payment separation (wallet policy guidance)
+
+Spending or revealing `1sat` basket outputs is **not** a [BRC-29](../payments/0029.md) / default-basket payment. Conforming wallets SHOULD:
+
+* Require distinct user authorization (or a dedicated item/basket grant) before `createAction` / `relinquishOutput` that spends `1sat` outputs.
+* Not treat a general “pay” or auto-pay grant as authorization to spend `1sat` tips.
+* Not fund ordinary payment outputs from `1sat` basket UTXOs.
+
+Normative fine-grained asset permission schemes remain [BRC-99](../wallet/0099.md) territory and are out of scope for this profile.
+
+### Compatibility
+
+* Wallets that do not implement this profile MUST still store and forward unknown baskets’ `customInstructions` and tags unchanged ([BRC-37](../outpoints/0037.md)).
+* This profile does not conflict with BRC-99 `p ` baskets; future permission-wrapped variants MAY wrap `1sat` semantics under a `p <scheme> …` name without invalidating this profile for the plain `1sat` basket.
+* Marketplaces (e.g. OrdLock), BSV-20/21, and mint APIs are out of scope.
+
+## Security considerations
+
+* **Tag / metadata spoofing** — Without provenance verification, a sender can attach another inscription’s `origin` and `name`. See [BRC-231](./0231.md).
+* **Basket pollution** — Placing non-1-sat or non-ordinal outputs in `1sat` confuses list UIs; receivers should re-check `satoshis` and inscription rules.
+* **Burn** — Per 1Sat Ordinals, packing a sat into a multi-sat output ends that origin trail. Do not continue `origin:` claims across a burn.
+* **Indexer trust** — Display media URLs and collection metadata often come from indexers; this profile does not make indexers authoritative for tip→origin binding.
+
+## Implementations
+
+* **HandCash Desktop** (reference): basket `1sat` list / send / import; tags and `customInstructions` as above; payment grants never cover item spends.  
+  Source: `src/wallet/collectables.ts`, `src/wallet/oneSatImport.ts`, `src/wallet/itemAccess.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).
+
+## References
+
+1. 1Sat Ordinals — <https://docs.1satordinals.com>
+2. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions Extension for Bitcoin Outpoints
+3. [BRC-45](./0045.md) — Outputs are Tokens
+4. [BRC-46](../wallet/0046.md) — Wallet Transaction Output Tracking (Output Baskets)
+5. [BRC-62](../transactions/0062.md) — BEEF Transactions
+6. [BRC-95](../transactions/0095.md) — Atomic BEEF Transactions
+7. [BRC-99](../wallet/0099.md) — P Baskets (reserved permission schemes)
+8. [BRC-100](../wallet/0100.md) — Unified Open BSV Wallet-to-Application Interface
+9. [BRC-231](./0231.md) — 1Sat Provenance Remittance for Basket `1sat`

--- a/tokens/0231.md
+++ b/tokens/0231.md
@@ -1,0 +1,135 @@
+# BRC-231: 1Sat Provenance Remittance for Basket `1sat`
+
+Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
+
+## Abstract
+
+This BRC defines the **provenance remittance** carried in [BRC-37](../outpoints/0037.md) `customInstructions` for outputs in the companion basket profile `1sat` ([BRC-230](./0230.md)). It specifies an offline-verifiable package that binds a current 1-sat outpoint (*tip*) to a 1Sat Ordinals *origin*, using BEEF or AtomicBEEF plus local verification of the first `ord` inscription envelope.
+
+Together with [BRC-230](./0230.md), this enables interoperable 1Sat hold/transfer while preventing forgeable `origin:` tags from being treated as proof. Verification does not require a global ordinals indexer.
+
+## Motivation
+
+[BRC-230](./0230.md) documents how wallets hold and transfer 1Sat tips and how they attach display metadata. Those metadata fields remain **claims**: a malicious or buggy sender can attach another inscription’s origin to an unrelated 1-sat UTXO. Indexer-only checks help UX but introduce a trust dependency when the indexer is wrong, lagging, or unavailable.
+
+[BRC-62](../transactions/0062.md) / [BRC-95](../transactions/0095.md) already provide SPV transaction ancestry packages. This BRC applies those formats to the 1Sat tip→origin path and adds the local script rule that the origin locking script contains a valid first `ord` envelope ([1Sat Ordinals](https://docs.1satordinals.com), aligned with [BRC-67](../transactions/0067.md) SPV principles).
+
+## Specification
+
+### Scope
+
+This remittance applies when:
+
+* The output is associated with basket `1sat` as defined in [BRC-230](./0230.md) (after BRC-46 name normalization), and
+* The tip being transferred or internalized is a **1-satoshi** output.
+
+Out of scope: OrdLock marketplace contracts, BSV-20/21, minting APIs, redefinition of 1Sat origin theory, and basket naming/tags (see [BRC-230](./0230.md)).
+
+### Transport
+
+Provenance is embedded as the `provenance` field of the basket profile’s `customInstructions` JSON object ([BRC-37](../outpoints/0037.md)). Display fields (`origin`, `name`, `app`) remain as defined by [BRC-230](./0230.md) and MUST NOT be treated as proven unless this remittance verifies.
+
+Wallets that do not implement this BRC MUST still store and forward unknown `customInstructions` unchanged ([BRC-37](../outpoints/0037.md)).
+
+### Provenance object (v2)
+
+```json
+{
+  "v": 2,
+  "origin": "<txid_vout>",
+  "tip": "<txid_vout>",
+  "path": ["<tip>", "…", "<origin>"],
+  "beefB64": "<base64>",
+  "contentType": "<optional string>"
+}
+```
+
+| Field | Type | Requirement | Description |
+|-------|------|-------------|-------------|
+| `v` | number | MUST | Schema version. This BRC defines `2`. |
+| `origin` | string | MUST | Inscription origin outpoint in underscore form `txid_vout`. |
+| `tip` | string | MUST | Current outpoint being proven, underscore form. MUST equal `path[0]`. |
+| `path` | string[] | MUST | Ordered outpoints tip → … → origin, inclusive. Length ≥ 1. |
+| `beefB64` | string | MUST | Base64 encoding of **AtomicBEEF** ([BRC-95](../transactions/0095.md)) preferred, rooted at the tip transaction id; or BEEF ([BRC-62](../transactions/0062.md)) covering all transactions required to validate `path`. |
+| `contentType` | string | OPTIONAL | Hint from the origin `ord` envelope content-type field when known. |
+
+Outpoint normalization (dot ↔ underscore) follows [BRC-230](./0230.md).
+
+#### Non-conforming versions
+
+Provenance objects with `v !== 2`, or path-only packages without `beefB64`, are **not** defined by this BRC and MUST NOT be considered conforming remittances. Implementations MAY use private fallbacks for local UX; they MUST NOT advertise those fallbacks as this BRC.
+
+### Sender requirements
+
+A conforming sender transferring a `1sat` tip under [BRC-230](./0230.md) SHOULD:
+
+1. Determine the true `origin` of the tip (indexer-assisted discovery is allowed for *building* the package).
+2. Construct `path` tip→origin such that each consecutive pair with different transaction ids is related by a spend of the parent outpoint as an input to the child transaction.
+3. Assemble `beefB64` covering every transaction id appearing in `path`.
+4. Prefer AtomicBEEF ([BRC-95](../transactions/0095.md)) whose subject txid is the tip transaction.
+5. Self-verify using the Receiver rules below before broadcast.
+6. If a valid v2 package cannot be produced, the sender MUST NOT claim a verified origin via tags alone. The sender MAY omit `provenance`; receivers MUST then treat identity as unverified per [BRC-230](./0230.md).
+
+Senders MUST NOT embed full inscription *content* solely for this remittance; envelope presence at origin is sufficient.
+
+### Receiver requirements
+
+Given a candidate tip outpoint `T` and `customInstructions.provenance` with `v === 2`, a conforming receiver MUST verify as follows. On any failure, the receiver MUST treat origin identity as **unproven** and MUST NOT adopt sender `name` / `app` / `origin:` tags as authoritative for that tip ([BRC-230](./0230.md) claims rule).
+
+1. **Parse** — Decode `beefB64` as BEEF ([BRC-62](../transactions/0062.md)) or AtomicBEEF ([BRC-95](../transactions/0095.md)). Failure → unproven.
+2. **Structure** — The BEEF MUST pass structural validation (e.g. `Beef.verifyValid`). Use of txid-only entries ([BRC-96](../transactions/0096.md)) is allowed only when the receiver already trusts those transactions by other means.
+3. **Atomic subject (when AtomicBEEF)** — If the bytes are AtomicBEEF, the subject txid MUST equal the tip’s transaction id.
+4. **Tip binding** — `provenance.tip` and `path[0]` MUST equal tip outpoint `T` after normalization.
+5. **Origin binding** — `path[path.length - 1]` MUST equal `provenance.origin`.
+6. **Ancestry** — For each consecutive pair `(child, parent)` in `path` with different transaction ids, the child transaction in the BEEF MUST spend `parent` as an input.
+7. **One-sat** — For each outpoint in `path` present in the BEEF with a known satoshi value, that value MUST be `1`.
+8. **Inscription** — The locking script of `origin` MUST contain a valid first `ord` envelope as defined by 1Sat Ordinals:
+
+   ```
+   OP_FALSE OP_IF <"ord"> … OP_ENDIF
+   ```
+
+   on a 1-sat output. Subsequent envelopes on the same sat MUST be ignored for origin identity (1Sat rule).
+
+9. **Headers (RECOMMENDED)** — Receivers SHOULD confirm BEEF merkle roots against a header source / ChainTracker per [BRC-67](../transactions/0067.md) when available.
+
+On success, the receiver MAY treat `provenance.origin` as the proven origin for tip `T` and MAY use indexer metadata keyed by that origin for display.
+
+### Relationship to BRC-230
+
+| Concern | Defined by |
+|---------|------------|
+| Basket name `1sat`, tags, display `customInstructions`, createAction / internalizeAction flows | [BRC-230](./0230.md) |
+| `provenance` object schema + verify/build rules | **This BRC** |
+| Whether unproven tips may be shown with sender `name`/`app` | [BRC-230](./0230.md) (claims); this BRC (when proof fails) |
+
+### Compatibility
+
+* This BRC does not alter BRC-62/95 encodings; it only constrains how they are used inside `customInstructions.provenance`.
+* Deep histories may produce large remittances. Implementations SHOULD prefer AtomicBEEF and MAY refuse to embed packages above an implementation-defined size, falling back to “unproven” rather than truncated proofs.
+* Partial BEEF (structurally valid but missing a path transaction) MUST fail verification.
+
+## Security considerations
+
+* **Tag spoofing** — Without this remittance, `origin:` tags are forgeable. Receivers that skip verification reintroduce the attack.
+* **Indexer divergence** — Indexers may lag or err. A verified remittance is authoritative for tip↔origin binding; indexers remain useful for discovery and media URLs.
+* **Burn / re-origin** — If a sat is packed into a multi-sat output, 1Sat origin tracking ends. Remittances MUST NOT invent a continuous path across a burn.
+* **Oversized remittance** — Truncating `path` or `beefB64` to fit a size budget invalidates the proof; omit provenance instead.
+* **Unspent status** — This remittance proves tip→origin identity. Proving the tip remains unspent requires the same network / UTXO checks as accepting any BSV payment.
+
+## Implementations
+
+* **HandCash Desktop** (reference): builds and verifies provenance v2 on collectable send / list.  
+  Source: `src/wallet/oneSatProvenance.ts`, `src/wallet/oneSatInscription.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).
+
+## References
+
+1. [BRC-230](./0230.md) — 1Sat Ordinals Basket Profile for BRC-46 / BRC-100
+2. 1Sat Ordinals protocol — <https://docs.1satordinals.com>
+3. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions Extension for Bitcoin Outpoints
+4. [BRC-46](../wallet/0046.md) — Wallet Transaction Output Tracking (Output Baskets)
+5. [BRC-62](../transactions/0062.md) — Background Evaluation Extended Format (BEEF) Transactions
+6. [BRC-67](../transactions/0067.md) — Simplified Payment Verification
+7. [BRC-95](../transactions/0095.md) — Atomic BEEF Transactions
+8. [BRC-96](../transactions/0096.md) — BEEF V2 Txid Only Extension
+9. [BRC-100](../wallet/0100.md) — Unified Open BSV Wallet-to-Application Interface

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -14,3 +14,5 @@ BRC | Standard
 115  | [Identity-Linked Deterministic Token Verification Framework](./0115.md)
 117  | [Proof-of-Indexing Hash-to-Mint Tokens](./0117.md)
 226  | [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./0226.md)
+230  | [1Sat Ordinals Basket Profile for BRC-46 / BRC-100](./0230.md)
+231  | [1Sat Provenance Remittance for Basket `1sat`](./0231.md)


### PR DESCRIPTION
## Summary

Adds two companion token BRCs for 1Sat Ordinals under BRC-46 / BRC-100:

- **BRC-230 — 1Sat Ordinals Basket Profile** (merged as **BRC-147**)  
  Basket `1sat`: eligibility, tags, BRC-37 `customInstructions` schema, and normative list / transfer / import flows. Tags and display fields are claims, not proof.

- **BRC-231 — 1Sat Provenance Remittance** (merged as **BRC-150**)  
  `customInstructions.provenance` v2: tip→origin path + BEEF / AtomicBEEF, with local verification of the first `ord` envelope at origin.

## Compatibility

- Transport: BRC-37 `customInstructions` + BRC-46/100 baskets
- Proof package: BRC-62 BEEF, BRC-95 AtomicBEEF
- Does not redefine 1Sat origin theory; OrdLock / BSV-20/21 out of scope
- Proposed 230/231 → assigned **147/150** on merge

## Reference implementation

https://github.com/HandCash/HANDCASH-DESKTOP

## Test plan

- [x] Spec review vs BRC-37, BRC-46, BRC-62, BRC-95, BRC-100
- [x] Numbers reassigned to 147/150
- [x] Index rows in `README.md` and `tokens/README.md`