### PR TITLE
BRC-150: extend prior remittance + parent tip inherit

### DIFF
--- a/tokens/0150.md
+++ b/tokens/0150.md
@@ -64,11 +64,12 @@ Provenance objects with `v !== 2`, or path-only packages without `beefB64`, are 
 A conforming sender transferring a `1sat` tip under [BRC-147](./0147.md) SHOULD:
 
 1. Determine the true `origin` of the tip (indexer-assisted discovery is allowed for *building* the package).
-2. Construct `path` tip→origin such that each consecutive pair with different transaction ids is related by a spend of the parent outpoint as an input to the child transaction.
-3. Assemble `beefB64` covering every transaction id appearing in `path`.
-4. Prefer AtomicBEEF ([BRC-95](../transactions/0095.md)) whose subject txid is the tip transaction.
-5. Self-verify using the Receiver rules below before broadcast.
-6. If a valid v2 package cannot be produced, the sender MUST NOT claim a verified origin via tags alone. The sender MAY omit `provenance`; receivers MUST then treat identity as unverified per [BRC-147](./0147.md).
+2. **Prefer extending a prior remittance** when the tip (or its immediate parent tip) already carries a verified v2 package: prepend the tip being proven to `path` and merge that tip’s transaction into `beefB64`. Do **not** re-walk full tip→origin lineage when an inductive extension verifies.
+3. Otherwise construct `path` tip→origin such that each consecutive pair with different transaction ids is related by a spend of the parent outpoint as an input to the child transaction.
+4. Assemble `beefB64` covering every transaction id appearing in `path`.
+5. Prefer a **full** BEEF serialization for remittance ancestry when AtomicBEEF would drop path parents (mined tips with no recursive dependencies). AtomicBEEF ([BRC-95](../transactions/0095.md)) remains allowed when it still covers the full `path`.
+6. Self-verify using the Receiver rules below before broadcast.
+7. If a valid v2 package cannot be produced, the sender MUST NOT claim a verified origin via tags alone. The sender MAY omit `provenance`; receivers MUST then treat identity as unverified per [BRC-147](./0147.md).
 
 Senders MUST NOT embed full inscription *content* solely for this remittance; envelope presence at origin is sufficient.
 
@@ -78,12 +79,18 @@ Given a candidate tip outpoint `T` and `customInstructions.provenance` with `v =
 
 1. **Parse** — Decode `beefB64` as BEEF ([BRC-62](../transactions/0062.md)) or AtomicBEEF ([BRC-95](../transactions/0095.md)). Failure → unproven.
 2. **Structure** — The BEEF MUST pass structural validation (e.g. `Beef.verifyValid`). Use of txid-only entries ([BRC-96](../transactions/0096.md)) is allowed only when the receiver already trusts those transactions by other means.
-3. **Atomic subject (when AtomicBEEF)** — If the bytes are AtomicBEEF, the subject txid MUST equal the tip’s transaction id.
-4. **Tip binding** — `provenance.tip` and `path[0]` MUST equal tip outpoint `T` after normalization.
-5. **Origin binding** — `path[path.length - 1]` MUST equal `provenance.origin`.
-6. **Ancestry** — For each consecutive pair `(child, parent)` in `path` with different transaction ids, the child transaction in the BEEF MUST spend `parent` as an input.
-7. **One-sat** — For each outpoint in `path` present in the BEEF with a known satoshi value, that value MUST be `1`.
-8. **Inscription** — The locking script of `origin` MUST contain a valid first `ord` envelope as defined by 1Sat Ordinals:
+3. **Atomic subject (when AtomicBEEF)** — If the bytes are AtomicBEEF, the subject txid MUST equal the tip’s transaction id (the tip named by `provenance.tip` after normalization).
+4. **Tip binding (direct)** — If `provenance.tip` and `path[0]` equal tip outpoint `T` after normalization, continue with steps 5–9 for that package.
+5. **Tip binding (parent remittance — settle-style)** — If step 4 fails, receivers **SHOULD** accept the package when all of the following hold (soft-latch / pre-broadcast remittance):
+   * `provenance.tip` and `path[0]` name a parent outpoint `P` (not `T`);
+   * the package verifies under steps 5–9 with held outpoint `P` (direct tip binding to `P`);
+   * transaction `T` spends `P` as a 1-satoshi input;
+   * output `T` is 1 satoshi.
+   This inductive hop exists because settle-style transfers often embed remittance for the *spent* tip before the new tip’s txid is known. Receivers that omit this step remain conforming for direct tip-bound packages but will treat settle-style remittances as unproven unless they rebuild lineage themselves.
+6. **Origin binding** — `path[path.length - 1]` MUST equal `provenance.origin`.
+7. **Ancestry** — For each consecutive pair `(child, parent)` in `path` with different transaction ids, the child transaction in the BEEF MUST spend `parent` as an input. For parent-remittance acceptance (step 5), the spend `T → P` is checked against transaction `T` (which MAY be obtained outside `beefB64`).
+8. **One-sat** — For each outpoint in `path` present in the BEEF with a known satoshi value, that value MUST be `1`.
+9. **Inscription** — The locking script of `origin` MUST contain a valid first `ord` envelope as defined by 1Sat Ordinals:
 
    ```
    OP_FALSE OP_IF <"ord"> … OP_ENDIF
@@ -91,7 +98,7 @@ Given a candidate tip outpoint `T` and `customInstructions.provenance` with `v =
 
    on a 1-sat output. Subsequent envelopes on the same sat MUST be ignored for origin identity (1Sat rule).
 
-9. **Headers (RECOMMENDED)** — Receivers SHOULD confirm BEEF merkle roots against a header source / ChainTracker per [BRC-67](../transactions/0067.md) when available.
+10. **Headers (RECOMMENDED)** — Receivers SHOULD confirm BEEF merkle roots against a header source / ChainTracker per [BRC-67](../transactions/0067.md) when available.
 
 On success, the receiver MAY treat `provenance.origin` as the proven origin for tip `T` and MAY use indexer metadata keyed by that origin for display.
 


### PR DESCRIPTION
## Summary
- Senders SHOULD extend a prior verified v2 remittance (prepend tip, merge tip tx) instead of re-walking lineage every hop.
- Receivers SHOULD accept settle-style **parent remittance** when the held tip spends `provenance.tip` (soft-latch embeds proof of the spent tip before the new tipid is known).
- Clarify full BEEF vs AtomicBEEF when ancestry would otherwise be dropped.

## Why
Soft-latch / settle-style transfers cannot name the new tip pre-broadcast. Without parent-inherit language, remittance is HandCash-private. Extend-on-send is how packages stay O(1) growth per hop instead of O(hops) rebuild.


Made with [Cursor](https://cursor.com)