### PR TITLE
BRC-156: Phase 1b latch state + Phase 3 hardened alternating proofs

### DIFF
--- a/tokens/0156.md
+++ b/tokens/0156.md
@@ -2,7 +2,8 @@
 
 Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
-**Status:** Draft — Phase 1b reference implementation in HandCash Desktop (soft-latch + on-chain latch state)
+**Status:** Draft — HandCash Desktop reference: soft-latch + Phase 3 hardened
+alternating delayed-proof Commit/Settle for identity-key peers
 
 ## Abstract
 
@@ -114,7 +115,7 @@ State MUST include at minimum:
 | `tip` | MUST | Tip outpoint this latch is currently paired with. |
 | `parentLatch` | MUST except genesis latch | Outpoint of the latch consumed to create this latch. `null` or omitted only for the **genesis latch** after bootstrap. |
 | `originScriptHash` | SHOULD | Hash of the origin locking script (or commitment thereto) to bind induction to the inscribed sat. |
-| `schema` | MUST | Latch schema version. This BRC defines `1`. |
+| `schema` | MUST | Latch schema version: `1` soft compatibility, `2` hardened. |
 
 **Inductive rule:** A Settle tx is valid only if it proves that the new latch’s `parentLatch` was consumed, the spent tip matches the old latch’s `tip`, and `origin` is unchanged from the parent latch. Thus counterfeiting a latched tip requires forging an ancestor latch or origin — equivalent to breaking a BOLT token chain.
 
@@ -170,6 +171,24 @@ OP_FALSE OP_RETURN "BRC156" {"schema":1,"origin":"<txid_vout>","tip":"OUTPUT:0",
 | `tip` | MUST | Tip this state describes. `OUTPUT:N` when the settle txid is not yet known. |
 | `parentLatch` | MUST | Consumed latch, or the genesis sentinel. |
 | `name`, `app`, `mimeType` | MAY | Display hints so a receiver can render without any indexer. |
+
+Schema **2** (hardened) additionally requires:
+
+| Field | Requirement | Notes |
+|-------|-------------|-------|
+| `mode` | MUST | `"hardened"` |
+| `proofOutpoint` | MUST | Delayed proof from the **previous** owner's Commit (vout1). Settle MUST consume this proof — never the sibling proof created in the current Commit. |
+| `latch` | SHOULD | Current Commit sibling proof (`OUTPUT:N` allowed) for discovery/internalization. |
+| `beacon` | MAY | Exactly 2-sat P2PKH discovery latch. Required when the consensus proof is non-P2PKH. |
+| `originScriptHash` | MUST | Lowercase SHA-256 of the origin locking script. Immutable. |
+| `ownerKeyHash` | MUST | HASH160 of the recipient public key authorized to continue the chain. |
+| `commitTxid` | MUST | Commit transaction in the current pair. |
+| `settleTxid` | MUST | `"SELF"`; the verifier binds it to the transaction carrying this state. A literal self-txid is impossible because it would recursively change the txid. |
+
+Hardened induction is **BOLT-style alternating delayed proofs**: each Settle
+verifies a fixed Tx set (current Settle + Commit, prior Settle, proof Commit)
+in O(1). A sliding parent/grandparent window is **not** sufficient. A marker
+prefix plus CHECKSIG (or any forgeable structural pattern) is **not** hardened.
 
 Receivers MUST match `tip` against the output index of the tip being classified, so a batched Settle carrying several items cannot bind the wrong identity to a tip. Receivers MUST treat state as a **claim** carried by the transfer, verified by latch interdependency — not as an authority on canonical 1Sat ordinal numbering.
 
@@ -280,6 +299,24 @@ Implementations MAY reuse BOLT script templates where applicable; interoperabili
 
 Wallets SHOULD retain [BRC-150](./0150.md) v2 builders for at least **24 months** after shipping v3 sends.
 
+### Normative authenticity fallback order
+
+Wallets MUST evaluate an incoming collectable in this order:
+
+1. **BRC-156 schema 2 hardened induction** — verify the bounded alternating
+   delayed-proof Tx set and immutable `originScriptHash`. Success is
+   authenticated in O(1). Soft-latch schema-1 state alone is **not** this tier.
+2. **BRC-150 v2** — when hardened state is absent or invalid, verify the full
+   one-sat path, BEEF, and origin `ord` envelope.
+3. **Indexer / chain discovery** — only when neither proof is available. This
+   MAY identify and display the item, but MUST be labelled **unproven** and MUST
+   NOT be cached or advertised as cryptographic authenticity.
+
+A bare P2PKH address does not reveal the recipient public key needed by the
+hardened covenant. Senders MUST use BRC-150 / soft-latch for such recipients.
+Capability-aware identity-key peers MUST use hardened BRC-156 when both wallets
+support it; bare P2PKH recipients keep soft-latch / BRC-150.
+
 Indexers (OrdFS, GorillaPool, etc.) remain useful for **media URLs and discovery**; they are not required for latched legitimacy verification.
 
 ## Security considerations
@@ -327,9 +364,29 @@ Scope note: identity here is the item as latched — canonical global ordinal nu
 
 * Genesis latch from legacy tips is automatic on first latched send (`parentLatch` = genesis sentinel).
 
-### Phase 3 — Hardened Commit + Settle (optional)
+### Phase 3 — Hardened Commit + Settle
 
-* BOLT-style covenant script templates + two-tx Commit/Settle pair when on-chain induction is required. Latch value MAY exceed 2; locking script MUST carry a marker.
+Schema 2 makes authenticity, not merely identity, constant-time:
+
+* The first hardened Commit MUST spend a legacy tip that passed complete
+  BRC-150 verification. Its state commits to the origin locking script with
+  `originScriptHash = SHA256(originLockingScript)`.
+* Later transfers use **alternating delayed proofs**: Commit creates tip +
+  next proof; Settle spends the tip and the **previous** owner's proof (never
+  the sibling proof from the current Commit).
+* The locking scripts MUST authenticate transaction context on chain via a
+  consensus covenant (clean-room scrypt-ts / PUSHTX-class). A marker prefix plus
+  owner `CHECKSIG`, a sliding parent/grandparent window, or any forgeable
+  structural pattern is **not** hardened BRC-156.
+* The recipient tip remains exactly 1 satoshi. The address-discovery beacon
+  remains exactly 2 satoshis. Hardened proof outputs are 3 satoshis and MUST
+  NOT be treated as funds or collectables.
+* Before broadcast the sender MUST execute every covenant input locally against
+  its source transaction. Receivers MUST reject altered outputs, missing
+  co-spends, wrong owner keys, replayed proofs and forged genesis state.
+* Verification reads a fixed Tx set: current Settle + Commit, prior Settle,
+  delayed-proof Commit, and the origin script commitment. It MUST NOT replay
+  the ownership chain.
 
 ### Phase 4 — Interop
 
