### PR TITLE
Add Luke Rohenaz as co-author of BRC-168

### DIFF
--- a/apps/0168.md
+++ b/apps/0168.md
@@ -1,6 +1,6 @@
 # BRC-168: Verifiable Time Allocation
 
-Crumbs
+Crumbs, Luke Rohenaz
 
 ## Abstract
 


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Adds Luke Rohenaz to the author line of `apps/0168.md`, at the authors' direction.

The addition was intended to be part of #195 but did not make it in: the co-author commit was pushed to the branch as that PR was being merged, so the merge captured the previous commit. This carries the one line over. It follows #199, which did the same for BRC-169 and BRC-218.

One line changed, in the author line only. No normative content, cross-references, or index entries are touched, so the standards table, `SUMMARY.md`, and `apps/README.md` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)