### PR TITLE
Brc 153 latched 1sat

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ BRC | Standard
 150  | [1Sat Provenance Remittance for Basket `1sat`](./tokens/0150.md)
 151  | [BRC-100 Risk Assessment and Best Integration Practices](./opinions/0151.md)
 152  | [Best Practices for Regulated Tokens in a BRC-100 Ecosystem](./opinions/0152.md)
+153  | [Latched 1Sat Provenance for Basket `1sat`](./tokens/0153.md)
 169  | [Universal Handle Addressing and Resolution for the Metanet](./peer-to-peer/0169.md)
 218  | [Chat-Native Command Grammar for the Metanet](./apps/0218.md)
 219  | [Wallet Permission Prompt Liveness Contract](./wallet/0219.md)

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ BRC | Standard
 225  | [Animated-QR Air-Gap Transport for Arbitrary Payloads (TKQR1)](./peer-to-peer/0225.md)
 226  | [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)
 227  | [Frictionless On-Chain Onboarding via Pre-Funded Claimable Tokens](./apps/0227.md)
+232  | [Pluggable Backup Services for BRC-140 Share Vaults](./wallet/0232.md)
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -46,6 +46,7 @@
 * [Wallet Permissions and Counterparty Trust](./wallet/0116.md)
 * [Basket Permission Scheme Registry and Governance](./wallet/0123.md)
 * [Wallet Permission Prompt Liveness Contract](./wallet/0219.md)
+* [Pluggable Backup Services for BRC-140 Share Vaults](./wallet/0232.md)
 
 ## Transactions
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -112,6 +112,7 @@
 * [Proof-of-Indexing Hash-to-Mint Tokens](./tokens/0117.md)
 * [1Sat Ordinals Basket Profile for BRC-46 / BRC-100](./tokens/0147.md)
 * [1Sat Provenance Remittance for Basket `1sat`](./tokens/0150.md)
+* [Latched 1Sat Provenance for Basket `1sat`](./tokens/0153.md)
 * [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)
 
 ## Overlays

--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -79,7 +79,7 @@ When present for basket `1sat`, `customInstructions` MUST be a **UTF-8 JSON obje
 | `origin` | string | SHOULD | Claimed origin outpoint (underscore form preferred). |
 | `name` | string | MAY | Display name. |
 | `app` | string | MAY | Creator / application id. |
-| `provenance` | object | SHOULD on transfer when available | Provenance remittance; schema and verification rules are defined only in [BRC-150](./0150.md). |
+| `provenance` | object | SHOULD on transfer when available | Provenance remittance; v2 in [BRC-150](./0150.md), optional v3 latched profile in [BRC-153](./0153.md). |
 
 Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers that do not understand `provenance` MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)).
 
@@ -87,7 +87,7 @@ Additional JSON keys are permitted and MUST be ignored by readers that do not un
 
 * `origin`, `name`, `app`, and all tags are **claims**.
 * A wallet MUST NOT treat a claimed `origin` as proven solely because it appears in tags or `customInstructions`.
-* Proven tip→origin binding is defined by [BRC-150](./0150.md). When that remittance is absent or fails verification, the wallet MUST treat identity as **unproven** and SHOULD avoid presenting sender-supplied `name` / `app` as authoritative for that tip.
+* Proven tip→origin binding is defined by [BRC-150](./0150.md) (v2) and optionally [BRC-153](./0153.md) (v3 latched). When remittance is absent or fails verification, the wallet MUST treat identity as **unproven** and SHOULD avoid presenting sender-supplied `name` / `app` as authoritative for that tip.
 
 ### Hold and list
 