@@ -342,7 +399,12 @@ Scope note: identity here is the item as latched — canonical global ordinal nu
 
 ## Implementations
 
-* **HandCash Desktop** (reference — soft-latch 2-sat companion + on-chain latch state OP_RETURN; BRC-150 v2 authenticity retained; O(1) hardened induction pending Phase 3): `oneSatLatch.ts` (`buildLatchStateScript` / `parseLatchStateScript` / `findLatchStateForTip`), `oneSatImport.resolveLatchedTip`, `collectables.sendCollectable`.  
+* **HandCash Desktop** (reference — soft-latch for bare addresses; hardened
+  alternating delayed-proof Commit/Settle live for identity-key peers; BRC-150
+  v2 bootstrap/fallback; authenticity ladder in `oneSatAuthenticity.ts`):
+  `oneSatLatch.ts`, `oneSatHardenedLatch.ts`, `oneSatHardenedSend.ts`,
+  `oneSatHardenedReceive.ts`, `oneSatImport.resolveLatchedTip`,
+  `collectables.sendCollectable`.
   Spec: `docs/bsva/brcs/tokens/0156.md`.
 * **Reference — BOLT:** [boltassociation.com](https://boltassociation.com/), [BetaBOLT](https://github.com/bsvhackathon/BetaBOLT) (script patterns only; not 1Sat-specific).
 

--- a/tokens/0156.md
+++ b/tokens/0156.md
@@ -2,7 +2,7 @@
 
 Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
-**Status:** Draft — Phase 1 reference implementation in HandCash Desktop
+**Status:** Draft — Phase 1b reference implementation in HandCash Desktop (soft-latch + on-chain latch state)
 
 ## Abstract
 
@@ -104,7 +104,9 @@ Tags on latch outputs:
 
 ### Latch state (inductive payload)
 
-Each latch UTXO carries ** latch state** sufficient for the next Settle to verify one inductive step. State MUST be recoverable from the locking script and/or taproot/script payload and MUST include at minimum:
+Each latched Settle MUST publish **latch state** sufficient for the next transfer to verify one inductive step. Soft-latch (Phase 1a/1b) recovers that state from the **latch state output** defined below — not from the 2-satoshi P2PKH latch locking script, which remains a standard address payment so scanners can find it. Hardened latch (Phase 3) MAY instead embed state in the latch locking script.
+
+State MUST include at minimum:
 
 | Field | Requirement | Description |
 |-------|-------------|-------------|
@@ -113,8 +115,6 @@ Each latch UTXO carries ** latch state** sufficient for the next Settle to verif
 | `parentLatch` | MUST except genesis latch | Outpoint of the latch consumed to create this latch. `null` or omitted only for the **genesis latch** after bootstrap. |
 | `originScriptHash` | SHOULD | Hash of the origin locking script (or commitment thereto) to bind induction to the inscribed sat. |
 | `schema` | MUST | Latch schema version. This BRC defines `1`. |
-
-Exact script encoding (push layout, template address, covenant) is **implementation-defined** in v1 of this BRC, provided nodes validate the interdependency and inductive fields at spend time. A normative script template MAY be added in a revision once reference implementations exist on testnet.
 
 **Inductive rule:** A Settle tx is valid only if it proves that the new latch’s `parentLatch` was consumed, the spent tip matches the old latch’s `tip`, and `origin` is unchanged from the parent latch. Thus counterfeiting a latched tip requires forging an ancestor latch or origin — equivalent to breaking a BOLT token chain.
 
@@ -133,23 +133,47 @@ Every **latched transfer** to a new owner MUST use two transactions broadcast as
 #### 2. Settle transaction
 
 * **Inputs:** Tip (1 sat) + active latch UTXO (must match latch state `tip`) + BSV for fees.
-* **Outputs:**
-  * **Recipient tip** (1 sat, basket `1sat`) with [BRC-147](./0147.md) `customInstructions`.
-  * **Recipient latch** (basket `1sat-latch`) with latch state:
-    * same `origin`
-    * `tip` = recipient tip outpoint
-    * `parentLatch` = consumed latch outpoint
-* **Purpose:** Move ownership; receiver can verify in O(1) from recipient tip + recipient latch + parent latch outpoint (spent in this tx).
+* **Outputs (soft-latch settle-style, normative layout):**
+  1. **Recipient tip** — 1 sat, basket `1sat` (vout 0).
+  2. **Recipient latch** — exactly 2 sats, plain P2PKH to the recipient (vout 1). Discovery only; locking script carries no state.
+  3. **Latch state output** — 0 sats, `OP_FALSE OP_RETURN "BRC156" <json>` (see below). Identity for the tip.
+* **Purpose:** Move ownership. Receiver verifies arrival from tip + 2-sat latch on an address scan, and names the item from the latch state output in the same transaction — O(1), no indexer.
 
 ```text
 Legacy bootstrap (once):
   BRC-150 v2 full path + origin ord check  →  genesis latch + tip
 
-Each latched transfer:
-  Commit:  tip ──► tip + latch'
-  Settle:  tip + latch' ──► tip'' (to Bob) + latch''
-  Verify:  O(1) on tip'' + latch'' (+ spent parent visible in tx)
+Each soft-latch transfer (Phase 1a/1b):
+  Settle: tip (+ prior latch) ──► tip'' (1) + latch'' (2) + state (0, OP_RETURN)
+  Discover: address scan finds tip'' + latch''
+  Identify: parse state from the same tx  (no indexer)
 ```
+
+### Latch state output (on chain, normative)
+
+Baskets, tags and `customInstructions` are BRC-100 **local wallet state**. None of it reaches a counterparty paid at an address. A latch whose state exists only in local metadata therefore proves *that* an item arrived while saying nothing about *which* item — leaving receivers to ask an indexer, which is the O(N) third-party dependency this BRC exists to remove.
+
+Every Settle transaction MUST therefore carry a **latch state output**:
+
+* `satoshis` MUST be **0** and the script MUST begin `OP_FALSE OP_RETURN`, so the output is provably unspendable and never appears in a recipient's UTXO scan.
+* First pushdata MUST be the ASCII protocol marker `BRC156`.
+* Second pushdata MUST be UTF-8 JSON carrying the latch state.
+
+```text
+OP_FALSE OP_RETURN "BRC156" {"schema":1,"origin":"<txid_vout>","tip":"OUTPUT:0","parentLatch":"<txid_vout>"}
+```
+
+| Field | Requirement | Notes |
+|-------|-------------|-------|
+| `schema` | MUST | Latch schema version (`1`). |
+| `origin` | MUST | Origin outpoint (underscore form). |
+| `tip` | MUST | Tip this state describes. `OUTPUT:N` when the settle txid is not yet known. |
+| `parentLatch` | MUST | Consumed latch, or the genesis sentinel. |
+| `name`, `app`, `mimeType` | MAY | Display hints so a receiver can render without any indexer. |
+
+Receivers MUST match `tip` against the output index of the tip being classified, so a batched Settle carrying several items cannot bind the wrong identity to a tip. Receivers MUST treat state as a **claim** carried by the transfer, verified by latch interdependency — not as an authority on canonical 1Sat ordinal numbering.
+
+Because the recipient already retrieves the Settle transaction to internalize its outputs, this makes identification **O(1) with no indexer**: the transfer names itself.
 
 ### Provenance remittance (v3)
 
@@ -287,9 +311,17 @@ Phased rollout recommended for HandCash and other BRC-100 wallets:
 
 HandCash ships tip (1 sat) + latch (**exactly 2** sats, P2PKH) in one settle-style `createAction`, co-spending the prior latch when present. Receivers classify `satoshis === 2` as latch dust (never tip, never funding).
 
-**Authenticity remains [BRC-150](./0150.md) v2** (full tip→origin BEEF remittance on the tip). Soft-latch P2PKH does **not** carry inductive latch state in the locking script, so structural v3 remittance alone MUST NOT be treated as proven origin binding. O(1) authenticity without a growing BEEF is Phase 3 (hardened Commit/Settle + on-chain induction).
+**Authenticity remains [BRC-150](./0150.md) v2** (full tip→origin BEEF remittance on the tip). Soft-latch P2PKH does **not** carry inductive latch state in its *locking* script, so structural v3 remittance alone MUST NOT be treated as proven origin binding. O(1) authenticity without a growing BEEF is Phase 3 (hardened Commit/Settle + on-chain induction).
 
 `isLatchedSendEnabled()` returns `true` for the companion latch UTXO; senders still attach v2 remittance when they can build it.
+
+### Phase 1b — On-chain latch state ✅
+
+HandCash writes the *Latch state output* above into every soft-latch Settle. Receivers resolve a latched tip's `origin` (plus display hints) directly from the Settle transaction they already fetch, so a latched receive completes with **no ordinal indexer and no ancestry walk**.
+
+The GorillaPool / WhatsOnChain ancestry walk is retained strictly as the **bootstrap path for legacy unlatched tips**, where nothing on chain states what the sat carries. It MUST NOT be what a latched receive waits on.
+
+Scope note: identity here is the item as latched — canonical global ordinal numbering is deliberately out of scope, since resolving it is precisely what reintroduces indexer dependence.
 
 ### Phase 2 — Bootstrap
 
@@ -310,7 +342,7 @@ HandCash ships tip (1 sat) + latch (**exactly 2** sats, P2PKH) in one settle-sty
 
 ## Implementations
 
-* **HandCash Desktop** (reference — soft-latch companion UTXO + BRC-150 v2 authenticity; O(1) v3 induction pending Phase 3): `oneSatLatch.ts`, `oneSatProvenance.verifyProvenance`, `collectables.sendCollectable`.  
+* **HandCash Desktop** (reference — soft-latch 2-sat companion + on-chain latch state OP_RETURN; BRC-150 v2 authenticity retained; O(1) hardened induction pending Phase 3): `oneSatLatch.ts` (`buildLatchStateScript` / `parseLatchStateScript` / `findLatchStateForTip`), `oneSatImport.resolveLatchedTip`, `collectables.sendCollectable`.  
   Spec: `docs/bsva/brcs/tokens/0156.md`.
 * **Reference — BOLT:** [boltassociation.com](https://boltassociation.com/), [BetaBOLT](https://github.com/bsvhackathon/BetaBOLT) (script patterns only; not 1Sat-specific).
 


### PR DESCRIPTION
## Summary
Updates **[BRC-156](https://github.com/bsv-blockchain/BRCs/blob/master/tokens/0156.md)** with:

### Phase 1b (soft-latch)
- Soft-latch Settle: tip (1) + latch (exactly 2, plain P2PKH) + latch state (`OP_FALSE OP_RETURN "BRC156" <json>`)
- Receivers name latched tips from the settle tx — no ordinal indexer / ancestry walk
- Indexer ancestry walk only for legacy unlatched bootstrap

### Phase 3 (hardened)
- Schema 2 requires `proofOutpoint` (delayed proof from previous Commit) — **not** a sliding parent/grandparent window
- Alternating delayed proofs: Settle consumes proof N−1, never current sibling proof
- Marker + CHECKSIG / forgeable structural patterns are **not** hardened
- Authenticity ladder: hardened O(1) → BRC-150 v2 → indexer **unproven**
- Soft-latch for bare P2PKH; hardened for identity-key peers
- Reference: HandCash Desktop **v1.2.84** (`oneSatHardenedSend.ts` / `oneSatHardenedLatch.ts` / `oneSatHardenedReceive.ts`)

## Test plan
- [ ] Confirm this amends `tokens/0156.md` only (no renumber)
- [ ] Soft-latch 2-sat discovery rule unchanged
- [ ] Schema-2 `proofOutpoint` + alternating delayed-proof language is unambiguous
- [ ] Cross-links from 147/150 still point at 156