### PR TITLE
Brc 232 pluggable backup services

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ BRC | Standard
 225  | [Animated-QR Air-Gap Transport for Arbitrary Payloads (TKQR1)](./peer-to-peer/0225.md)
 226  | [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)
 227  | [Frictionless On-Chain Onboarding via Pre-Funded Claimable Tokens](./apps/0227.md)
+232  | [Pluggable Backup Services for BRC-140 Share Vaults](./wallet/0232.md)
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -46,6 +46,7 @@
 * [Wallet Permissions and Counterparty Trust](./wallet/0116.md)
 * [Basket Permission Scheme Registry and Governance](./wallet/0123.md)
 * [Wallet Permission Prompt Liveness Contract](./wallet/0219.md)
+* [Pluggable Backup Services for BRC-140 Share Vaults](./wallet/0232.md)
 
 ## Transactions
 

--- a/wallet/0232.md
+++ b/wallet/0232.md
@@ -4,7 +4,7 @@ Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
 ## Abstract
 
-This BRC defines an HTTP **backup service** profile for optional recovery of [BRC-140](../key-derivation/0140.md) key shares. A backup service stores **at most one** BRC-140 share per `userIdHash` and releases it only after authentication. Wallets may enroll a **list** of independent service URLs, deposit distinct shares across them under a threshold scheme, and reconstruct the key locally after obtaining enough shares.
+This BRC defines an HTTP **backup service** profile for optional recovery of [BRC-140](../key-derivation/0140.md) key shares. A backup service stores **at most one** BRC-140 share per authenticated account and releases it only after authentication. Wallets may enroll a **list** of independent service URLs, deposit distinct shares across them under a threshold scheme, and reconstruct the key locally after obtaining enough shares.
 
 A backup service MUST NOT be required for ordinary wallet operation under [BRC-100](./0100.md). It MUST NOT receive the root private key, and a conforming wallet MUST NOT send enough shares to any single service to meet the wallet’s recovery threshold.
 
@@ -20,9 +20,9 @@ This BRC specifies a minimal, pluggable wire contract so any operator can run a 
 
 | Term | Meaning |
 |------|---------|
-| **Backup service** | HTTP origin that stores ≤ 1 BRC-140 share per `userIdHash` and releases it after auth. |
+| **Backup service** | HTTP origin that stores ≤ 1 BRC-140 share per authenticated account and releases it after auth. |
 | **Wallet** | Client that splits/reconstructs keys per BRC-140 and speaks this profile. |
-| **Enrollment** | Successful deposit of exactly one share to one backup service for one `userIdHash`. |
+| **Enrollment** | Successful deposit of exactly one share to one backup service for one authenticated account. |
 | **Recovery** | Obtaining ≥ threshold distinct shares and reconstructing the key in the wallet. |
 
 ### Relationship to other BRCs
@@ -49,26 +49,17 @@ This BRC specifies a minimal, pluggable wire contract so any operator can run a 
 3. Reconstruction happens only in the wallet after enough shares are obtained.
 4. Services MUST NEVER receive the reconstructed key.
 
-**Invariant (service):** store at most one share per `userIdHash`; reject non-BRC-140 share strings.
+**Invariant (service):** store at most one share per authenticated account; reject non-BRC-140 share strings.
 
 **Invariant (wallet):** MUST NOT send the root private key, mnemonic, or ≥ threshold shares from one split to any single backup service.
 
 A common enrollment scheme is threshold 2 of 3 total shares. Other thresholds are permitted if the wallet and user agree on the scheme before deposit.
 
-### User identity handle
+### Account binding
 
-`userIdHash` is a **64-character lowercase hex** SHA-256 digest used as the storage key at each service.
+The bearer session returned by authentication MUST be bound to a provider-local account. Share endpoints operate on that authenticated account and MUST NOT accept a caller-supplied email, handle, public key, or account hash to select another account's share.
 
-For email OTP auth:
-
-```
-userIdHash = hex( SHA-256( UTF-8( normalize(email) ) ) )
-normalize(email) = trim + lowercase
-```
-
-Wallets and services MUST use the same normalization before hashing. Share endpoints identify the record by `userIdHash` only.
-
-`userIdHash` is a stable lookup key, not an anonymity mechanism: an operator that learns the email during authentication can recompute the hash and associate it with the stored share. Other auth methods MAY define a different preimage in a future revision.
+The provider MAY use any internal account identifier. That identifier is not part of this wire profile and MUST NOT be treated as an anonymity mechanism: a provider can associate the stored share with the identity presented during authentication.
 
 ### HTTP profile
 
@@ -83,8 +74,7 @@ No auth required.
   "name": "Example Backup",
   "version": "0.1.0",
   "role": "backup-service",
