### PR TITLE
Add BRC-153: Action References for BRC-100 Wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ BRC | Standard
 150  | [1Sat Provenance Remittance for Basket `1sat`](./tokens/0150.md)
 151  | [BRC-100 Risk Assessment and Best Integration Practices](./opinions/0151.md)
 152  | [Best Practices for Regulated Tokens in a BRC-100 Ecosystem](./opinions/0152.md)
+153  | [Action References for BRC-100 Wallets](./wallet/0153.md)
 169  | [Universal Handle Addressing and Resolution for the Metanet](./peer-to-peer/0169.md)
 218  | [Chat-Native Command Grammar for the Metanet](./apps/0218.md)
 219  | [Wallet Permission Prompt Liveness Contract](./wallet/0219.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -45,6 +45,7 @@
 * [Time Labels: Backwards-Compatible Action Timestamp Filters for List Actions](./wallet/0114.md)
 * [Wallet Permissions and Counterparty Trust](./wallet/0116.md)
 * [Basket Permission Scheme Registry and Governance](./wallet/0123.md)
+* [Action References for BRC-100 Wallets](./wallet/0153.md)
 * [Wallet Permission Prompt Liveness Contract](./wallet/0219.md)
 
 ## Transactions

--- a/wallet/0153.md
+++ b/wallet/0153.md
@@ -1,0 +1,115 @@
+# BRC-153: Action References for BRC-100 Wallets
+
+David Case
+
+## Abstract
+
+This specification defines a backwards-compatible extension to [BRC-100](./0100.md) that allows the caller to optionally supply the action `reference` on `createAction` and `internalizeAction`, requires `reference` on action records from `listActions`, and adds a `getAction` method for single-item lookup by reference.
+
+## Motivation
+
+Under [BRC-100](./0100.md), `createAction` may return `signableTransaction.reference`. That value is required for subsequent `signAction` and `abortAction` calls. The interface does not include `reference` on action records returned from `listActions`, and it does not define a way to fetch one action by `reference`.
+
+If an application loses the reference after a successful `createAction`—for example because of process failure, lost in-memory scope, or a delayed multi-step signing flow—there is no interoperable way to resume or abort the in-flight action through the public wallet interface.
+
+Application-level correlators (labels or output tags) can aid discovery of completed or basket-tracked outputs, but they do not substitute for the wallet’s action reference: tags are not the key used by `signAction` and `abortAction`, and they do not make the wallet reference itself recoverable through the standard interface.
+
+`internalizeAction` also creates wallet-tracked action state. The same optional caller-supplied reference rules apply.
+
+## Specification
+
+This BRC extends the [BRC-100](./0100.md) wallet interface. Unless stated otherwise, types, permission behavior, and error structure are those of BRC-100.
+
+### Action reference
+
+- The canonical field name is `reference`, consistent with `signableTransaction.reference`, `signAction`, and `abortAction` in BRC-100.
+- Values use the BRC-100 `Base64String` type.
+- `createAction` accepts an optional `reference` on the request. If omitted, the wallet generates a unique `reference`.
+- `internalizeAction` accepts an optional `reference` on the request under the same rules.
+- For a given wallet user, `reference` values must be unique across action records. If the caller supplies a `reference` that already exists, the wallet must return an error.
+- The `reference` remains stable for the life of the action record across all action statuses exposed by the wallet (including `unsigned`, `nosend`, `sending`, `unproven`, `completed`, and `failed`).
+
+### createAction
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `reference` | no | Caller-supplied action reference (`Base64String`). If omitted, the wallet generates one. |
+
+When the result includes `signableTransaction`, `signableTransaction.reference` is the assigned action reference (caller-supplied or wallet-generated).
+
+### internalizeAction
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `reference` | no | Caller-supplied action reference (`Base64String`). If omitted, the wallet generates one. |
+
+### listActions
+
+Each action record must include `reference`.
+
+### getAction
+
+`getAction` fetches a single action by `reference`.
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `reference` | yes | Action reference (`Base64String`) |
+| `includeLabels` | no | Same meaning as `listActions` |
+| `includeInputs` | no | Same meaning as `listActions` |
+| `includeInputSourceLockingScripts` | no | Same meaning as `listActions` |
+| `includeInputUnlockingScripts` | no | Same meaning as `listActions` |
+| `includeOutputs` | no | Same meaning as `listActions` |
+| `includeOutputLockingScripts` | no | Same meaning as `listActions` |
+| `seekPermission` | no | Same meaning as `listActions` |
+
+The successful result is a single action object with the same shape as an element of `listActions.actions`.
+
+If no action exists for `reference`, or the action is not visible under ordinary permission rules, the wallet must return an error.
+
+### Required behavior
+
+- `getAction` must enforce the same originator and permission checks that apply when inspecting the corresponding record via `listActions`.
+- Supplying `reference` on `createAction` or `internalizeAction` must not bypass basket, protocol, or other authorization checks.
+- A second `createAction` or `internalizeAction` that supplies a `reference` already used by an existing action for the user must fail. Wallets must not overwrite the existing action.
+
+### Errors
+
+Errors use the uniform structure defined in [BRC-100](./0100.md):
+
+- `status` — always `"error"`
+- `code` — a short machine-readable string
+- `description` — a human-readable explanation
+- `context` — optional additional data
+
+As in BRC-100, wallets may choose their own `code` naming conventions provided `description` clearly identifies the failure. Illustrative examples:
+
+```json
+{
+  "status": "error",
+  "code": "ERR_DUPLICATE_REFERENCE",
+  "description": "An action with the supplied reference already exists."
+}
+```
+
+```json
+{
+  "status": "error",
+  "code": "ERR_ACTION_NOT_FOUND",
+  "description": "No action was found for the supplied reference."
+}
+```
+
+### Validation rules
+
+- Optional request `reference` values must be valid `Base64String` values under BRC-100.
+- Wallet-generated `reference` values must be valid `Base64String` values and must not collide with existing action references for the user.
+
+## Conclusion
+
+By making action `reference` optionally caller-supplied, unique, present on action records, and fetchable via `getAction`, this specification closes the recovery gap for in-flight BRC-100 actions.
+
+## References
+
+- [BRC-100](./0100.md) — Unified wallet-to-application interface
+- [BRC-65](./0065.md) — Transaction labels and list actions
+- [BRC-116](./0116.md) — Wallet permissions and counterparty trust

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -35,4 +35,5 @@ BRC | Standard
 114  | [Time Labels: Backwards-Compatible Action Timestamp Filters for List Actions](./0114.md)
 116  | [Wallet Permissions and Counterparty Trust](./0116.md)
 123  | [Basket Permission Scheme Registry and Governance](./0123.md)
+153  | [Action References for BRC-100 Wallets](./0153.md)
 219  | [Wallet Permission Prompt Liveness Contract](./0219.md)


### PR DESCRIPTION
## BRC-153: Action References for BRC-100 Wallets

Extends BRC-100 so in-flight actions remain recoverable by `reference`.

### Changes

- Optional `reference` on `createAction` and `internalizeAction` requests (wallet generates if omitted)
- Uniqueness of `reference` per wallet user
- `reference` included on each `listActions` action record
- New `getAction` method to fetch a single action by `reference`

### Why

`signAction` and `abortAction` require the `reference` returned on `signableTransaction`. If the application loses that value, BRC-100 provides no way to look the action up again. Labels and output tags are not a substitute for the wallet action reference.

Candidate number 153 (first free slot). Fine to renumber if needed.