@@ -194,3 +194,4 @@ Normative fine-grained asset permission schemes remain [BRC-99](../wallet/0099.m
 7. [BRC-99](../wallet/0099.md) — P Baskets (reserved permission schemes)
 8. [BRC-100](../wallet/0100.md) — Unified Open BSV Wallet-to-Application Interface
 9. [BRC-150](./0150.md) — 1Sat Provenance Remittance for Basket `1sat`
+10. [BRC-153](./0153.md) — Latched 1Sat Provenance for Basket `1sat` (draft)

--- a/tokens/0150.md
+++ b/tokens/0150.md
@@ -108,6 +108,7 @@ On success, the receiver MAY treat `provenance.origin` as the proven origin for 
 * This BRC does not alter BRC-62/95 encodings; it only constrains how they are used inside `customInstructions.provenance`.
 * Deep histories may produce large remittances. Implementations SHOULD prefer AtomicBEEF and MAY refuse to embed packages above an implementation-defined size, falling back to “unproven” rather than truncated proofs.
 * Partial BEEF (structurally valid but missing a path transaction) MUST fail verification.
+* [BRC-153](./0153.md) defines an optional **latched** profile (v3 provenance, O(1) verify) for wallets that adopt Commit/Settle transfers; v2 remains valid for legacy tips.
 
 ## Security considerations
 
@@ -125,11 +126,12 @@ On success, the receiver MAY treat `provenance.origin` as the proven origin for 
 ## References
 
 1. [BRC-147](./0147.md) — 1Sat Ordinals Basket Profile for BRC-46 / BRC-100
-2. 1Sat Ordinals protocol — <https://docs.1satordinals.com>
-3. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions Extension for Bitcoin Outpoints
-4. [BRC-46](../wallet/0046.md) — Wallet Transaction Output Tracking (Output Baskets)
-5. [BRC-62](../transactions/0062.md) — Background Evaluation Extended Format (BEEF) Transactions
-6. [BRC-67](../transactions/0067.md) — Simplified Payment Verification
-7. [BRC-95](../transactions/0095.md) — Atomic BEEF Transactions
-8. [BRC-96](../transactions/0096.md) — BEEF V2 Txid Only Extension
-9. [BRC-100](../wallet/0100.md) — Unified Open BSV Wallet-to-Application Interface
+2. [BRC-153](./0153.md) — Latched 1Sat Provenance for Basket `1sat` (draft)
+3. 1Sat Ordinals protocol — <https://docs.1satordinals.com>
+4. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions Extension for Bitcoin Outpoints
+5. [BRC-46](../wallet/0046.md) — Wallet Transaction Output Tracking (Output Baskets)
+6. [BRC-62](../transactions/0062.md) — Background Evaluation Extended Format (BEEF) Transactions
+7. [BRC-67](../transactions/0067.md) — Simplified Payment Verification
+8. [BRC-95](../transactions/0095.md) — Atomic BEEF Transactions
+9. [BRC-96](../transactions/0096.md) — BEEF V2 Txid Only Extension
+10. [BRC-100](../wallet/0100.md) — Unified Open BSV Wallet-to-Application Interface

--- a/tokens/0153.md
+++ b/tokens/0153.md
@@ -258,21 +258,20 @@ Phased rollout recommended for HandCash and other BRC-100 wallets:
 * Freeze terminology, v3 JSON, basket split, verify rules.
 * Publish reference script template draft (separate appendix or BRC-153a).
 
-### Phase 1 — Read-only verification ✅
+### Phase 1 — Soft-latch verify + send ✅
 
-* `oneSatLatch.ts`: `parseProvenanceV3`, `verifyProvenanceV3`, `buildProvenanceV3`, latch tags.
+* `oneSatLatch.ts`: `parseProvenanceV3`, `verifyProvenanceV3`, `buildProvenanceV3` / `buildSoftLatchProvenanceV3`, latch tags, relative `OUTPUT:N` remittance.
 * `oneSatProvenance.verifyProvenance` prefers v3 then v2.
 * Collectables listing uses unified verify.
-* Commit/Settle sends: `isLatchedSendEnabled()` returns `false` until script template lands.
+* Soft-latch sends: tip + latch P2PKH in one settle-style `createAction`; prior latch co-spent when present; `isLatchedSendEnabled()` returns `true`.
 
 ### Phase 2 — Bootstrap
 
-* Wallet can genesis-latch from v2-verified legacy tips (local only / testnet).
+* Genesis latch from legacy tips is automatic on first latched send (`parentLatch` = genesis sentinel).
 
-### Phase 3 — Latched send
+### Phase 3 — Hardened Commit + Settle (optional)
 
-* `createAction` Commit+Settle pair; coordinator serializes with spend guard.
-* v3 remittance on collectable send; fallback to v2.
+* BOLT-style covenant script templates + two-tx Commit/Settle pair when on-chain induction is required.
 
 ### Phase 4 — Interop
 
@@ -285,7 +284,7 @@ Phased rollout recommended for HandCash and other BRC-100 wallets:
 
 ## Implementations
 
-* **HandCash Desktop** (reference, phase 1): `oneSatLatch.ts`, `oneSatProvenance.verifyProvenance`, `collectables.ts`.  
+* **HandCash Desktop** (reference, soft-latch live): `oneSatLatch.ts`, `oneSatProvenance.verifyProvenance`, `collectables.sendCollectable`.  
   Spec: `docs/bsva/brcs/tokens/0153.md`.
 * **Reference — BOLT:** [boltassociation.com](https://boltassociation.com/), [BetaBOLT](https://github.com/bsvhackathon/BetaBOLT) (script patterns only; not 1Sat-specific).
 

--- a/tokens/0153.md
+++ b/tokens/0153.md
@@ -283,9 +283,13 @@ Phased rollout recommended for HandCash and other BRC-100 wallets:
 * `oneSatProvenance.verifyProvenance` prefers v3 then v2.
 * Collectables listing uses unified verify and deduplicates by origin.
 
-### Phase 1a — Soft-latch sends ✅
+### Phase 1a — Soft-latch companion + v2 authenticity ✅
 
-Soft-latch sends are live: tip (1 sat) + latch (**exactly 2** sats, P2PKH) in one settle-style `createAction`; prior latch co-spent when present; v3 remittance with relative `OUTPUT:N` tip/latch refs. `isLatchedSendEnabled()` returns `true`. Receivers classify `satoshis === 2` as latch dust (never tip, never funding).
+HandCash ships tip (1 sat) + latch (**exactly 2** sats, P2PKH) in one settle-style `createAction`, co-spending the prior latch when present. Receivers classify `satoshis === 2` as latch dust (never tip, never funding).
+
+**Authenticity remains [BRC-150](./0150.md) v2** (full tip→origin BEEF remittance on the tip). Soft-latch P2PKH does **not** carry inductive latch state in the locking script, so structural v3 remittance alone MUST NOT be treated as proven origin binding. O(1) authenticity without a growing BEEF is Phase 3 (hardened Commit/Settle + on-chain induction).
+
+`isLatchedSendEnabled()` returns `true` for the companion latch UTXO; senders still attach v2 remittance when they can build it.
 
 ### Phase 2 — Bootstrap
 
@@ -306,7 +310,7 @@ Soft-latch sends are live: tip (1 sat) + latch (**exactly 2** sats, P2PKH) in on
 
 ## Implementations
 
-* **HandCash Desktop** (reference, soft-latch live — 2-sat P2PKH latch): `oneSatLatch.ts`, `oneSatProvenance.verifyProvenance`, `collectables.sendCollectable`.  
+* **HandCash Desktop** (reference — soft-latch companion UTXO + BRC-150 v2 authenticity; O(1) v3 induction pending Phase 3): `oneSatLatch.ts`, `oneSatProvenance.verifyProvenance`, `collectables.sendCollectable`.  
   Spec: `docs/bsva/brcs/tokens/0153.md`.
 * **Reference — BOLT:** [boltassociation.com](https://boltassociation.com/), [BetaBOLT](https://github.com/bsvhackathon/BetaBOLT) (script patterns only; not 1Sat-specific).
 

--- a/tokens/0153.md
+++ b/tokens/0153.md
@@ -1,0 +1,302 @@
+# BRC-153: Latched 1Sat Provenance for Basket `1sat`
+
+Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
+
+**Status:** Draft — Phase 1 reference implementation in HandCash Desktop
+
+## Abstract
+
+This BRC defines an **optional latched transfer profile** for 1Sat Ordinals tips held in basket `1sat` ([BRC-147](./0147.md)). It applies the *transaction latching* philosophy of the [BOLT](https://boltassociation.com/) protocol — constant-time legitimacy from a **small, fixed set of live UTXOs** — to the 1Sat ownership chain **without** replacing 1Sat origin theory or inscription content rules.
+
+Each latched transfer uses a **Commit** transaction (creates a proof latch UTXO) and a **Settle** transaction (spends tip + latch together to deliver the tip to the recipient). Receivers verify tip→origin binding in **O(1)** from the current tip, its paired proof output, and one hop of latch state. Full ancestry replay ([BRC-150](./0150.md) v2 BEEF path) is required only when **bootstrapping** from legacy unlatched tips or at **genesis**.
+
+This BRC complements [BRC-150](./0150.md); it does not obsolete v2 remittance for wallets that have not adopted latching.
+
+## Motivation
+
+### Back-To-Genesis on 1Sat today
+
+[BRC-150](./0150.md) v2 proves that a 1-sat *tip* belongs to a 1Sat *origin* by embedding an ordered `path` and a BEEF/AtomicBEEF package in `customInstructions.provenance`. Verification is offline and indexer-independent, which addresses tag spoofing ([BRC-147](./0147.md)).
+
+However, v2 remittance size grows with **transfer depth**:
+
+* Each hop may add transactions to `path` and `beefB64`.
+* Deep collectable histories exceed practical remittance budgets; conforming implementations omit proof rather than truncate ([BRC-150](./0150.md) security considerations).
+* Verification work is **O(N)** in path length for every receive.
+
+The [BOLT protocol](https://boltassociation.com/) (Honohan, 2024) shows that UTXO token legitimacy can be proven at Layer 1 by **mathematical induction**: each spend carries enough state to validate against a **paired proof UTXO**, so only **two unspent outputs** are needed to verify regardless of history length.
+
+### Design goal
+
+Apply BOLT’s *philosophy* (latch + inductive ancestry, O(1) verify, no legitimacy database) to **1Sat NF tips** while preserving:
+
+* 1Sat **origin** = first valid `ord` envelope on the sat ([1Sat Ordinals](https://docs.1satordinals.com)).
+* [BRC-147](./0147.md) basket profile, tags, and BRC-100 transfer flows.
+* [BRC-150](./0150.md) v2 as the **legacy bootstrap** and interoperability fallback.
+
+Out of scope for this BRC: fungible token balances (BSV-20/21), OrdLock marketplace script templates, BOLT EventListener automation (reserved for a future companion BRC), and redefinition of minting APIs.
+
+## Terminology
+
+| Term | Meaning |
+|------|---------|
+| **Tip** | Current 1-sat UTXO representing inscription ownership in the tip→origin chain. |
+| **Origin** | First 1-sat outpoint in the chain whose locking script contains the valid first `ord` envelope (1Sat rule). |
+| **Latch** | A proof UTXO whose unlocking is interdependent with a specific tip UTXO (BOLT-style bolt). |
+| **Commit tx** | Transaction that creates or renews a latch UTXO while the tip remains with the sender. |
+| **Settle tx** | Transaction that spends tip + latch together and creates the recipient’s tip + next latch. |
+| **Legacy tip** | A tip with no active latch UTXO on chain; proven only via [BRC-150](./0150.md) v2 or unproven. |
+| **Latched tip** | A tip accompanied by an unspent latch UTXO conforming to this BRC. |
+
+## Specification
+
+### Scope
+
+This profile applies when:
+
+* The output is in basket `1sat` per [BRC-147](./0147.md).
+* The output value is exactly **1 satoshi**.
+* The sender and receiver wallets **advertise support** for latched transfers (see *Wallet capability*).
+
+When either party does not support latching, senders MUST fall back to [BRC-150](./0150.md) v2 or move the tip with unproven identity per [BRC-147](./0147.md).
+
+### Wallet capability
+
+Conforming wallets SHOULD expose latched-1sat support via BRC-100 application metadata or a documented capability flag (implementation-defined until a BRC-100 extension is registered). Wallets MUST NOT broadcast Commit/Settle pairs to counterparties that cannot receive latch outputs.
+
+### Companion basket `1sat-latch`
+
+Latch UTXOs are tracked in basket **`1sat-latch`** ([BRC-46](../wallet/0046.md)):
+
+| Basket | Holds | Eligibility |
+|--------|-------|-------------|
+| `1sat` | Tip (1 sat) | [BRC-147](./0147.md) |
+| `1sat-latch` | Proof latch | Created only by this BRC; value ≥ dust limit; satoshis MAY be > 1 |
+
+Wallets MUST NOT sweep latch outputs as spendable BSV change. Latch outputs MUST be spent only in Settle transactions defined below or when explicitly abandoning a legacy migration path.
+
+Tags on latch outputs:
+
+| Tag | Requirement | Meaning |
+|-----|-------------|---------|
+| `latch:1sat` | MUST | Marks output as a 1Sat proof latch under this BRC. |
+| `origin:<outpoint>` | MUST | Underscore-form origin outpoint (claim; verified by script + state). |
+| `tip:<outpoint>` | MUST | Tip outpoint this latch is paired with (underscore form). |
+
+### Latch state (inductive payload)
+
+Each latch UTXO carries ** latch state** sufficient for the next Settle to verify one inductive step. State MUST be recoverable from the locking script and/or taproot/script payload and MUST include at minimum:
+
+| Field | Requirement | Description |
+|-------|-------------|-------------|
+| `origin` | MUST | Inscription origin outpoint (underscore form). Immutable for the life of the chain. |
+| `tip` | MUST | Tip outpoint this latch is currently paired with. |
+| `parentLatch` | MUST except genesis latch | Outpoint of the latch consumed to create this latch. `null` or omitted only for the **genesis latch** after bootstrap. |
+| `originScriptHash` | SHOULD | Hash of the origin locking script (or commitment thereto) to bind induction to the inscribed sat. |
+| `schema` | MUST | Latch schema version. This BRC defines `1`. |
+
+Exact script encoding (push layout, template address, covenant) is **implementation-defined** in v1 of this BRC, provided nodes validate the interdependency and inductive fields at spend time. A normative script template MAY be added in a revision once reference implementations exist on testnet.
+
+**Inductive rule:** A Settle tx is valid only if it proves that the new latch’s `parentLatch` was consumed, the spent tip matches the old latch’s `tip`, and `origin` is unchanged from the parent latch. Thus counterfeiting a latched tip requires forging an ancestor latch or origin — equivalent to breaking a BOLT token chain.
+
+### Transfer flow (Commit + Settle)
+
+Every **latched transfer** to a new owner MUST use two transactions broadcast as an atomic pair (same submission batch). Order MAY be Commit then Settle or co-dependent; both MUST confirm for the transfer to be valid.
+
+#### 1. Commit transaction
+
+* **Inputs:** Sender’s current tip (1 sat) + funding as needed.
+* **Outputs:**
+  * Same tip returned to sender (1 sat, basket `1sat`) **OR** tip held in-contract until Settle (implementation choice).
+  * **New latch UTXO** (basket `1sat-latch`) with updated latch state referencing the current tip.
+* **Purpose:** Publish a proof UTXO that a future Settle must co-spend with the tip.
+
+#### 2. Settle transaction
+
+* **Inputs:** Tip (1 sat) + active latch UTXO (must match latch state `tip`) + BSV for fees.
+* **Outputs:**
+  * **Recipient tip** (1 sat, basket `1sat`) with [BRC-147](./0147.md) `customInstructions`.
+  * **Recipient latch** (basket `1sat-latch`) with latch state:
+    * same `origin`
+    * `tip` = recipient tip outpoint
+    * `parentLatch` = consumed latch outpoint
+* **Purpose:** Move ownership; receiver can verify in O(1) from recipient tip + recipient latch + parent latch outpoint (spent in this tx).
+
+```text
+Legacy bootstrap (once):
+  BRC-150 v2 full path + origin ord check  →  genesis latch + tip
+
+Each latched transfer:
+  Commit:  tip ──► tip + latch'
+  Settle:  tip + latch' ──► tip'' (to Bob) + latch''
+  Verify:  O(1) on tip'' + latch'' (+ spent parent visible in tx)
+```
+
+### Provenance remittance (v3)
+
+When `customInstructions.provenance` is present on a latched transfer, it uses **v3**:
+
+```json
+{
+  "v": 3,
+  "mode": "latched",
+  "origin": "<txid_vout>",
+  "tip": "<txid_vout>",
+  "latch": "<txid_vout>",
+  "parentLatch": "<txid_vout>",
+  "commitTxid": "<txid>",
+  "settleTxid": "<txid>"
+}
+```
+
+| Field | Type | Requirement | Description |
+|-------|------|-------------|-------------|
+| `v` | number | MUST | `3` for this BRC. |
+| `mode` | string | MUST | `"latched"` |
+| `origin` | string | MUST | Origin outpoint (underscore). |
+| `tip` | string | MUST | Recipient tip after Settle. |
+| `latch` | string | MUST | Recipient latch after Settle. |
+| `parentLatch` | string | MUST | Latch consumed in Settle (inductive link). |
+| `commitTxid` | string | SHOULD | Commit tx id for audit/debug. |
+| `settleTxid` | string | SHOULD | Settle tx id for audit/debug. |
+
+**v3 MUST NOT include `beefB64` or `path`.** If a sender includes v2 fields alongside v3, receivers MUST prefer v3 when latch outputs are present on chain.
+
+#### Legacy mode (unchanged)
+
+`"v": 2` with `beefB64` remains defined solely by [BRC-150](./0150.md). Wallets MUST accept v2 indefinitely for legacy tips.
+
+### Bootstrap: legacy tip → latched chain
+
+Before the first latched transfer, a wallet holding a **legacy tip** (no latch) MUST:
+
+1. Build a conforming [BRC-150](./0150.md) v2 package and verify origin locally (full path + `ord` envelope at origin).
+2. Broadcast a **genesis latch** transaction that creates the first `1sat-latch` output with `parentLatch` empty and `origin` from v2.
+3. Optionally attach v3 remittance on the **first Settle** to the next owner.
+
+Wallets MUST NOT create a genesis latch without a successful v2 verification (or an earlier valid latched receive).
+
+### Receiver requirements (O(1) verify)
+
+Given recipient tip `T` and `customInstructions.provenance` with `v === 3` and `mode === "latched"`, a conforming receiver MUST:
+
+1. **Parse** — Valid v3 object; `tip` normalizes to held outpoint `T`.
+2. **Latch exists** — `latch` is unspent on chain (or spent only by a conflicting tx the receiver rejects).
+3. **Co-spend binding** — `settleTxid` (or the transaction that created `T`) spends both `T`’s predecessor tip and `parentLatch` as inputs per latch rules.
+4. **Induction** — Latch state on `latch` has `parentLatch` equal to the consumed latch; `origin` matches v3 and parent state; `tip` equals `T`.
+5. **Origin binding (one-time cache)** — Receiver MUST have previously verified `origin` via [BRC-150](./0150.md) v2 **or** inherited a verified origin from an earlier latched receive in the same wallet. If origin script is unknown, receiver MUST fetch origin output and verify first `ord` envelope once, then cache `originScriptHash`.
+6. **One-sat** — Tip output value is 1.
+
+On success, receiver MAY treat `origin` as **proven** for tip `T` with the same semantics as successful [BRC-150](./0150.md) v2 verification.
+
+On failure, receiver MUST treat identity as **unproven** per [BRC-147](./0147.md).
+
+### Sender requirements
+
+A conforming sender performing a latched transfer MUST:
+
+1. Hold tip + active latch pair (or complete bootstrap first).
+2. Construct valid Commit + Settle pair satisfying latch script rules.
+3. Attach v3 provenance on the recipient tip in Settle (via BRC-100 `createAction` / remittance).
+4. Self-verify O(1) rules before broadcast.
+5. Fall back to [BRC-150](./0150.md) v2 if the receiver does not support latching or if script template deployment is unavailable.
+
+Senders MUST NOT drop the latch UTXO while the tip remains in basket `1sat` (orphan tip = legacy).
+
+### Relationship to other BRCs
+
+| Concern | Defined by |
+|---------|------------|
+| Basket `1sat`, tags, display metadata, unproven claims | [BRC-147](./0147.md) |
+| Full-path BEEF remittance (legacy / bootstrap) | [BRC-150](./0150.md) |
+| Latch basket, Commit/Settle, v3 provenance, O(1) verify | **This BRC** |
+| BEEF encoding | [BRC-62](../transactions/0062.md), [BRC-95](../transactions/0095.md) |
+| Wallet API surface | [BRC-100](../wallet/0100.md) |
+
+### Relationship to BOLT
+
+This BRC is **inspired by** BOLT transaction latching and inductive provenance but **is not** a BOLT token mint. Differences:
+
+| | BOLT | BRC-153 |
+|---|------|---------|
+| Asset identity | Protocol genesis + induction | 1Sat `ord` origin + induction |
+| Proof UTXO | Bolt | `1sat-latch` |
+| Content | Token amount / NF metadata | Inscription at origin (out of band) |
+| Fungible splits | Native | Out of scope |
+
+Implementations MAY reuse BOLT script templates where applicable; interoperability with native BOLT tokens is not required.
+
+## Compatibility and migration
+
+| Tip state | Send mode | Provenance |
+|-----------|-----------|------------|
+| Legacy, no latch | Single tx (BRC-100) | v2 BEEF or unproven |
+| Legacy → first latch | Bootstrap + optional Settle | v2 then v3 |
+| Latched | Commit + Settle | v3 |
+| Receiver old wallet | Single tx | v2 only (sender rebuilds path) |
+
+Wallets SHOULD retain [BRC-150](./0150.md) v2 builders for at least **24 months** after shipping v3 sends.
+
+Indexers (OrdFS, GorillaPool, etc.) remain useful for **media URLs and discovery**; they are not required for latched legitimacy verification.
+
+## Security considerations
+
+* **Orphan tips** — Spending or losing the latch while retaining the tip reverts the tip to legacy; next sender must v2-bootstrap again.
+* **Tag spoofing** — v3 without valid latch outputs on chain MUST fail verification (same spirit as [BRC-150](./0150.md)).
+* **Reorg** — Receivers SHOULD treat latched transfers as final only after sufficient confirmations on **both** Commit and Settle (policy per wallet).
+* **Script template bugs** — Invalid latch scripts could lock tips; reference implementations MUST ship on testnet before mainnet enforcement.
+* **Origin cache poisoning** — Receivers MUST verify `ord` envelope at origin at least once per distinct origin; cache only by outpoint hash.
+* **Fee griefing** — Two-tx transfers cost more; wallets SHOULD batch Commit+Settle and surface fee estimates clearly.
+* **Burn / re-origin** — Packing the sat into a multi-sat output ends the chain ([BRC-150](./0150.md)); latching MUST NOT continue across burns.
+
+## Implementation plan (normative roadmap)
+
+Phased rollout recommended for HandCash and other BRC-100 wallets:
+
+### Phase 0 — Specification (this document)
+
+* Freeze terminology, v3 JSON, basket split, verify rules.
+* Publish reference script template draft (separate appendix or BRC-153a).
+
+### Phase 1 — Read-only verification ✅
+
+* `oneSatLatch.ts`: `parseProvenanceV3`, `verifyProvenanceV3`, `buildProvenanceV3`, latch tags.
+* `oneSatProvenance.verifyProvenance` prefers v3 then v2.
+* Collectables listing uses unified verify.
+* Commit/Settle sends: `isLatchedSendEnabled()` returns `false` until script template lands.
+
+### Phase 2 — Bootstrap
+
+* Wallet can genesis-latch from v2-verified legacy tips (local only / testnet).
+
+### Phase 3 — Latched send
+
+* `createAction` Commit+Settle pair; coordinator serializes with spend guard.
+* v3 remittance on collectable send; fallback to v2.
+
+### Phase 4 — Interop
+
+* BRC-100 capability negotiation; items-market / migrate docs updated.
+* Optional: public testnet faucet for latched collectables.
+
+### Phase 5 (future BRC) — Automation
+
+* BOLT-style EventListener for marketplace settle (out of scope here).
+
+## Implementations
+
+* **HandCash Desktop** (reference, phase 1): `oneSatLatch.ts`, `oneSatProvenance.verifyProvenance`, `collectables.ts`.  
+  Spec: `docs/bsva/brcs/tokens/0153.md`.
+* **Reference — BOLT:** [boltassociation.com](https://boltassociation.com/), [BetaBOLT](https://github.com/bsvhackathon/BetaBOLT) (script patterns only; not 1Sat-specific).
+
+## References
+
+1. [BRC-147](./0147.md) — 1Sat Ordinals Basket Profile for BRC-46 / BRC-100
+2. [BRC-150](./0150.md) — 1Sat Provenance Remittance for Basket `1sat`
+3. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions Extension
+4. [BRC-46](../wallet/0046.md) — Wallet Transaction Output Tracking
+5. [BRC-62](../transactions/0062.md) — BEEF Transactions
+6. [BRC-95](../transactions/0095.md) — Atomic BEEF Transactions
+7. [BRC-100](../wallet/0100.md) — Unified Open BSV Wallet Interface
+8. BOLT — *A Bitcoin Transaction Latching Mechanism & Token Protocol*, Honohan, 2024 — [boltassociation.com](https://boltassociation.com/)
+9. 1Sat Ordinals — <https://docs.1satordinals.com>

--- a/tokens/0153.md
+++ b/tokens/0153.md
@@ -71,9 +71,28 @@ Latch UTXOs are tracked in basket **`1sat-latch`** ([BRC-46](../wallet/0046.md))
 | Basket | Holds | Eligibility |
 |--------|-------|-------------|
 | `1sat` | Tip (1 sat) | [BRC-147](./0147.md) |
-| `1sat-latch` | Proof latch | Created only by this BRC; value ≥ dust limit; satoshis MAY be > 1 |
+| `1sat-latch` | Proof latch | Created only by this BRC; see *Latch value* below |
 
 Wallets MUST NOT sweep latch outputs as spendable BSV change. Latch outputs MUST be spent only in Settle transactions defined below or when explicitly abandoning a legacy migration path.
+
+#### Latch value
+
+A tip is always exactly **1** satoshi. Latch value MUST therefore never be 1, or receivers that scan for 1-sat outputs will import the latch as a duplicate collectable (basket tags are local and never travel on chain).
+
+| Profile | Latch satoshis | Notes |
+|---------|----------------|-------|
+| **Soft-latch** (Phase 1a) | **Exactly 2** | Standard P2PKH to the tip owner so address scanners still find it. Receivers MUST treat `satoshis === 2` as latch dust: route to `1sat-latch`, never list as a collectable, never fund-sweep. |
+| Hardened latch (Phase 3) | ≥ dust, **≠ 1** | Marker / covenant script; value MAY exceed 2. |
+
+Wallets MUST NOT invent alternate soft-latch dust amounts. Interop depends on the fixed **2**-satoshi constant.
+
+#### Latch outputs MUST be identifiable on chain
+
+Basket membership and tags are **local wallet state** and never reach the receiver. A latch delivered as a bare 1-satoshi P2PKH output is therefore byte-identical to a tip.
+
+Soft-latch outputs are identified by value alone (`satoshis === 2`). Hardened latch outputs MUST additionally carry a latch marker in the locking script (e.g. a pushdata prefix before the ownership branch).
+
+Receivers MUST route soft-latch dust and marked latch outputs to `1sat-latch` and MUST NOT list them as collectables. Receivers SHOULD deduplicate basket `1sat` by origin, keeping the best-attested tip, since an origin has exactly one live tip.
 
 Tags on latch outputs:
 
@@ -258,12 +277,15 @@ Phased rollout recommended for HandCash and other BRC-100 wallets:
 * Freeze terminology, v3 JSON, basket split, verify rules.
 * Publish reference script template draft (separate appendix or BRC-153a).
 
-### Phase 1 — Soft-latch verify + send ✅
+### Phase 1 — v3 verify ✅
 
 * `oneSatLatch.ts`: `parseProvenanceV3`, `verifyProvenanceV3`, `buildProvenanceV3` / `buildSoftLatchProvenanceV3`, latch tags, relative `OUTPUT:N` remittance.
 * `oneSatProvenance.verifyProvenance` prefers v3 then v2.
-* Collectables listing uses unified verify.
-* Soft-latch sends: tip + latch P2PKH in one settle-style `createAction`; prior latch co-spent when present; `isLatchedSendEnabled()` returns `true`.
+* Collectables listing uses unified verify and deduplicates by origin.
+
+### Phase 1a — Soft-latch sends ✅
+
+Soft-latch sends are live: tip (1 sat) + latch (**exactly 2** sats, P2PKH) in one settle-style `createAction`; prior latch co-spent when present; v3 remittance with relative `OUTPUT:N` tip/latch refs. `isLatchedSendEnabled()` returns `true`. Receivers classify `satoshis === 2` as latch dust (never tip, never funding).
 
 ### Phase 2 — Bootstrap
 
@@ -271,7 +293,7 @@ Phased rollout recommended for HandCash and other BRC-100 wallets:
 
 ### Phase 3 — Hardened Commit + Settle (optional)
 
-* BOLT-style covenant script templates + two-tx Commit/Settle pair when on-chain induction is required.
+* BOLT-style covenant script templates + two-tx Commit/Settle pair when on-chain induction is required. Latch value MAY exceed 2; locking script MUST carry a marker.
 
 ### Phase 4 — Interop
 
@@ -284,7 +306,7 @@ Phased rollout recommended for HandCash and other BRC-100 wallets:
 
 ## Implementations
 
-* **HandCash Desktop** (reference, soft-latch live): `oneSatLatch.ts`, `oneSatProvenance.verifyProvenance`, `collectables.sendCollectable`.  
+* **HandCash Desktop** (reference, soft-latch live — 2-sat P2PKH latch): `oneSatLatch.ts`, `oneSatProvenance.verifyProvenance`, `collectables.sendCollectable`.  
   Spec: `docs/bsva/brcs/tokens/0153.md`.
 * **Reference — BOLT:** [boltassociation.com](https://boltassociation.com/), [BetaBOLT](https://github.com/bsvhackathon/BetaBOLT) (script patterns only; not 1Sat-specific).
 

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -15,4 +15,5 @@ BRC | Standard
 117  | [Proof-of-Indexing Hash-to-Mint Tokens](./0117.md)
 147  | [1Sat Ordinals Basket Profile for BRC-46 / BRC-100](./0147.md)
 150  | [1Sat Provenance Remittance for Basket `1sat`](./0150.md)
+153  | [Latched 1Sat Provenance for Basket `1sat`](./0153.md)
 226  | [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./0226.md)

--- a/wallet/0232.md
+++ b/wallet/0232.md
@@ -4,7 +4,7 @@ Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
 ## Abstract
 
-This BRC defines an HTTP **backup service** profile for optional recovery of [BRC-140](../key-derivation/0140.md) key shares. A backup service stores **at most one** BRC-140 share per `userIdHash` and releases it only after authentication. Wallets may enroll a **list** of independent service URLs, deposit distinct shares across them under a threshold scheme, and reconstruct the key locally after obtaining enough shares.
+This BRC defines an HTTP **backup service** profile for optional recovery of [BRC-140](../key-derivation/0140.md) key shares. A backup service stores **at most one** BRC-140 share per authenticated account and releases it only after authentication. Wallets may enroll a **list** of independent service URLs, deposit distinct shares across them under a threshold scheme, and reconstruct the key locally after obtaining enough shares.
 
 A backup service MUST NOT be required for ordinary wallet operation under [BRC-100](./0100.md). It MUST NOT receive the root private key, and a conforming wallet MUST NOT send enough shares to any single service to meet the wallet’s recovery threshold.
 
@@ -20,9 +20,9 @@ This BRC specifies a minimal, pluggable wire contract so any operator can run a 
 
 | Term | Meaning |
 |------|---------|
-| **Backup service** | HTTP origin that stores ≤ 1 BRC-140 share per `userIdHash` and releases it after auth. |
+| **Backup service** | HTTP origin that stores ≤ 1 BRC-140 share per authenticated account and releases it after auth. |
 | **Wallet** | Client that splits/reconstructs keys per BRC-140 and speaks this profile. |
-| **Enrollment** | Successful deposit of exactly one share to one backup service for one `userIdHash`. |
+| **Enrollment** | Successful deposit of exactly one share to one backup service for one authenticated account. |
 | **Recovery** | Obtaining ≥ threshold distinct shares and reconstructing the key in the wallet. |
 
 ### Relationship to other BRCs
@@ -49,26 +49,17 @@ This BRC specifies a minimal, pluggable wire contract so any operator can run a 
 3. Reconstruction happens only in the wallet after enough shares are obtained.
 4. Services MUST NEVER receive the reconstructed key.
 
-**Invariant (service):** store at most one share per `userIdHash`; reject non-BRC-140 share strings.
+**Invariant (service):** store at most one share per authenticated account; reject non-BRC-140 share strings.
 
 **Invariant (wallet):** MUST NOT send the root private key, mnemonic, or ≥ threshold shares from one split to any single backup service.
 
 A common enrollment scheme is threshold 2 of 3 total shares. Other thresholds are permitted if the wallet and user agree on the scheme before deposit.
 
-### User identity handle
+### Account binding
 
-`userIdHash` is a **64-character lowercase hex** SHA-256 digest used as the storage key at each service.
+The bearer session returned by authentication MUST be bound to a provider-local account. Share endpoints operate on that authenticated account and MUST NOT accept a caller-supplied email, handle, public key, or account hash to select another account's share.
 
-For email OTP auth:
-
-```
-userIdHash = hex( SHA-256( UTF-8( normalize(email) ) ) )
-normalize(email) = trim + lowercase
-```
-
-Wallets and services MUST use the same normalization before hashing. Share endpoints identify the record by `userIdHash` only.
-
-`userIdHash` is a stable lookup key, not an anonymity mechanism: an operator that learns the email during authentication can recompute the hash and associate it with the stored share. Other auth methods MAY define a different preimage in a future revision.
+The provider MAY use any internal account identifier. That identifier is not part of this wire profile and MUST NOT be treated as an anonymity mechanism: a provider can associate the stored share with the identity presented during authentication.
 
 ### HTTP profile
 
@@ -83,8 +74,7 @@ No auth required.
   "name": "Example Backup",
   "version": "0.1.0",
   "role": "backup-service",
-  "authMethods": ["EmailOtp"],
-  "requiresPasswordWithOtp": false,
+  "authMethods": ["com.example.connect", "webauthn", "email-otp"],
   "lifecycle": {
     "status": "active",
     "sunsetAt": null,
@@ -100,8 +90,7 @@ No auth required.
 | `name` | MUST | Operator display name |
 | `version` | SHOULD | Operator software version |
 | `role` | SHOULD | Constant `backup-service` |
-| `authMethods` | MUST | Non-empty array of auth method identifiers |
-| `requiresPasswordWithOtp` | SHOULD | If `true`, retrieve (and optionally enroll) requires an additional password/PIN field under the operator’s documented policy |
+| `authMethods` | MUST | Non-empty array of supported authentication method identifiers |
 | `lifecycle` | MUST | Operator lifecycle block |
 
 #### Lifecycle
@@ -121,12 +110,21 @@ No auth required.
 
 Wallets SHOULD refresh `/info` for enrolled URLs and stop new enrolls when status is not `active`. Operators SHOULD provide a sunset window before `retireAt`.
 
-#### Auth (email OTP)
+#### Authentication
+
+Authentication is capability-negotiated. This BRC defines a common start/complete envelope but does not mandate a specific identity provider or factor.
+
+`authMethods` contains identifiers for authentication profiles understood by the service. Provider-specific identifiers SHOULD use reverse-domain form (for example `com.example.connect`). Existing standardized identifiers such as `webauthn` MAY be used directly. Email OTP, redirect-based Connect providers, passkeys, and challenge-response systems are all possible profiles; none is required by this BRC. Wallets MUST ignore methods they do not implement.
+
+An authentication method used for recovery MUST remain usable without possession of the secret being recovered. A signature key derived only from the BRC-140-protected root key MUST NOT be the sole recovery method, because that creates a circular dependency. Redirect or challenge methods are conforming only when their credential can be recovered independently.
 
 ##### `POST /auth/start`
 
 ```json
-{ "email": "user@example.com" }
+{
+  "method": "com.example.connect",
+  "params": {}
+}
 ```
 
 Response (`200`):
@@ -134,18 +132,28 @@ Response (`200`):
 ```json
 {
   "requestId": "<opaque>",
-  "expiresInSec": 600
+  "expiresInSec": 600,
+  "action": {
+    "type": "redirect",
+    "url": "https://identity.example/authorize?request=<opaque>"
+  }
 }
 ```
 
-The operator delivers a one-time code out of band. Production deployments MUST NOT return the code in the HTTP response.
+`params` and `action` are method-specific objects. Defined `action.type` values are:
 
-##### `POST /auth/verify`
+* `redirect` — open `action.url`; the authorization result is supplied to `/auth/complete`.
+* `challenge` — produce a proof over `action.challenge`.
+* `outOfBand` — complete the externally delivered challenge (such as an OTP).
+
+Unknown action fields MUST be ignored.
+
+##### `POST /auth/complete`
 
 ```json
 {
   "requestId": "<opaque>",
-  "code": "<otp>"
+  "response": {}
 }
 ```
 
@@ -154,14 +162,13 @@ Response (`200`):
 ```json
 {
   "token": "<bearer secret>",
-  "email": "user@example.com",
   "expiresInSec": 1800
 }
 ```
 
-Share endpoints use `Authorization: Bearer <token>`.
+`response` is method-specific. The service MUST validate that it completes the referenced request and MUST bind the returned bearer token to the authenticated provider-local account.
 
-Wallets MUST skip services whose `authMethods` they do not implement. When `requiresPasswordWithOtp` is `true`, the service MAY require an additional password/PIN on share operations as documented by the operator.
+Share endpoints use `Authorization: Bearer <token>`. Tokens SHOULD be short-lived and scoped to backup-service operations.
 
 #### Share endpoints
 
@@ -169,7 +176,6 @@ All share endpoints require a valid bearer session.
 
 ```json
 {
-  "userIdHash": "<64 hex>",
   "share": "<BRC-140 backup string>"
 }
 ```
@@ -180,17 +186,17 @@ All share endpoints require a valid bearer session.
 
 * MUST validate `share` as BRC-140 backup serialization.
 * MUST fail with `403` when lifecycle forbids enroll.
-* Stores exactly one share for `userIdHash` (overwrite policy is operator-defined; `/share/rotate` SHOULD be preferred for explicit replacement).
+* Stores exactly one share for the authenticated account (overwrite policy is operator-defined; `/share/rotate` SHOULD be preferred for explicit replacement).
 
 Response (`200`):
 
 ```json
-{ "ok": true, "userIdHash": "<64 hex>", "enrolledAt": "<RFC 3339>" }
+{ "ok": true, "enrolledAt": "<RFC 3339>" }
 ```
 
 ##### `POST /share/retrieve`
 
-Request: `{ "userIdHash" }`.
+Request: `{}`.
 
 Response (`200`):
 
@@ -208,7 +214,7 @@ Replace the stored share after auth. Same validation as enroll.
 
 ##### `POST /share/delete`
 
-Request: `{ "userIdHash" }`. Idempotent; response `{ "ok": true }`.
+Request: `{}`. Idempotent; response `{ "ok": true }`.
 
 ### Wallet requirements
 
@@ -224,8 +230,9 @@ Request: `{ "userIdHash" }`. Idempotent; response `{ "ok": true }`.
 |------|------------|
 | Single service compromised | Threshold ≥ 2; one share insufficient |
 | Colluding services | Threshold and enrollment topology determine exposure; wallets MUST NOT send ≥ threshold shares to one party |
-| OTP / inbox takeover | Short-lived tokens; optional `requiresPasswordWithOtp`; auth rate limiting |
-| Email↔share linkage | Operator that authenticates the email can link it to `userIdHash` and the share; treat operators as share custodians for that record |
+| Authentication compromise | Short-lived scoped tokens, rate limiting, and operator-appropriate factors |
+| Circular recovery auth | A key derived solely from the protected root MUST NOT be the only release credential |
+| Identity↔share linkage | The provider can associate its authenticated account with the share; treat providers as share custodians for that record |
 | Operator disappearance | Multi-provider enrollment and offline BRC-140 / BRC-75 |
 | Malformed shares | Reject non-BRC-140; verify integrity at reconstruct |
 
@@ -233,8 +240,7 @@ Protect share transport with TLS. Minimize logging of share material. Encrypt sh
 
 ## Implementations
 
-1. HandCash Desktop — multi-URL backup-service client and local BRC-140 split/reconstruct (`feat/backup-services`).
-2. HandCash `backup-service` — reference share vault implementing this profile.
+HandCash Desktop and its `backup-service` prototype implement multi-provider BRC-140 share storage on branch `feat/backup-services`. The prototype's original email-OTP exchange predates the capability-negotiated authentication envelope in this draft and is not presented as a complete conforming implementation.
 
 ## References
 

--- a/wallet/0232.md
+++ b/wallet/0232.md
@@ -1,0 +1,270 @@
+# BRC-232: Pluggable Backup Services for BRC-140 Share Vaults
+
+Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
+
+## Abstract
+
+This BRC defines an interoperable **backup service** profile: an independent HTTP provider that stores **at most one** [BRC-140](../key-derivation/0140.md) recovery share per user and releases it only after the user authenticates. Wallets maintain a **list** of backup-service URLs (not a single hardcoded vendor), deposit distinct shares across providers under a threshold scheme (for example 2-of-3), and recover by authenticating to enough enrolled services.
+
+A backup service is a **disaster-recovery aid**. It MUST NOT be required for day-to-day spend, connect, or [BRC-100](./0100.md) wallet use. It is not a threshold-signature co-signer and MUST NOT receive the root private key or enough shares to meet the wallet’s recovery threshold by itself.
+
+## Motivation
+
+[BRC-140](../key-derivation/0140.md) solves key sharding for offline backup: split a secp256k1 private key into shares so a threshold can reconstruct it. Users still face a practical gap — many lose the only device and never finish offline share placement (paper, password manager, second device).
+
+Vendor-specific “trustholder” or wallet-authentication backends historically filled that gap by holding a share (or worse, remaining in the spend path). A single hardcoded recovery vendor recreates custody concentration and shutdown risk: if that vendor disappears, enrolled users who relied on it alone are stranded.
+
+This profile decentralizes that role:
+
+1. **Any** operator may run a conforming backup service.
+2. Wallets treat providers as a **replaceable URL list**.
+3. Cryptography stays [BRC-140](../key-derivation/0140.md); this BRC only specifies the **service wire contract**, lifecycle signaling, and wallet enrollment rules that make multi-provider recovery interoperable.
+
+Recording the contract as a BRC gives independent wallets and operators a shared legitimacy target instead of each inventing a private recovery API.
+
+## Specification
+
+### Terminology
+
+| Term | Meaning |
+|------|---------|
+| **Backup service** | HTTP origin that stores ≤ 1 BRC-140 share per `userIdHash` and releases it after auth. |
+| **Wallet** | Client that splits/reconstructs keys per BRC-140 and speaks this profile. |
+| **Enrollment** | Successful deposit of exactly one share to one backup service for one `userIdHash`. |
+| **Recovery** | Fetching ≥ threshold distinct shares (from services and/or offline holdings) and reconstructing the key locally. |
+
+Preferred user-facing language is **backup service** / **recovery provider**. Implementations SHOULD avoid implying that a service can move funds or that any single vendor “recovers the account.”
+
+### Relationship to other BRCs
+
+| Standard | Role |
+|----------|------|
+| [BRC-140](../key-derivation/0140.md) | Share math + `x.y.threshold.integrity` serialization (normative for `share` payloads) |
+| [BRC-75](../key-derivation/0075.md) | Complementary offline mnemonic path; out of scope here |
+| [BRC-38](../outpoints/0038.md) / [BRC-39](../outpoints/0039.md) / [BRC-40](../outpoints/0040.md) | Wallet *data* export/sync — not key sharding; out of scope |
+| [BRC-100](./0100.md) | Day-to-day app↔wallet interface; MUST remain usable with zero backup services configured |
+
+### Non-goals
+
+* Threshold signatures / spend-time co-signing.
+* Requiring backup services for send, receive, or BRC-100 connect.
+* Mandating a global directory of providers (wallets MAY ship curated defaults; empty default is valid).
+* Synchronizing full UTXO / history state (remain BRC-38/39/40 or local).
+* Binding operators to a specific email ISP or KYC regime.
+
+### Cryptographic model (wallet)
+
+1. The wallet splits its **root private key** with BRC-140 (reference: `toBackupShares` / `fromBackupShares`).
+2. Default multi-service enrollment scheme: **threshold = 2**, **total = 3** (other schemes are allowed if clearly disclosed in wallet UX).
+3. The wallet deposits **at most one share per backup service**.
+4. Reconstruction ALWAYS happens inside the wallet after enough shares are obtained. Services MUST NEVER receive the reconstructed key.
+
+**Invariant (service):** a conforming backup service stores at most one share per `userIdHash` and MUST reject payloads that are not BRC-140 backup strings.
+
+**Invariant (wallet):** a conforming wallet MUST NOT send the root private key, mnemonic, or ≥ threshold shares to any single backup service.
+
+#### Opt-in service-majority recovery
+
+Wallets MAY offer an opt-in path where the user deposits three shares to three services under 2-of-3 and holds no offline share. That path trades offline independence for device-loss convenience: any two enrolled services that release shares after user auth can reconstruct. Wallets MUST disclose this tradeoff at enrollment. Offline BRC-140 / BRC-75 paths remain first-class and MUST remain available without any service.
+
+### User identity handle
+
+`userIdHash` is a **64-character lowercase hex** SHA-256 digest used as the storage key at each service.
+
+For email OTP auth, the normative binding is:
+
+```
+userIdHash = hex( SHA-256( UTF-8( normalize(email) ) ) )
+normalize(email) = trim + lowercase
+```
+
+Wallets and services MUST use the same normalization before hashing. Services MUST treat `userIdHash` as an opaque key and MUST NOT require the raw email on share endpoints (email appears only in auth start/verify as needed by the operator).
+
+Other auth methods MAY define their own preimage for `userIdHash` in a future revision; v1 documents the email binding above because it matches deployed practice.
+
+### HTTP profile
+
+Base URL is an HTTPS (or loopback HTTP for development) origin. Paths below are relative to that origin. JSON UTF-8 request/response bodies unless noted. Unknown JSON fields MUST be ignored by readers.
+
+#### `GET /info`
+
+Returns service metadata. No auth required.
+
+```json
+{
+  "name": "Example Backup",
+  "version": "0.1.0",
+  "role": "backup-service",
+  "authMethods": ["EmailOtp"],
+  "requiresPasswordWithOtp": false,
+  "lifecycle": {
+    "status": "active",
+    "sunsetAt": null,
+    "retireAt": null,
+    "message": null,
+    "successorUrl": null
+  }
+}
+```
+
+| Field | Requirement | Meaning |
+|-------|-------------|---------|
+| `name` | MUST | Human-readable operator name |
+| `version` | SHOULD | Operator software version string |
+| `role` | SHOULD | Constant `backup-service` for discovery |
+| `authMethods` | MUST | Non-empty array of auth method identifiers |
+| `requiresPasswordWithOtp` | SHOULD | If `true`, wallet SHOULD also collect a user password/PIN and send it on retrieve per operator policy (extension; see Auth) |
+| `lifecycle` | MUST | Operator lifecycle block (below) |
+
+#### Lifecycle / shutdown signaling
+
+Operators MUST publish planned shutdown so wallets can urge rotation before shares become unreachable.
+
+| `lifecycle.status` | Meaning |
+|--------------------|---------|
+| `active` | Normal enroll + retrieve |
+| `sunset` | Still serving retrieve; MUST reject new enrolls (or wallet MUST treat enroll as forbidden) |
+| `retired` | Gone or past `retireAt`; retrieve MUST fail |
+
+| Field | Requirement | Meaning |
+|-------|-------------|---------|
+| `sunsetAt` | MAY | When sunset began / begins (RFC 3339 UTC) |
+| `retireAt` | SHOULD when sunsetting | Last moment retrieve is expected to work |
+| `message` | MAY | Human explanation |
+| `successorUrl` | MAY | Suggested replacement backup-service base URL |
+
+**Wallet behavior**
+
+1. Refresh `/info` for each enrolled URL periodically (on launch and at least daily while the wallet runs is sufficient).
+2. If `sunset` / `retired` / `retireAt` within 90 days: warn the user to rotate.
+3. **Rotate:** retrieve (while still possible) → enroll at a replacement URL → delete old enrollment when delete is available.
+4. Recommend operators advertise ≥ 90 days between `sunset` and `retireAt`. Absence of signaling does not remove the need for offline backup.
+
+#### Auth (email OTP v1)
+
+##### `POST /auth/start`
+
+Request:
+
+```json
+{ "email": "user@example.com" }
+```
+
+Response (`200`):
+
+```json
+{
+  "requestId": "<opaque>",
+  "expiresInSec": 600
+}
+```
+
+Operators MUST deliver a one-time code out of band (email). Development-only fields such as `devCode` MUST NOT appear in production deployments.
+
+##### `POST /auth/verify`
+
+Request:
+
+```json
+{
+  "requestId": "<opaque>",
+  "code": "<otp>"
+}
+```
+
+Response (`200`):
+
+```json
+{
+  "token": "<bearer secret>",
+  "email": "user@example.com",
+  "expiresInSec": 1800
+}
+```
+
+Subsequent share endpoints use `Authorization: Bearer <token>`.
+
+`authMethods` MAY list additional schemes later (`PhoneOtp`, etc.). Wallets MUST skip services whose methods they do not implement.
+
+When `requiresPasswordWithOtp` is `true`, the service MAY require an additional `password` / `recoveryPin` field on `/share/retrieve` (and optionally enroll). The precise field name SHOULD be documented by the operator; wallets that cannot satisfy the policy MUST not enroll that service.
+
+#### Share endpoints
+
+All share endpoints require a valid bearer session. Bodies use:
+
+```json
+{
+  "userIdHash": "<64 hex>",
+  "share": "<BRC-140 backup string>"
+}
+```
+
+(`share` only on enroll / rotate.)
+
+##### `POST /share/enroll`
+
+Store exactly one share for `userIdHash`.
+
+* MUST validate `share` as BRC-140 backup serialization (`x.y.threshold.integrity`).
+* MUST overwrite or reject-duplicate per operator policy; wallets SHOULD treat a second enroll for the same `userIdHash` as rotate-equivalent and prefer `/share/rotate` when implemented.
+* MUST fail with `403` when lifecycle forbids enroll (`sunset` / `retired` / past `retireAt`).
+
+Response (`200`):
+
+```json
+{ "ok": true, "userIdHash": "<64 hex>", "enrolledAt": "<RFC 3339>" }
+```
+
+##### `POST /share/retrieve`
+
+Request: `{ "userIdHash" }`. Response (`200`):
+
+```json
+{ "share": "<BRC-140 backup string>", "enrolledAt": "<RFC 3339>" }
+```
+
+* MUST NOT return a share without successful auth under the service’s published policy.
+* MUST fail when lifecycle is `retired` or past `retireAt`.
+* MUST `404` when no share is stored.
+
+##### `POST /share/rotate` (SHOULD)
+
+Replace the stored share for `userIdHash` with a new BRC-140 string after auth. Same validation as enroll. Used after recovery or when migrating providers.
+
+##### `POST /share/delete`
+
+Request: `{ "userIdHash" }`. Deletes any stored share. Response `{ "ok": true }` even if none existed (idempotent).
+
+### Wallet requirements
+
+1. **Pluggable list** — durable prefs of backup-service base URLs; empty list MUST be valid.
+2. **No spend dependency** — send / BRC-100 connect MUST work with zero services.
+3. **One share per URL** — never deposit two shares from the same split to one origin.
+4. **Local reconstruct** — combine shares only on device; then re-wrap into the wallet’s normal vault.
+5. **Offline first** — BRC-140 user-held shares and/or BRC-75 remain available without services.
+6. **Lifecycle UX** — surface sunset warnings and offer rotate while retrieve still works.
+7. **Honest copy** — enrollment UI MUST NOT claim a service can move funds or that HandCash (or any single vendor) is required to recover.
+
+### Security considerations
+
+| Risk | Mitigation |
+|------|------------|
+| Single service compromised | Threshold ≥ 2; one share insufficient |
+| Two services collude after user auth (2-of-3 service-majority) | Accepted tradeoff of opt-in convenience path; disclose at enroll; prefer hybrid (user-held + services) when possible |
+| OTP / inbox takeover | Prefer `requiresPasswordWithOtp: true` for high-value operators; rate-limit auth; short-lived bearer tokens |
+| Malicious `/info` or successor URL | Wallet SHOULD confirm successor with the user before auto-rotating |
+| Operator silent disappearance | Offline BRC-140 / BRC-75 remain the backstop; multi-provider enrollment reduces blast radius |
+| Service stores wrong share format | Reject non-BRC-140; integrity tag checked at reconstruct |
+
+A backup service that can authenticate a user and holds a share is a **sensitive** system: protect transport with TLS, minimize logs of share material, and encrypt shares at rest under an operator key that is not the user’s root key.
+
+## Implementations
+
+1. **HandCash Desktop** — Settings → Backup services (empty default list); enroll / restore against multiple URLs; BRC-140 split/reconstruct locally (`feat/backup-services`).
+2. **HandCash open backup-service** — runnable share-vault reference (`HANDCASH-DESKTOP/backup-service`): `/info`, email OTP (dev), enroll / retrieve / delete, lifecycle tooling, local 2-of-3 cluster smoke test.
+
+## References
+
+- <a name="footnote-1">1</a>: [BRC-140 — Threshold Key Sharing and Backup via Shamir's Secret Sharing Scheme](../key-derivation/0140.md)
+- <a name="footnote-2">2</a>: [BRC-100 — Unified Wallet-to-Application Interface](./0100.md)
+- <a name="footnote-3">3</a>: HandCash Desktop backup services proposal and reference server — https://github.com/HandCash/HANDCASH-DESKTOP (branch `feat/backup-services`)

--- a/wallet/0232.md
+++ b/wallet/0232.md
@@ -4,23 +4,15 @@ Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
 ## Abstract
 
-This BRC defines an interoperable **backup service** profile: an independent HTTP provider that stores **at most one** [BRC-140](../key-derivation/0140.md) recovery share per user and releases it only after the user authenticates. Wallets maintain a **list** of backup-service URLs (not a single hardcoded vendor), deposit distinct shares across providers under a threshold scheme (for example 2-of-3), and recover by authenticating to enough enrolled services.
+This BRC defines an HTTP **backup service** profile for optional recovery of [BRC-140](../key-derivation/0140.md) key shares. A backup service stores **at most one** BRC-140 share per `userIdHash` and releases it only after authentication. Wallets may enroll a **list** of independent service URLs, deposit distinct shares across them under a threshold scheme, and reconstruct the key locally after obtaining enough shares.
 
-A backup service is a **disaster-recovery aid**. It MUST NOT be required for day-to-day spend, connect, or [BRC-100](./0100.md) wallet use. It is not a threshold-signature co-signer and MUST NOT receive the root private key or enough shares to meet the wallet’s recovery threshold by itself.
+A backup service MUST NOT be required for ordinary wallet operation under [BRC-100](./0100.md). It MUST NOT receive the root private key, and a conforming wallet MUST NOT send enough shares to any single service to meet the wallet’s recovery threshold.
 
 ## Motivation
 
-[BRC-140](../key-derivation/0140.md) solves key sharding for offline backup: split a secp256k1 private key into shares so a threshold can reconstruct it. Users still face a practical gap — many lose the only device and never finish offline share placement (paper, password manager, second device).
+[BRC-140](../key-derivation/0140.md) specifies threshold key sharing and the canonical share serialization. It does not define how optional network providers store and release those shares. Without a shared service profile, wallets invent incompatible recovery APIs and users concentrate recovery on a single operator.
 
-Vendor-specific “trustholder” or wallet-authentication backends historically filled that gap by holding a share (or worse, remaining in the spend path). A single hardcoded recovery vendor recreates custody concentration and shutdown risk: if that vendor disappears, enrolled users who relied on it alone are stranded.
-
-This profile decentralizes that role:
-
-1. **Any** operator may run a conforming backup service.
-2. Wallets treat providers as a **replaceable URL list**.
-3. Cryptography stays [BRC-140](../key-derivation/0140.md); this BRC only specifies the **service wire contract**, lifecycle signaling, and wallet enrollment rules that make multi-provider recovery interoperable.
-
-Recording the contract as a BRC gives independent wallets and operators a shared legitimacy target instead of each inventing a private recovery API.
+This BRC specifies a minimal, pluggable wire contract so any operator can run a share vault and any wallet can enroll multiple providers interchangeably. Cryptography remains BRC-140; this document covers discovery metadata, authentication for release, share endpoints, and operator lifecycle signaling.
 
 ## Specification
 
@@ -31,64 +23,60 @@ Recording the contract as a BRC gives independent wallets and operators a shared
 | **Backup service** | HTTP origin that stores ≤ 1 BRC-140 share per `userIdHash` and releases it after auth. |
 | **Wallet** | Client that splits/reconstructs keys per BRC-140 and speaks this profile. |
 | **Enrollment** | Successful deposit of exactly one share to one backup service for one `userIdHash`. |
-| **Recovery** | Fetching ≥ threshold distinct shares (from services and/or offline holdings) and reconstructing the key locally. |
-
-Preferred user-facing language is **backup service** / **recovery provider**. Implementations SHOULD avoid implying that a service can move funds or that any single vendor “recovers the account.”
+| **Recovery** | Obtaining ≥ threshold distinct shares and reconstructing the key in the wallet. |
 
 ### Relationship to other BRCs
 
 | Standard | Role |
 |----------|------|
-| [BRC-140](../key-derivation/0140.md) | Share math + `x.y.threshold.integrity` serialization (normative for `share` payloads) |
-| [BRC-75](../key-derivation/0075.md) | Complementary offline mnemonic path; out of scope here |
-| [BRC-38](../outpoints/0038.md) / [BRC-39](../outpoints/0039.md) / [BRC-40](../outpoints/0040.md) | Wallet *data* export/sync — not key sharding; out of scope |
-| [BRC-100](./0100.md) | Day-to-day app↔wallet interface; MUST remain usable with zero backup services configured |
+| [BRC-140](../key-derivation/0140.md) | Share math and `x.y.threshold.integrity` serialization (normative for `share` payloads) |
+| [BRC-75](../key-derivation/0075.md) | Offline mnemonic recovery; complementary and out of scope |
+| [BRC-38](../outpoints/0038.md) / [BRC-39](../outpoints/0039.md) / [BRC-40](../outpoints/0040.md) | Wallet *data* export/sync; out of scope |
+| [BRC-100](./0100.md) | App↔wallet interface; MUST remain usable with zero backup services configured |
 
 ### Non-goals
 
-* Threshold signatures / spend-time co-signing.
+* Threshold signatures or spend-time co-signing.
 * Requiring backup services for send, receive, or BRC-100 connect.
-* Mandating a global directory of providers (wallets MAY ship curated defaults; empty default is valid).
-* Synchronizing full UTXO / history state (remain BRC-38/39/40 or local).
-* Binding operators to a specific email ISP or KYC regime.
+* A global registry of providers.
+* Wallet UTXO / history synchronization.
+* Mandating a particular identity or KYC regime.
 
-### Cryptographic model (wallet)
+### Cryptographic model
 
-1. The wallet splits its **root private key** with BRC-140 (reference: `toBackupShares` / `fromBackupShares`).
-2. Default multi-service enrollment scheme: **threshold = 2**, **total = 3** (other schemes are allowed if clearly disclosed in wallet UX).
-3. The wallet deposits **at most one share per backup service**.
-4. Reconstruction ALWAYS happens inside the wallet after enough shares are obtained. Services MUST NEVER receive the reconstructed key.
+1. The wallet splits its root private key with BRC-140.
+2. The wallet deposits **at most one share per backup service**.
+3. Reconstruction happens only in the wallet after enough shares are obtained.
+4. Services MUST NEVER receive the reconstructed key.
 
-**Invariant (service):** a conforming backup service stores at most one share per `userIdHash` and MUST reject payloads that are not BRC-140 backup strings.
+**Invariant (service):** store at most one share per `userIdHash`; reject non-BRC-140 share strings.
 
-**Invariant (wallet):** a conforming wallet MUST NOT send the root private key, mnemonic, or ≥ threshold shares to any single backup service.
+**Invariant (wallet):** MUST NOT send the root private key, mnemonic, or ≥ threshold shares from one split to any single backup service.
 
-#### Opt-in service-majority recovery
-
-Wallets MAY offer an opt-in path where the user deposits three shares to three services under 2-of-3 and holds no offline share. That path trades offline independence for device-loss convenience: any two enrolled services that release shares after user auth can reconstruct. Wallets MUST disclose this tradeoff at enrollment. Offline BRC-140 / BRC-75 paths remain first-class and MUST remain available without any service.
+A common enrollment scheme is threshold 2 of 3 total shares. Other thresholds are permitted if the wallet and user agree on the scheme before deposit.
 
 ### User identity handle
 
 `userIdHash` is a **64-character lowercase hex** SHA-256 digest used as the storage key at each service.
 
-For email OTP auth, the normative binding is:
+For email OTP auth:
 
 ```
 userIdHash = hex( SHA-256( UTF-8( normalize(email) ) ) )
 normalize(email) = trim + lowercase
 ```
 
-Wallets and services MUST use the same normalization before hashing. Services MUST treat `userIdHash` as an opaque key and MUST NOT require the raw email on share endpoints (email appears only in auth start/verify as needed by the operator).
+Wallets and services MUST use the same normalization before hashing. Share endpoints identify the record by `userIdHash` only.
 
-Other auth methods MAY define their own preimage for `userIdHash` in a future revision; v1 documents the email binding above because it matches deployed practice.
+`userIdHash` is a stable lookup key, not an anonymity mechanism: an operator that learns the email during authentication can recompute the hash and associate it with the stored share. Other auth methods MAY define a different preimage in a future revision.
 
 ### HTTP profile
 
-Base URL is an HTTPS (or loopback HTTP for development) origin. Paths below are relative to that origin. JSON UTF-8 request/response bodies unless noted. Unknown JSON fields MUST be ignored by readers.
+Base URL is an HTTPS origin (loopback HTTP MAY be used for development). Paths are relative to that origin. JSON UTF-8 bodies. Unknown JSON fields MUST be ignored.
 
 #### `GET /info`
 
-Returns service metadata. No auth required.
+No auth required.
 
 ```json
 {
@@ -109,42 +97,33 @@ Returns service metadata. No auth required.
 
 | Field | Requirement | Meaning |
 |-------|-------------|---------|
-| `name` | MUST | Human-readable operator name |
-| `version` | SHOULD | Operator software version string |
-| `role` | SHOULD | Constant `backup-service` for discovery |
+| `name` | MUST | Operator display name |
+| `version` | SHOULD | Operator software version |
+| `role` | SHOULD | Constant `backup-service` |
 | `authMethods` | MUST | Non-empty array of auth method identifiers |
-| `requiresPasswordWithOtp` | SHOULD | If `true`, wallet SHOULD also collect a user password/PIN and send it on retrieve per operator policy (extension; see Auth) |
-| `lifecycle` | MUST | Operator lifecycle block (below) |
+| `requiresPasswordWithOtp` | SHOULD | If `true`, retrieve (and optionally enroll) requires an additional password/PIN field under the operator’s documented policy |
+| `lifecycle` | MUST | Operator lifecycle block |
 
-#### Lifecycle / shutdown signaling
-
-Operators MUST publish planned shutdown so wallets can urge rotation before shares become unreachable.
+#### Lifecycle
 
 | `lifecycle.status` | Meaning |
 |--------------------|---------|
-| `active` | Normal enroll + retrieve |
-| `sunset` | Still serving retrieve; MUST reject new enrolls (or wallet MUST treat enroll as forbidden) |
-| `retired` | Gone or past `retireAt`; retrieve MUST fail |
+| `active` | Enroll and retrieve allowed |
+| `sunset` | Retrieve allowed; new enrolls MUST be rejected |
+| `retired` | Retrieve MUST fail |
 
 | Field | Requirement | Meaning |
 |-------|-------------|---------|
-| `sunsetAt` | MAY | When sunset began / begins (RFC 3339 UTC) |
-| `retireAt` | SHOULD when sunsetting | Last moment retrieve is expected to work |
-| `message` | MAY | Human explanation |
-| `successorUrl` | MAY | Suggested replacement backup-service base URL |
+| `sunsetAt` | MAY | RFC 3339 UTC |
+| `retireAt` | SHOULD when sunsetting | Last expected retrieve time (RFC 3339 UTC) |
+| `message` | MAY | Operator explanation |
+| `successorUrl` | MAY | Suggested replacement base URL |
 
-**Wallet behavior**
+Wallets SHOULD refresh `/info` for enrolled URLs and stop new enrolls when status is not `active`. Operators SHOULD provide a sunset window before `retireAt`.
 
-1. Refresh `/info` for each enrolled URL periodically (on launch and at least daily while the wallet runs is sufficient).
-2. If `sunset` / `retired` / `retireAt` within 90 days: warn the user to rotate.
-3. **Rotate:** retrieve (while still possible) → enroll at a replacement URL → delete old enrollment when delete is available.
-4. Recommend operators advertise ≥ 90 days between `sunset` and `retireAt`. Absence of signaling does not remove the need for offline backup.
-
-#### Auth (email OTP v1)
+#### Auth (email OTP)
 
 ##### `POST /auth/start`
-
-Request:
 
 ```json
 { "email": "user@example.com" }
@@ -159,11 +138,9 @@ Response (`200`):
 }
 ```
 
-Operators MUST deliver a one-time code out of band (email). Development-only fields such as `devCode` MUST NOT appear in production deployments.
+The operator delivers a one-time code out of band. Production deployments MUST NOT return the code in the HTTP response.
 
 ##### `POST /auth/verify`
-
-Request:
 
 ```json
 {
@@ -182,15 +159,13 @@ Response (`200`):
 }
 ```
 
-Subsequent share endpoints use `Authorization: Bearer <token>`.
+Share endpoints use `Authorization: Bearer <token>`.
 
-`authMethods` MAY list additional schemes later (`PhoneOtp`, etc.). Wallets MUST skip services whose methods they do not implement.
-
-When `requiresPasswordWithOtp` is `true`, the service MAY require an additional `password` / `recoveryPin` field on `/share/retrieve` (and optionally enroll). The precise field name SHOULD be documented by the operator; wallets that cannot satisfy the policy MUST not enroll that service.
+Wallets MUST skip services whose `authMethods` they do not implement. When `requiresPasswordWithOtp` is `true`, the service MAY require an additional password/PIN on share operations as documented by the operator.
 
 #### Share endpoints
 
-All share endpoints require a valid bearer session. Bodies use:
+All share endpoints require a valid bearer session.
 
 ```json
 {
@@ -199,15 +174,13 @@ All share endpoints require a valid bearer session. Bodies use:
 }
 ```
 
-(`share` only on enroll / rotate.)
+(`share` only where noted.)
 
 ##### `POST /share/enroll`
 
-Store exactly one share for `userIdHash`.
-
-* MUST validate `share` as BRC-140 backup serialization (`x.y.threshold.integrity`).
-* MUST overwrite or reject-duplicate per operator policy; wallets SHOULD treat a second enroll for the same `userIdHash` as rotate-equivalent and prefer `/share/rotate` when implemented.
-* MUST fail with `403` when lifecycle forbids enroll (`sunset` / `retired` / past `retireAt`).
+* MUST validate `share` as BRC-140 backup serialization.
+* MUST fail with `403` when lifecycle forbids enroll.
+* Stores exactly one share for `userIdHash` (overwrite policy is operator-defined; `/share/rotate` SHOULD be preferred for explicit replacement).
 
 Response (`200`):
 
@@ -217,54 +190,54 @@ Response (`200`):
 
 ##### `POST /share/retrieve`
 
-Request: `{ "userIdHash" }`. Response (`200`):
+Request: `{ "userIdHash" }`.
+
+Response (`200`):
 
 ```json
 { "share": "<BRC-140 backup string>", "enrolledAt": "<RFC 3339>" }
 ```
 
-* MUST NOT return a share without successful auth under the service’s published policy.
+* MUST NOT return a share without successful auth under the service’s policy.
 * MUST fail when lifecycle is `retired` or past `retireAt`.
 * MUST `404` when no share is stored.
 
 ##### `POST /share/rotate` (SHOULD)
 
-Replace the stored share for `userIdHash` with a new BRC-140 string after auth. Same validation as enroll. Used after recovery or when migrating providers.
+Replace the stored share after auth. Same validation as enroll.
 
 ##### `POST /share/delete`
 
-Request: `{ "userIdHash" }`. Deletes any stored share. Response `{ "ok": true }` even if none existed (idempotent).
+Request: `{ "userIdHash" }`. Idempotent; response `{ "ok": true }`.
 
 ### Wallet requirements
 
-1. **Pluggable list** — durable prefs of backup-service base URLs; empty list MUST be valid.
-2. **No spend dependency** — send / BRC-100 connect MUST work with zero services.
-3. **One share per URL** — never deposit two shares from the same split to one origin.
-4. **Local reconstruct** — combine shares only on device; then re-wrap into the wallet’s normal vault.
-5. **Offline first** — BRC-140 user-held shares and/or BRC-75 remain available without services.
-6. **Lifecycle UX** — surface sunset warnings and offer rotate while retrieve still works.
-7. **Honest copy** — enrollment UI MUST NOT claim a service can move funds or that HandCash (or any single vendor) is required to recover.
+1. Support a list of backup-service base URLs; an empty list MUST be valid.
+2. Ordinary spend / BRC-100 use MUST NOT depend on any backup service.
+3. Deposit at most one share from a given split to a given service origin.
+4. Reconstruct only locally.
+5. Keep offline BRC-140 and/or BRC-75 recovery available without services.
 
 ### Security considerations
 
 | Risk | Mitigation |
 |------|------------|
 | Single service compromised | Threshold ≥ 2; one share insufficient |
-| Two services collude after user auth (2-of-3 service-majority) | Accepted tradeoff of opt-in convenience path; disclose at enroll; prefer hybrid (user-held + services) when possible |
-| OTP / inbox takeover | Prefer `requiresPasswordWithOtp: true` for high-value operators; rate-limit auth; short-lived bearer tokens |
-| Malicious `/info` or successor URL | Wallet SHOULD confirm successor with the user before auto-rotating |
-| Operator silent disappearance | Offline BRC-140 / BRC-75 remain the backstop; multi-provider enrollment reduces blast radius |
-| Service stores wrong share format | Reject non-BRC-140; integrity tag checked at reconstruct |
+| Colluding services | Threshold and enrollment topology determine exposure; wallets MUST NOT send ≥ threshold shares to one party |
+| OTP / inbox takeover | Short-lived tokens; optional `requiresPasswordWithOtp`; auth rate limiting |
+| Email↔share linkage | Operator that authenticates the email can link it to `userIdHash` and the share; treat operators as share custodians for that record |
+| Operator disappearance | Multi-provider enrollment and offline BRC-140 / BRC-75 |
+| Malformed shares | Reject non-BRC-140; verify integrity at reconstruct |
 
-A backup service that can authenticate a user and holds a share is a **sensitive** system: protect transport with TLS, minimize logs of share material, and encrypt shares at rest under an operator key that is not the user’s root key.
+Protect share transport with TLS. Minimize logging of share material. Encrypt shares at rest under an operator key that is not the user’s root key.
 
 ## Implementations
 
-1. **HandCash Desktop** — Settings → Backup services (empty default list); enroll / restore against multiple URLs; BRC-140 split/reconstruct locally (`feat/backup-services`).
-2. **HandCash open backup-service** — runnable share-vault reference (`HANDCASH-DESKTOP/backup-service`): `/info`, email OTP (dev), enroll / retrieve / delete, lifecycle tooling, local 2-of-3 cluster smoke test.
+1. HandCash Desktop — multi-URL backup-service client and local BRC-140 split/reconstruct (`feat/backup-services`).
+2. HandCash `backup-service` — reference share vault implementing this profile.
 
 ## References
 
 - <a name="footnote-1">1</a>: [BRC-140 — Threshold Key Sharing and Backup via Shamir's Secret Sharing Scheme](../key-derivation/0140.md)
 - <a name="footnote-2">2</a>: [BRC-100 — Unified Wallet-to-Application Interface](./0100.md)
-- <a name="footnote-3">3</a>: HandCash Desktop backup services proposal and reference server — https://github.com/HandCash/HANDCASH-DESKTOP (branch `feat/backup-services`)
+- <a name="footnote-3">3</a>: https://github.com/HandCash/HANDCASH-DESKTOP (branch `feat/backup-services`)

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -36,3 +36,4 @@ BRC | Standard
 116  | [Wallet Permissions and Counterparty Trust](./0116.md)
 123  | [Basket Permission Scheme Registry and Governance](./0123.md)
 219  | [Wallet Permission Prompt Liveness Contract](./0219.md)
+232  | [Pluggable Backup Services for BRC-140 Share Vaults](./0232.md)


### PR DESCRIPTION
## Summary

Adds **BRC-153: Latched 1Sat Provenance** — an optional transfer profile for basket `1sat` that applies BOLT-style transaction latching so tip→origin legitimacy can be verified in **O(1)** instead of replaying a growing BEEF path on every hop.

Numbered **153** (not 151) because BRC-151 is already assigned to opinions.

### Why

[BRC-150](./tokens/0150.md) v2 remittance proves tip→origin offline, but remittance size and verify cost grow with transfer depth. Deep histories blow remittance budgets; wallets then omit proof rather than truncate.

BRC-153 keeps 1Sat origin theory and [BRC-147](./tokens/0147.md) basket semantics, and uses a paired **proof latch** UTXO (`1sat-latch`) so receivers only need the current tip, its latch, and one inductive hop.

### What this BRC defines

- Companion basket **`1sat-latch`** (not spendable change)
- Latch state + inductive rule (origin immutable; tip/parentLatch advance each settle)
- **Commit + Settle** transfer flow (or co-dependent / soft-latch settle)
- Provenance remittance **v3** (`mode: "latched"`) — no `beefB64` / `path`
- Legacy bootstrap via BRC-150 v2 → genesis latch
- Compatibility: v2 remains valid forever for unlatched tips; senders fall back when the counterparty does not advertise latch support

### Index / cross-links

- New: `tokens/0153.md`
- Updates: `tokens/0147.md`, `tokens/0150.md`, `tokens/README.md`, `README.md`, `SUMMARY.md`

### Reference implementation

HandCash Desktop ships a soft-latch path (tip + P2PKH latch, v3 remittance with relative `OUTPUT:N` refs). Full BOLT covenant Commit/Settle remains a hardening path; script encoding is implementation-defined in v1 of this BRC.

## Test plan

- [ ] Confirm **153** is free in the registry (151/152 remain opinions)
- [ ] Spec links resolve: 147 ↔ 150 ↔ 153, BRC-46/100/37/62/95
- [ ] v3 JSON rejects hybrids that also carry `beefB64` / `path`
- [ ] Genesis latch + legacy bootstrap path is unambiguous
- [ ] Security section covers orphan tips, tag spoofing, reorg, fee griefing