-  "authMethods": ["EmailOtp"],
-  "requiresPasswordWithOtp": false,
+  "authMethods": ["com.example.connect", "webauthn", "email-otp"],
   "lifecycle": {
     "status": "active",
     "sunsetAt": null,
@@ -100,8 +90,7 @@ No auth required.
 | `name` | MUST | Operator display name |
 | `version` | SHOULD | Operator software version |
 | `role` | SHOULD | Constant `backup-service` |
-| `authMethods` | MUST | Non-empty array of auth method identifiers |
-| `requiresPasswordWithOtp` | SHOULD | If `true`, retrieve (and optionally enroll) requires an additional password/PIN field under the operator’s documented policy |
+| `authMethods` | MUST | Non-empty array of supported authentication method identifiers |
 | `lifecycle` | MUST | Operator lifecycle block |
 
 #### Lifecycle
@@ -121,12 +110,21 @@ No auth required.
 
 Wallets SHOULD refresh `/info` for enrolled URLs and stop new enrolls when status is not `active`. Operators SHOULD provide a sunset window before `retireAt`.
 
-#### Auth (email OTP)
+#### Authentication
+
+Authentication is capability-negotiated. This BRC defines a common start/complete envelope but does not mandate a specific identity provider or factor.
+
+`authMethods` contains identifiers for authentication profiles understood by the service. Provider-specific identifiers SHOULD use reverse-domain form (for example `com.example.connect`). Existing standardized identifiers such as `webauthn` MAY be used directly. Email OTP, redirect-based Connect providers, passkeys, and challenge-response systems are all possible profiles; none is required by this BRC. Wallets MUST ignore methods they do not implement.
+
+An authentication method used for recovery MUST remain usable without possession of the secret being recovered. A signature key derived only from the BRC-140-protected root key MUST NOT be the sole recovery method, because that creates a circular dependency. Redirect or challenge methods are conforming only when their credential can be recovered independently.
 
 ##### `POST /auth/start`
 
 ```json
-{ "email": "user@example.com" }
+{
+  "method": "com.example.connect",
+  "params": {}
+}
 ```
 
 Response (`200`):
@@ -134,18 +132,28 @@ Response (`200`):
 ```json
 {
   "requestId": "<opaque>",
-  "expiresInSec": 600
+  "expiresInSec": 600,
+  "action": {
+    "type": "redirect",
+    "url": "https://identity.example/authorize?request=<opaque>"
+  }
 }
 ```
 
-The operator delivers a one-time code out of band. Production deployments MUST NOT return the code in the HTTP response.
+`params` and `action` are method-specific objects. Defined `action.type` values are:
 
-##### `POST /auth/verify`
+* `redirect` — open `action.url`; the authorization result is supplied to `/auth/complete`.
+* `challenge` — produce a proof over `action.challenge`.
+* `outOfBand` — complete the externally delivered challenge (such as an OTP).
+
+Unknown action fields MUST be ignored.
+
+##### `POST /auth/complete`
 
 ```json
 {
   "requestId": "<opaque>",
-  "code": "<otp>"
+  "response": {}
 }
 ```
 
@@ -154,14 +162,13 @@ Response (`200`):
 ```json
 {
   "token": "<bearer secret>",
-  "email": "user@example.com",
   "expiresInSec": 1800
 }
 ```
 
-Share endpoints use `Authorization: Bearer <token>`.
+`response` is method-specific. The service MUST validate that it completes the referenced request and MUST bind the returned bearer token to the authenticated provider-local account.
 
-Wallets MUST skip services whose `authMethods` they do not implement. When `requiresPasswordWithOtp` is `true`, the service MAY require an additional password/PIN on share operations as documented by the operator.
+Share endpoints use `Authorization: Bearer <token>`. Tokens SHOULD be short-lived and scoped to backup-service operations.
 
 #### Share endpoints
 
@@ -169,7 +176,6 @@ All share endpoints require a valid bearer session.
 
 ```json
 {
-  "userIdHash": "<64 hex>",
   "share": "<BRC-140 backup string>"
 }
 ```
@@ -180,17 +186,17 @@ All share endpoints require a valid bearer session.
 
 * MUST validate `share` as BRC-140 backup serialization.
 * MUST fail with `403` when lifecycle forbids enroll.
-* Stores exactly one share for `userIdHash` (overwrite policy is operator-defined; `/share/rotate` SHOULD be preferred for explicit replacement).
+* Stores exactly one share for the authenticated account (overwrite policy is operator-defined; `/share/rotate` SHOULD be preferred for explicit replacement).
 
 Response (`200`):
 
 ```json
-{ "ok": true, "userIdHash": "<64 hex>", "enrolledAt": "<RFC 3339>" }
+{ "ok": true, "enrolledAt": "<RFC 3339>" }
 ```
 
 ##### `POST /share/retrieve`
 
-Request: `{ "userIdHash" }`.
+Request: `{}`.
 
 Response (`200`):
 
@@ -208,7 +214,7 @@ Replace the stored share after auth. Same validation as enroll.
 
 ##### `POST /share/delete`
 
-Request: `{ "userIdHash" }`. Idempotent; response `{ "ok": true }`.
+Request: `{}`. Idempotent; response `{ "ok": true }`.
 
 ### Wallet requirements
 
@@ -224,8 +230,9 @@ Request: `{ "userIdHash" }`. Idempotent; response `{ "ok": true }`.
 |------|------------|
 | Single service compromised | Threshold ≥ 2; one share insufficient |
 | Colluding services | Threshold and enrollment topology determine exposure; wallets MUST NOT send ≥ threshold shares to one party |
-| OTP / inbox takeover | Short-lived tokens; optional `requiresPasswordWithOtp`; auth rate limiting |
-| Email↔share linkage | Operator that authenticates the email can link it to `userIdHash` and the share; treat operators as share custodians for that record |
+| Authentication compromise | Short-lived scoped tokens, rate limiting, and operator-appropriate factors |
+| Circular recovery auth | A key derived solely from the protected root MUST NOT be the only release credential |
+| Identity↔share linkage | The provider can associate its authenticated account with the share; treat providers as share custodians for that record |
 | Operator disappearance | Multi-provider enrollment and offline BRC-140 / BRC-75 |
 | Malformed shares | Reject non-BRC-140; verify integrity at reconstruct |
 
@@ -233,8 +240,7 @@ Protect share transport with TLS. Minimize logging of share material. Encrypt sh
 
 ## Implementations
 
-1. HandCash Desktop — multi-URL backup-service client and local BRC-140 split/reconstruct (`feat/backup-services`).
-2. HandCash `backup-service` — reference share vault implementing this profile.
+HandCash Desktop and its `backup-service` prototype implement multi-provider BRC-140 share storage on branch `feat/backup-services`. The prototype's original email-OTP exchange predates the capability-negotiated authentication envelope in this draft and is not presented as a complete conforming implementation.
 
 ## References
 

--- a/wallet/0232.md
+++ b/wallet/0232.md
@@ -1,0 +1,270 @@
+# BRC-232: Pluggable Backup Services for BRC-140 Share Vaults
+
+Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
+
+## Abstract
+
+This BRC defines an interoperable **backup service** profile: an independent HTTP provider that stores **at most one** [BRC-140](../key-derivation/0140.md) recovery share per user and releases it only after the user authenticates. Wallets maintain a **list** of backup-service URLs (not a single hardcoded vendor), deposit distinct shares across providers under a threshold scheme (for example 2-of-3), and recover by authenticating to enough enrolled services.
+
+A backup service is a **disaster-recovery aid**. It MUST NOT be required for day-to-day spend, connect, or [BRC-100](./0100.md) wallet use. It is not a threshold-signature co-signer and MUST NOT receive the root private key or enough shares to meet the wallet’s recovery threshold by itself.
+
+## Motivation
+
+[BRC-140](../key-derivation/0140.md) solves key sharding for offline backup: split a secp256k1 private key into shares so a threshold can reconstruct it. Users still face a practical gap — many lose the only device and never finish offline share placement (paper, password manager, second device).
+
+Vendor-specific “trustholder” or wallet-authentication backends historically filled that gap by holding a share (or worse, remaining in the spend path). A single hardcoded recovery vendor recreates custody concentration and shutdown risk: if that vendor disappears, enrolled users who relied on it alone are stranded.
+
+This profile decentralizes that role:
+
+1. **Any** operator may run a conforming backup service.
+2. Wallets treat providers as a **replaceable URL list**.
+3. Cryptography stays [BRC-140](../key-derivation/0140.md); this BRC only specifies the **service wire contract**, lifecycle signaling, and wallet enrollment rules that make multi-provider recovery interoperable.
+
+Recording the contract as a BRC gives independent wallets and operators a shared legitimacy target instead of each inventing a private recovery API.
+
+## Specification
+
+### Terminology
+
+| Term | Meaning |
+|------|---------|
+| **Backup service** | HTTP origin that stores ≤ 1 BRC-140 share per `userIdHash` and releases it after auth. |
+| **Wallet** | Client that splits/reconstructs keys per BRC-140 and speaks this profile. |
+| **Enrollment** | Successful deposit of exactly one share to one backup service for one `userIdHash`. |
+| **Recovery** | Fetching ≥ threshold distinct shares (from services and/or offline holdings) and reconstructing the key locally. |
+
+Preferred user-facing language is **backup service** / **recovery provider**. Implementations SHOULD avoid implying that a service can move funds or that any single vendor “recovers the account.”
+
+### Relationship to other BRCs
+
+| Standard | Role |
+|----------|------|
+| [BRC-140](../key-derivation/0140.md) | Share math + `x.y.threshold.integrity` serialization (normative for `share` payloads) |
+| [BRC-75](../key-derivation/0075.md) | Complementary offline mnemonic path; out of scope here |
+| [BRC-38](../outpoints/0038.md) / [BRC-39](../outpoints/0039.md) / [BRC-40](../outpoints/0040.md) | Wallet *data* export/sync — not key sharding; out of scope |
+| [BRC-100](./0100.md) | Day-to-day app↔wallet interface; MUST remain usable with zero backup services configured |
+
+### Non-goals
+
+* Threshold signatures / spend-time co-signing.
+* Requiring backup services for send, receive, or BRC-100 connect.
+* Mandating a global directory of providers (wallets MAY ship curated defaults; empty default is valid).
+* Synchronizing full UTXO / history state (remain BRC-38/39/40 or local).
+* Binding operators to a specific email ISP or KYC regime.
+
+### Cryptographic model (wallet)
+
+1. The wallet splits its **root private key** with BRC-140 (reference: `toBackupShares` / `fromBackupShares`).
+2. Default multi-service enrollment scheme: **threshold = 2**, **total = 3** (other schemes are allowed if clearly disclosed in wallet UX).
+3. The wallet deposits **at most one share per backup service**.
+4. Reconstruction ALWAYS happens inside the wallet after enough shares are obtained. Services MUST NEVER receive the reconstructed key.
+
+**Invariant (service):** a conforming backup service stores at most one share per `userIdHash` and MUST reject payloads that are not BRC-140 backup strings.
+
+**Invariant (wallet):** a conforming wallet MUST NOT send the root private key, mnemonic, or ≥ threshold shares to any single backup service.
+
+#### Opt-in service-majority recovery
+
+Wallets MAY offer an opt-in path where the user deposits three shares to three services under 2-of-3 and holds no offline share. That path trades offline independence for device-loss convenience: any two enrolled services that release shares after user auth can reconstruct. Wallets MUST disclose this tradeoff at enrollment. Offline BRC-140 / BRC-75 paths remain first-class and MUST remain available without any service.
+
+### User identity handle
+
+`userIdHash` is a **64-character lowercase hex** SHA-256 digest used as the storage key at each service.
+
+For email OTP auth, the normative binding is:
+
+```
+userIdHash = hex( SHA-256( UTF-8( normalize(email) ) ) )
+normalize(email) = trim + lowercase
+```
+
+Wallets and services MUST use the same normalization before hashing. Services MUST treat `userIdHash` as an opaque key and MUST NOT require the raw email on share endpoints (email appears only in auth start/verify as needed by the operator).
+
+Other auth methods MAY define their own preimage for `userIdHash` in a future revision; v1 documents the email binding above because it matches deployed practice.
+
+### HTTP profile
+
+Base URL is an HTTPS (or loopback HTTP for development) origin. Paths below are relative to that origin. JSON UTF-8 request/response bodies unless noted. Unknown JSON fields MUST be ignored by readers.
+
+#### `GET /info`
+
+Returns service metadata. No auth required.
+
+```json
+{
+  "name": "Example Backup",
+  "version": "0.1.0",
+  "role": "backup-service",
+  "authMethods": ["EmailOtp"],
+  "requiresPasswordWithOtp": false,
+  "lifecycle": {
+    "status": "active",
+    "sunsetAt": null,
+    "retireAt": null,
+    "message": null,
+    "successorUrl": null
+  }
+}
+```
+
+| Field | Requirement | Meaning |
+|-------|-------------|---------|
+| `name` | MUST | Human-readable operator name |
+| `version` | SHOULD | Operator software version string |
+| `role` | SHOULD | Constant `backup-service` for discovery |
+| `authMethods` | MUST | Non-empty array of auth method identifiers |
+| `requiresPasswordWithOtp` | SHOULD | If `true`, wallet SHOULD also collect a user password/PIN and send it on retrieve per operator policy (extension; see Auth) |
+| `lifecycle` | MUST | Operator lifecycle block (below) |
+
+#### Lifecycle / shutdown signaling
+
+Operators MUST publish planned shutdown so wallets can urge rotation before shares become unreachable.
+
+| `lifecycle.status` | Meaning |
+|--------------------|---------|
+| `active` | Normal enroll + retrieve |
+| `sunset` | Still serving retrieve; MUST reject new enrolls (or wallet MUST treat enroll as forbidden) |
+| `retired` | Gone or past `retireAt`; retrieve MUST fail |
+
+| Field | Requirement | Meaning |
+|-------|-------------|---------|
+| `sunsetAt` | MAY | When sunset began / begins (RFC 3339 UTC) |
+| `retireAt` | SHOULD when sunsetting | Last moment retrieve is expected to work |
+| `message` | MAY | Human explanation |
+| `successorUrl` | MAY | Suggested replacement backup-service base URL |
+
+**Wallet behavior**
+
+1. Refresh `/info` for each enrolled URL periodically (on launch and at least daily while the wallet runs is sufficient).
+2. If `sunset` / `retired` / `retireAt` within 90 days: warn the user to rotate.
+3. **Rotate:** retrieve (while still possible) → enroll at a replacement URL → delete old enrollment when delete is available.
+4. Recommend operators advertise ≥ 90 days between `sunset` and `retireAt`. Absence of signaling does not remove the need for offline backup.
+
+#### Auth (email OTP v1)
+
+##### `POST /auth/start`
+
+Request:
+
+```json
+{ "email": "user@example.com" }
+```
+
+Response (`200`):
+
+```json
+{
+  "requestId": "<opaque>",
+  "expiresInSec": 600
+}
+```
+
+Operators MUST deliver a one-time code out of band (email). Development-only fields such as `devCode` MUST NOT appear in production deployments.
+
+##### `POST /auth/verify`
+
+Request:
+
+```json
+{
+  "requestId": "<opaque>",
+  "code": "<otp>"
+}
+```
+
+Response (`200`):
+
+```json
+{
+  "token": "<bearer secret>",
+  "email": "user@example.com",
+  "expiresInSec": 1800
+}
+```
+
+Subsequent share endpoints use `Authorization: Bearer <token>`.
+
+`authMethods` MAY list additional schemes later (`PhoneOtp`, etc.). Wallets MUST skip services whose methods they do not implement.
+
+When `requiresPasswordWithOtp` is `true`, the service MAY require an additional `password` / `recoveryPin` field on `/share/retrieve` (and optionally enroll). The precise field name SHOULD be documented by the operator; wallets that cannot satisfy the policy MUST not enroll that service.
+
+#### Share endpoints
+
+All share endpoints require a valid bearer session. Bodies use:
+
+```json
+{
+  "userIdHash": "<64 hex>",
+  "share": "<BRC-140 backup string>"
+}
+```
+
+(`share` only on enroll / rotate.)
+
+##### `POST /share/enroll`
+
+Store exactly one share for `userIdHash`.
+
+* MUST validate `share` as BRC-140 backup serialization (`x.y.threshold.integrity`).
+* MUST overwrite or reject-duplicate per operator policy; wallets SHOULD treat a second enroll for the same `userIdHash` as rotate-equivalent and prefer `/share/rotate` when implemented.
+* MUST fail with `403` when lifecycle forbids enroll (`sunset` / `retired` / past `retireAt`).
+
+Response (`200`):
+
+```json
+{ "ok": true, "userIdHash": "<64 hex>", "enrolledAt": "<RFC 3339>" }
+```
+
+##### `POST /share/retrieve`
+
+Request: `{ "userIdHash" }`. Response (`200`):
+
+```json
+{ "share": "<BRC-140 backup string>", "enrolledAt": "<RFC 3339>" }
+```
+
+* MUST NOT return a share without successful auth under the service’s published policy.
+* MUST fail when lifecycle is `retired` or past `retireAt`.
+* MUST `404` when no share is stored.
+
+##### `POST /share/rotate` (SHOULD)
+
+Replace the stored share for `userIdHash` with a new BRC-140 string after auth. Same validation as enroll. Used after recovery or when migrating providers.
+
+##### `POST /share/delete`
+
+Request: `{ "userIdHash" }`. Deletes any stored share. Response `{ "ok": true }` even if none existed (idempotent).
+
+### Wallet requirements
+
+1. **Pluggable list** — durable prefs of backup-service base URLs; empty list MUST be valid.
+2. **No spend dependency** — send / BRC-100 connect MUST work with zero services.
+3. **One share per URL** — never deposit two shares from the same split to one origin.
+4. **Local reconstruct** — combine shares only on device; then re-wrap into the wallet’s normal vault.
+5. **Offline first** — BRC-140 user-held shares and/or BRC-75 remain available without services.
+6. **Lifecycle UX** — surface sunset warnings and offer rotate while retrieve still works.
+7. **Honest copy** — enrollment UI MUST NOT claim a service can move funds or that HandCash (or any single vendor) is required to recover.
+
+### Security considerations
+
+| Risk | Mitigation |
+|------|------------|
+| Single service compromised | Threshold ≥ 2; one share insufficient |
+| Two services collude after user auth (2-of-3 service-majority) | Accepted tradeoff of opt-in convenience path; disclose at enroll; prefer hybrid (user-held + services) when possible |
+| OTP / inbox takeover | Prefer `requiresPasswordWithOtp: true` for high-value operators; rate-limit auth; short-lived bearer tokens |
+| Malicious `/info` or successor URL | Wallet SHOULD confirm successor with the user before auto-rotating |
+| Operator silent disappearance | Offline BRC-140 / BRC-75 remain the backstop; multi-provider enrollment reduces blast radius |
+| Service stores wrong share format | Reject non-BRC-140; integrity tag checked at reconstruct |
+
+A backup service that can authenticate a user and holds a share is a **sensitive** system: protect transport with TLS, minimize logs of share material, and encrypt shares at rest under an operator key that is not the user’s root key.
+
+## Implementations
+
+1. **HandCash Desktop** — Settings → Backup services (empty default list); enroll / restore against multiple URLs; BRC-140 split/reconstruct locally (`feat/backup-services`).
+2. **HandCash open backup-service** — runnable share-vault reference (`HANDCASH-DESKTOP/backup-service`): `/info`, email OTP (dev), enroll / retrieve / delete, lifecycle tooling, local 2-of-3 cluster smoke test.
+
+## References
+
+- <a name="footnote-1">1</a>: [BRC-140 — Threshold Key Sharing and Backup via Shamir's Secret Sharing Scheme](../key-derivation/0140.md)
+- <a name="footnote-2">2</a>: [BRC-100 — Unified Wallet-to-Application Interface](./0100.md)
+- <a name="footnote-3">3</a>: HandCash Desktop backup services proposal and reference server — https://github.com/HandCash/HANDCASH-DESKTOP (branch `feat/backup-services`)

--- a/wallet/0232.md
+++ b/wallet/0232.md
@@ -4,23 +4,15 @@ Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
 ## Abstract
 
-This BRC defines an interoperable **backup service** profile: an independent HTTP provider that stores **at most one** [BRC-140](../key-derivation/0140.md) recovery share per user and releases it only after the user authenticates. Wallets maintain a **list** of backup-service URLs (not a single hardcoded vendor), deposit distinct shares across providers under a threshold scheme (for example 2-of-3), and recover by authenticating to enough enrolled services.
+This BRC defines an HTTP **backup service** profile for optional recovery of [BRC-140](../key-derivation/0140.md) key shares. A backup service stores **at most one** BRC-140 share per `userIdHash` and releases it only after authentication. Wallets may enroll a **list** of independent service URLs, deposit distinct shares across them under a threshold scheme, and reconstruct the key locally after obtaining enough shares.
 
-A backup service is a **disaster-recovery aid**. It MUST NOT be required for day-to-day spend, connect, or [BRC-100](./0100.md) wallet use. It is not a threshold-signature co-signer and MUST NOT receive the root private key or enough shares to meet the wallet’s recovery threshold by itself.
+A backup service MUST NOT be required for ordinary wallet operation under [BRC-100](./0100.md). It MUST NOT receive the root private key, and a conforming wallet MUST NOT send enough shares to any single service to meet the wallet’s recovery threshold.
 
 ## Motivation
 
-[BRC-140](../key-derivation/0140.md) solves key sharding for offline backup: split a secp256k1 private key into shares so a threshold can reconstruct it. Users still face a practical gap — many lose the only device and never finish offline share placement (paper, password manager, second device).
+[BRC-140](../key-derivation/0140.md) specifies threshold key sharing and the canonical share serialization. It does not define how optional network providers store and release those shares. Without a shared service profile, wallets invent incompatible recovery APIs and users concentrate recovery on a single operator.
 
-Vendor-specific “trustholder” or wallet-authentication backends historically filled that gap by holding a share (or worse, remaining in the spend path). A single hardcoded recovery vendor recreates custody concentration and shutdown risk: if that vendor disappears, enrolled users who relied on it alone are stranded.
-
-This profile decentralizes that role:
-
-1. **Any** operator may run a conforming backup service.
-2. Wallets treat providers as a **replaceable URL list**.
-3. Cryptography stays [BRC-140](../key-derivation/0140.md); this BRC only specifies the **service wire contract**, lifecycle signaling, and wallet enrollment rules that make multi-provider recovery interoperable.
-
-Recording the contract as a BRC gives independent wallets and operators a shared legitimacy target instead of each inventing a private recovery API.
+This BRC specifies a minimal, pluggable wire contract so any operator can run a share vault and any wallet can enroll multiple providers interchangeably. Cryptography remains BRC-140; this document covers discovery metadata, authentication for release, share endpoints, and operator lifecycle signaling.
 
 ## Specification
 
@@ -31,64 +23,60 @@ Recording the contract as a BRC gives independent wallets and operators a shared
 | **Backup service** | HTTP origin that stores ≤ 1 BRC-140 share per `userIdHash` and releases it after auth. |
 | **Wallet** | Client that splits/reconstructs keys per BRC-140 and speaks this profile. |
 | **Enrollment** | Successful deposit of exactly one share to one backup service for one `userIdHash`. |
-| **Recovery** | Fetching ≥ threshold distinct shares (from services and/or offline holdings) and reconstructing the key locally. |
-
-Preferred user-facing language is **backup service** / **recovery provider**. Implementations SHOULD avoid implying that a service can move funds or that any single vendor “recovers the account.”
+| **Recovery** | Obtaining ≥ threshold distinct shares and reconstructing the key in the wallet. |
 
 ### Relationship to other BRCs
 
 | Standard | Role |
 |----------|------|
-| [BRC-140](../key-derivation/0140.md) | Share math + `x.y.threshold.integrity` serialization (normative for `share` payloads) |
-| [BRC-75](../key-derivation/0075.md) | Complementary offline mnemonic path; out of scope here |
-| [BRC-38](../outpoints/0038.md) / [BRC-39](../outpoints/0039.md) / [BRC-40](../outpoints/0040.md) | Wallet *data* export/sync — not key sharding; out of scope |
-| [BRC-100](./0100.md) | Day-to-day app↔wallet interface; MUST remain usable with zero backup services configured |
+| [BRC-140](../key-derivation/0140.md) | Share math and `x.y.threshold.integrity` serialization (normative for `share` payloads) |
+| [BRC-75](../key-derivation/0075.md) | Offline mnemonic recovery; complementary and out of scope |
+| [BRC-38](../outpoints/0038.md) / [BRC-39](../outpoints/0039.md) / [BRC-40](../outpoints/0040.md) | Wallet *data* export/sync; out of scope |
+| [BRC-100](./0100.md) | App↔wallet interface; MUST remain usable with zero backup services configured |
 
 ### Non-goals
 
-* Threshold signatures / spend-time co-signing.
+* Threshold signatures or spend-time co-signing.
 * Requiring backup services for send, receive, or BRC-100 connect.
-* Mandating a global directory of providers (wallets MAY ship curated defaults; empty default is valid).
-* Synchronizing full UTXO / history state (remain BRC-38/39/40 or local).
-* Binding operators to a specific email ISP or KYC regime.
+* A global registry of providers.
+* Wallet UTXO / history synchronization.
+* Mandating a particular identity or KYC regime.
 
-### Cryptographic model (wallet)
+### Cryptographic model
 
-1. The wallet splits its **root private key** with BRC-140 (reference: `toBackupShares` / `fromBackupShares`).
-2. Default multi-service enrollment scheme: **threshold = 2**, **total = 3** (other schemes are allowed if clearly disclosed in wallet UX).
-3. The wallet deposits **at most one share per backup service**.
-4. Reconstruction ALWAYS happens inside the wallet after enough shares are obtained. Services MUST NEVER receive the reconstructed key.
+1. The wallet splits its root private key with BRC-140.
+2. The wallet deposits **at most one share per backup service**.
+3. Reconstruction happens only in the wallet after enough shares are obtained.
+4. Services MUST NEVER receive the reconstructed key.
 
-**Invariant (service):** a conforming backup service stores at most one share per `userIdHash` and MUST reject payloads that are not BRC-140 backup strings.
+**Invariant (service):** store at most one share per `userIdHash`; reject non-BRC-140 share strings.
 
-**Invariant (wallet):** a conforming wallet MUST NOT send the root private key, mnemonic, or ≥ threshold shares to any single backup service.
+**Invariant (wallet):** MUST NOT send the root private key, mnemonic, or ≥ threshold shares from one split to any single backup service.
 
-#### Opt-in service-majority recovery
-
-Wallets MAY offer an opt-in path where the user deposits three shares to three services under 2-of-3 and holds no offline share. That path trades offline independence for device-loss convenience: any two enrolled services that release shares after user auth can reconstruct. Wallets MUST disclose this tradeoff at enrollment. Offline BRC-140 / BRC-75 paths remain first-class and MUST remain available without any service.
+A common enrollment scheme is threshold 2 of 3 total shares. Other thresholds are permitted if the wallet and user agree on the scheme before deposit.
 
 ### User identity handle
 
 `userIdHash` is a **64-character lowercase hex** SHA-256 digest used as the storage key at each service.
 
-For email OTP auth, the normative binding is:
+For email OTP auth:
 
 ```
 userIdHash = hex( SHA-256( UTF-8( normalize(email) ) ) )
 normalize(email) = trim + lowercase
 ```
 
-Wallets and services MUST use the same normalization before hashing. Services MUST treat `userIdHash` as an opaque key and MUST NOT require the raw email on share endpoints (email appears only in auth start/verify as needed by the operator).
+Wallets and services MUST use the same normalization before hashing. Share endpoints identify the record by `userIdHash` only.
 
-Other auth methods MAY define their own preimage for `userIdHash` in a future revision; v1 documents the email binding above because it matches deployed practice.
+`userIdHash` is a stable lookup key, not an anonymity mechanism: an operator that learns the email during authentication can recompute the hash and associate it with the stored share. Other auth methods MAY define a different preimage in a future revision.
 
 ### HTTP profile
 
-Base URL is an HTTPS (or loopback HTTP for development) origin. Paths below are relative to that origin. JSON UTF-8 request/response bodies unless noted. Unknown JSON fields MUST be ignored by readers.
+Base URL is an HTTPS origin (loopback HTTP MAY be used for development). Paths are relative to that origin. JSON UTF-8 bodies. Unknown JSON fields MUST be ignored.
 
 #### `GET /info`
 
-Returns service metadata. No auth required.
+No auth required.
 
 ```json
 {
@@ -109,42 +97,33 @@ Returns service metadata. No auth required.
 
 | Field | Requirement | Meaning |
 |-------|-------------|---------|
-| `name` | MUST | Human-readable operator name |
-| `version` | SHOULD | Operator software version string |
-| `role` | SHOULD | Constant `backup-service` for discovery |
+| `name` | MUST | Operator display name |
+| `version` | SHOULD | Operator software version |
+| `role` | SHOULD | Constant `backup-service` |
 | `authMethods` | MUST | Non-empty array of auth method identifiers |
-| `requiresPasswordWithOtp` | SHOULD | If `true`, wallet SHOULD also collect a user password/PIN and send it on retrieve per operator policy (extension; see Auth) |
-| `lifecycle` | MUST | Operator lifecycle block (below) |
+| `requiresPasswordWithOtp` | SHOULD | If `true`, retrieve (and optionally enroll) requires an additional password/PIN field under the operator’s documented policy |
+| `lifecycle` | MUST | Operator lifecycle block |
 
-#### Lifecycle / shutdown signaling
-
-Operators MUST publish planned shutdown so wallets can urge rotation before shares become unreachable.
+#### Lifecycle
 
 | `lifecycle.status` | Meaning |
 |--------------------|---------|
-| `active` | Normal enroll + retrieve |
-| `sunset` | Still serving retrieve; MUST reject new enrolls (or wallet MUST treat enroll as forbidden) |
-| `retired` | Gone or past `retireAt`; retrieve MUST fail |
+| `active` | Enroll and retrieve allowed |
+| `sunset` | Retrieve allowed; new enrolls MUST be rejected |
+| `retired` | Retrieve MUST fail |
 
 | Field | Requirement | Meaning |
 |-------|-------------|---------|
-| `sunsetAt` | MAY | When sunset began / begins (RFC 3339 UTC) |
-| `retireAt` | SHOULD when sunsetting | Last moment retrieve is expected to work |
-| `message` | MAY | Human explanation |
-| `successorUrl` | MAY | Suggested replacement backup-service base URL |
+| `sunsetAt` | MAY | RFC 3339 UTC |
+| `retireAt` | SHOULD when sunsetting | Last expected retrieve time (RFC 3339 UTC) |
+| `message` | MAY | Operator explanation |
+| `successorUrl` | MAY | Suggested replacement base URL |
 
-**Wallet behavior**
+Wallets SHOULD refresh `/info` for enrolled URLs and stop new enrolls when status is not `active`. Operators SHOULD provide a sunset window before `retireAt`.
 
-1. Refresh `/info` for each enrolled URL periodically (on launch and at least daily while the wallet runs is sufficient).
-2. If `sunset` / `retired` / `retireAt` within 90 days: warn the user to rotate.
-3. **Rotate:** retrieve (while still possible) → enroll at a replacement URL → delete old enrollment when delete is available.
-4. Recommend operators advertise ≥ 90 days between `sunset` and `retireAt`. Absence of signaling does not remove the need for offline backup.
-
-#### Auth (email OTP v1)
+#### Auth (email OTP)
 
 ##### `POST /auth/start`
-
-Request:
 
 ```json
 { "email": "user@example.com" }
@@ -159,11 +138,9 @@ Response (`200`):
 }
 ```
 
-Operators MUST deliver a one-time code out of band (email). Development-only fields such as `devCode` MUST NOT appear in production deployments.
+The operator delivers a one-time code out of band. Production deployments MUST NOT return the code in the HTTP response.
 
 ##### `POST /auth/verify`
-
-Request:
 
 ```json
 {
@@ -182,15 +159,13 @@ Response (`200`):
 }
 ```
 
-Subsequent share endpoints use `Authorization: Bearer <token>`.
+Share endpoints use `Authorization: Bearer <token>`.
 
-`authMethods` MAY list additional schemes later (`PhoneOtp`, etc.). Wallets MUST skip services whose methods they do not implement.
-
-When `requiresPasswordWithOtp` is `true`, the service MAY require an additional `password` / `recoveryPin` field on `/share/retrieve` (and optionally enroll). The precise field name SHOULD be documented by the operator; wallets that cannot satisfy the policy MUST not enroll that service.
+Wallets MUST skip services whose `authMethods` they do not implement. When `requiresPasswordWithOtp` is `true`, the service MAY require an additional password/PIN on share operations as documented by the operator.
 
 #### Share endpoints
 
-All share endpoints require a valid bearer session. Bodies use:
+All share endpoints require a valid bearer session.
 
 ```json
 {
@@ -199,15 +174,13 @@ All share endpoints require a valid bearer session. Bodies use:
 }
 ```
 
-(`share` only on enroll / rotate.)
+(`share` only where noted.)
 
 ##### `POST /share/enroll`
 
-Store exactly one share for `userIdHash`.
-
-* MUST validate `share` as BRC-140 backup serialization (`x.y.threshold.integrity`).
-* MUST overwrite or reject-duplicate per operator policy; wallets SHOULD treat a second enroll for the same `userIdHash` as rotate-equivalent and prefer `/share/rotate` when implemented.
-* MUST fail with `403` when lifecycle forbids enroll (`sunset` / `retired` / past `retireAt`).
+* MUST validate `share` as BRC-140 backup serialization.
+* MUST fail with `403` when lifecycle forbids enroll.
+* Stores exactly one share for `userIdHash` (overwrite policy is operator-defined; `/share/rotate` SHOULD be preferred for explicit replacement).
 
 Response (`200`):
 
@@ -217,54 +190,54 @@ Response (`200`):
 
 ##### `POST /share/retrieve`
 
-Request: `{ "userIdHash" }`. Response (`200`):
+Request: `{ "userIdHash" }`.
+
+Response (`200`):
 
 ```json
 { "share": "<BRC-140 backup string>", "enrolledAt": "<RFC 3339>" }
 ```
 
-* MUST NOT return a share without successful auth under the service’s published policy.
+* MUST NOT return a share without successful auth under the service’s policy.
 * MUST fail when lifecycle is `retired` or past `retireAt`.
 * MUST `404` when no share is stored.
 
 ##### `POST /share/rotate` (SHOULD)
 
-Replace the stored share for `userIdHash` with a new BRC-140 string after auth. Same validation as enroll. Used after recovery or when migrating providers.
+Replace the stored share after auth. Same validation as enroll.
 
 ##### `POST /share/delete`
 
-Request: `{ "userIdHash" }`. Deletes any stored share. Response `{ "ok": true }` even if none existed (idempotent).
+Request: `{ "userIdHash" }`. Idempotent; response `{ "ok": true }`.
 
 ### Wallet requirements
 
-1. **Pluggable list** — durable prefs of backup-service base URLs; empty list MUST be valid.
-2. **No spend dependency** — send / BRC-100 connect MUST work with zero services.
-3. **One share per URL** — never deposit two shares from the same split to one origin.
-4. **Local reconstruct** — combine shares only on device; then re-wrap into the wallet’s normal vault.
-5. **Offline first** — BRC-140 user-held shares and/or BRC-75 remain available without services.
-6. **Lifecycle UX** — surface sunset warnings and offer rotate while retrieve still works.
-7. **Honest copy** — enrollment UI MUST NOT claim a service can move funds or that HandCash (or any single vendor) is required to recover.
+1. Support a list of backup-service base URLs; an empty list MUST be valid.
+2. Ordinary spend / BRC-100 use MUST NOT depend on any backup service.
+3. Deposit at most one share from a given split to a given service origin.
+4. Reconstruct only locally.
+5. Keep offline BRC-140 and/or BRC-75 recovery available without services.
 
 ### Security considerations
 
 | Risk | Mitigation |
 |------|------------|
 | Single service compromised | Threshold ≥ 2; one share insufficient |
-| Two services collude after user auth (2-of-3 service-majority) | Accepted tradeoff of opt-in convenience path; disclose at enroll; prefer hybrid (user-held + services) when possible |
-| OTP / inbox takeover | Prefer `requiresPasswordWithOtp: true` for high-value operators; rate-limit auth; short-lived bearer tokens |
-| Malicious `/info` or successor URL | Wallet SHOULD confirm successor with the user before auto-rotating |
-| Operator silent disappearance | Offline BRC-140 / BRC-75 remain the backstop; multi-provider enrollment reduces blast radius |
-| Service stores wrong share format | Reject non-BRC-140; integrity tag checked at reconstruct |
+| Colluding services | Threshold and enrollment topology determine exposure; wallets MUST NOT send ≥ threshold shares to one party |
+| OTP / inbox takeover | Short-lived tokens; optional `requiresPasswordWithOtp`; auth rate limiting |
+| Email↔share linkage | Operator that authenticates the email can link it to `userIdHash` and the share; treat operators as share custodians for that record |
+| Operator disappearance | Multi-provider enrollment and offline BRC-140 / BRC-75 |
+| Malformed shares | Reject non-BRC-140; verify integrity at reconstruct |
 
-A backup service that can authenticate a user and holds a share is a **sensitive** system: protect transport with TLS, minimize logs of share material, and encrypt shares at rest under an operator key that is not the user’s root key.
+Protect share transport with TLS. Minimize logging of share material. Encrypt shares at rest under an operator key that is not the user’s root key.
 
 ## Implementations
 
-1. **HandCash Desktop** — Settings → Backup services (empty default list); enroll / restore against multiple URLs; BRC-140 split/reconstruct locally (`feat/backup-services`).
-2. **HandCash open backup-service** — runnable share-vault reference (`HANDCASH-DESKTOP/backup-service`): `/info`, email OTP (dev), enroll / retrieve / delete, lifecycle tooling, local 2-of-3 cluster smoke test.
+1. HandCash Desktop — multi-URL backup-service client and local BRC-140 split/reconstruct (`feat/backup-services`).
+2. HandCash `backup-service` — reference share vault implementing this profile.
 
 ## References
 
 - <a name="footnote-1">1</a>: [BRC-140 — Threshold Key Sharing and Backup via Shamir's Secret Sharing Scheme](../key-derivation/0140.md)
 - <a name="footnote-2">2</a>: [BRC-100 — Unified Wallet-to-Application Interface](./0100.md)
-- <a name="footnote-3">3</a>: HandCash Desktop backup services proposal and reference server — https://github.com/HandCash/HANDCASH-DESKTOP (branch `feat/backup-services`)
+- <a name="footnote-3">3</a>: https://github.com/HandCash/HANDCASH-DESKTOP (branch `feat/backup-services`)

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -36,3 +36,4 @@ BRC | Standard
 116  | [Wallet Permissions and Counterparty Trust](./0116.md)
 123  | [Basket Permission Scheme Registry and Governance](./0123.md)
 219  | [Wallet Permission Prompt Liveness Contract](./0219.md)
+232  | [Pluggable Backup Services for BRC-140 Share Vaults](./0232.md)


### PR DESCRIPTION
## Summary

Adds **BRC-232 — Pluggable Backup Services for BRC-140 Share Vaults**.

Defines a provider-neutral HTTP profile for optional multi-provider recovery of BRC-140 shares:

- At most one BRC-140 share per authenticated account per service
- Capability-negotiated authentication (redirect/Connect-style, passkey, challenge, OTP, or other advertised profiles)
- Authentication sessions bind share operations to a provider-local account; callers cannot select records by email or account hash
- Wallets enroll a list of service URLs; an empty list remains valid
- Operator lifecycle: `active` → `sunset` → `retired`
- Not required for BRC-100 use and not a spend-time co-signer

## Security boundaries

- Authentication must remain recoverable without the BRC-140-protected root key; a key derived solely from that root cannot be the only release factor
- Providers can associate an authenticated account with its stored share; this profile does not claim provider anonymity
- Share payloads use BRC-140 `x.y.threshold.integrity`

## Compatibility

- Does not mandate an identity provider or authentication factor
- Does not redefine Shamir math, threshold signatures, or BRC-38/39/40
- Proposed number **232** — renumber to the lowest free number on merge if needed

## Prototype

https://github.com/HandCash/HANDCASH-DESKTOP (`feat/backup-services`)

The current prototype predates the generalized authentication envelope and is identified as such in the draft.

## Test plan

- [ ] Review against BRC-140 / BRC-100
- [ ] Review authentication recovery-circularity constraint
- [ ] Confirm number free or reassign
- [ ] Index rows in `README.md`, `SUMMARY.md`, `wallet/README.md`