### PR TITLE
Add Luke Rohenaz as co-author of BRC-169 and BRC-218

### DIFF
--- a/apps/0218.md
+++ b/apps/0218.md
@@ -1,6 +1,6 @@
 # BRC-218: Chat-Native Command Grammar for the Metanet
 
-Crumbs, Deggen, BrandonC
+Crumbs, Deggen, BrandonC, Luke Rohenaz
 
 ## Abstract
 

--- a/peer-to-peer/0169.md
+++ b/peer-to-peer/0169.md
@@ -1,6 +1,6 @@
 # BRC-169: Universal Handle Addressing and Resolution for the Metanet
 
-Crumbs, Deggen, BrandonC
+Crumbs, Deggen, BrandonC, Luke Rohenaz
 
 ## Abstract
 


### PR DESCRIPTION
Adds Luke Rohenaz to the author line of two merged proposals, at the authors' direction.

- `peer-to-peer/0169.md` (BRC-169: Universal Handle Addressing and Resolution for the Metanet, merged in #184)
- `apps/0218.md` (BRC-218: Chat-Native Command Grammar for the Metanet, merged in #185)

One line changed in each file. No normative content, cross-references, or index entries are touched, so the standards table, `SUMMARY.md`, and the category READMEs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)