### PR TITLE
docs(147): id/type tags, origin forms, tags vs CI

### DIFF
--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -86,7 +86,6 @@ Both tags and `customInstructions` travel with the output under [BRC-46](../wall
 
 * Put **filterable** facts in tags: `ordinal`, `origin:…`, `id:…`, `type:…`, and when useful `app:`, `collection:…`, `creator:…`.
 * Put the human **display name** in `customInstructions.name` when known (case-preserving).
-* Put **provenance** in `customInstructions.provenance` when available.
 * When this wallet can spend the output, SHOULD include spend fields in the same JSON object (`protocolID`, `keyID`, `counterparty`, …). Readers that do not understand a key MUST ignore it.
 
 **Writers SHOULD NOT** rely on a `name:` tag as the primary display name. A `name:` tag remains **MAY** so existing deployments stay conforming; new implementations SHOULD prefer CI `name` and MAY omit the tag.

--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -54,7 +54,7 @@ Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hi
 |-----|-------------|---------|
 | `ordinal` | SHOULD on conforming transfers and imports | Marks the output as an ordinal/inscription tip under this profile. |
 | `origin` or `origin:<outpoint>` | SHOULD when origin is known | Claimed inscription origin. Two forms — see rules below. |
-| `id:<string>` | SHOULD on outputs the wallet manages | Wallet-local unique id for this inventory row. Opaque to this profile; generation is wallet-defined. MUST be unique among the wallet’s `1sat` outputs (compared case-insensitively). MUST NOT contain spaces. Because tags are commonly lowercased in storage, writers SHOULD use a case-insensitive alphabet (e.g. lowercase hex) and readers MUST treat ids as case-insensitive. |
+| `id:<string>` | SHOULD when the wallet wants a stable list key | Wallet-local handle for this row (e.g. so `listOutputs` can find it by tag). Opaque; generation is wallet-defined. Not global identity. Prefer no spaces; treat equality as case-insensitive if the wallet lowercases tags. |
 | `type:<type>/<subtype>` | SHOULD when the content type is known | IANA media type of the **origin** inscription (envelope content-type), with parameters removed — the substring before the first `;` (e.g. `type:image/png` from `image/png; charset=binary`). |
 | `name:<string>` | MAY (legacy) | Short display name in a tag. New writers SHOULD put display name in `customInstructions` instead (see [Tags vs customInstructions](#tags-vs-custominstructions)). If written, implementations SHOULD truncate to ≤ 80 UTF-8 code units. |
 | `app:<string>` | MAY | Application id for filtering (SHOULD truncate to ≤ 40). |
@@ -68,7 +68,7 @@ Rules:
   * `origin:<outpoint>` — this output is a later tip; `<outpoint>` is the chain origin (`dot` or `underscore` form; readers MUST treat both as the same outpoint per [Outpoint encoding](#outpoint-encoding)).
   * On self-keep transfer or re-file: if the source has `origin:<outpoint>`, copy that tag unchanged; if the source has bare `origin`, the spent outpoint **is** the origin — write `origin:<spent outpoint>` on the new output.
   * The origin tag is a wallet **claim**, not proof of chain membership ([BRC-150](./0150.md)).
-* **`id:`** — Local row key only (list by tag, correlate UI and spends). It is not an origin and MUST NOT be treated as global asset identity. Uniqueness and equality are **case-insensitive** (wallet storage often lowercases tags). A receiver MAY assign a new `id:` on import. Wallets that do not manage the row (e.g. a pure send to an external lock) need not stamp one on that output.
+* **`id:`** — Wallet-local list key for this inventory row. Not an origin and MUST NOT be treated as global asset identity. Unique among this wallet’s `1sat` outputs when present. A receiver MAY assign a new `id:` on import. Skip on outputs this wallet does not manage.
 * **`type:`** — Describes the origin inscription’s content type, not whatever the current tip’s locking script contains. Self-keep transfers SHOULD copy `type:…` forward with the origin claim rather than re-deriving it from a bare transfer output. Tag matching is exact; there is no prefix or wildcard form.
 * Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md) / BRC-46 spirit). Tag query via `listOutputs` uses existing `tags` / `tagQueryMode` fields.
 

--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -54,7 +54,7 @@ Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hi
 |-----|-------------|---------|
 | `ordinal` | SHOULD on conforming transfers and imports | Marks the output as an ordinal/inscription tip under this profile. |
 | `origin` or `origin:<outpoint>` | SHOULD when origin is known | Claimed inscription origin. Two forms — see rules below. |
-| `id:<string>` | SHOULD on outputs the wallet manages | Wallet-local unique id for this inventory row. Opaque to this profile; generation is wallet-defined. MUST be unique among the wallet’s `1sat` outputs. MUST NOT contain spaces. |
+| `id:<string>` | SHOULD on outputs the wallet manages | Wallet-local unique id for this inventory row. Opaque to this profile; generation is wallet-defined. MUST be unique among the wallet’s `1sat` outputs (compared case-insensitively). MUST NOT contain spaces. Because tags are commonly lowercased in storage, writers SHOULD use a case-insensitive alphabet (e.g. lowercase hex) and readers MUST treat ids as case-insensitive. |
 | `type:<type>/<subtype>` | SHOULD when the content type is known | IANA media type of the **origin** inscription (envelope content-type), with parameters removed — the substring before the first `;` (e.g. `type:image/png` from `image/png; charset=binary`). |
 | `name:<string>` | MAY (legacy) | Short display name in a tag. New writers SHOULD put display name in `customInstructions` instead (see [Tags vs customInstructions](#tags-vs-custominstructions)). If written, implementations SHOULD truncate to ≤ 80 UTF-8 code units. |
 | `app:<string>` | MAY | Application id for filtering (SHOULD truncate to ≤ 40). |
@@ -68,7 +68,7 @@ Rules:
   * `origin:<outpoint>` — this output is a later tip; `<outpoint>` is the chain origin (`dot` or `underscore` form; readers MUST treat both as the same outpoint per [Outpoint encoding](#outpoint-encoding)).
   * On self-keep transfer or re-file: if the source has `origin:<outpoint>`, copy that tag unchanged; if the source has bare `origin`, the spent outpoint **is** the origin — write `origin:<spent outpoint>` on the new output.
   * The origin tag is a wallet **claim**, not proof of chain membership ([BRC-150](./0150.md)).
-* **`id:`** — Local row key only (list by tag, correlate UI and spends). It is not an origin and MUST NOT be treated as global asset identity. A receiver MAY assign a new `id:` on import. Wallets that do not manage the row (e.g. a pure send to an external lock) need not stamp one on that output.
+* **`id:`** — Local row key only (list by tag, correlate UI and spends). It is not an origin and MUST NOT be treated as global asset identity. Uniqueness and equality are **case-insensitive** (wallet storage often lowercases tags). A receiver MAY assign a new `id:` on import. Wallets that do not manage the row (e.g. a pure send to an external lock) need not stamp one on that output.
 * **`type:`** — Describes the origin inscription’s content type, not whatever the current tip’s locking script contains. Self-keep transfers SHOULD copy `type:…` forward with the origin claim rather than re-deriving it from a bare transfer output. Tag matching is exact; there is no prefix or wildcard form.
 * Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md) / BRC-46 spirit). Tag query via `listOutputs` uses existing `tags` / `tagQueryMode` fields.
 

--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -87,7 +87,7 @@ Both tags and `customInstructions` travel with the output under [BRC-46](../wall
 * Put **filterable** facts in tags: `ordinal`, `origin:…`, `id:…`, `type:…`, and when useful `app:`, `collection:…`, `creator:…`.
 * Put the human **display name** in `customInstructions.name` when known (case-preserving).
 * Put **provenance** in `customInstructions.provenance` when available.
-* When this wallet can spend the output, MAY add spend fields to the same JSON object (`protocolID`, `keyID`, `counterparty`, …). Readers that do not understand a key MUST ignore it.
+* When this wallet can spend the output, SHOULD include spend fields in the same JSON object (`protocolID`, `keyID`, `counterparty`, …). Readers that do not understand a key MUST ignore it.
 
 **Writers SHOULD NOT** rely on a `name:` tag as the primary display name. A `name:` tag remains **MAY** so existing deployments stay conforming; new implementations SHOULD prefer CI `name` and MAY omit the tag.
 
@@ -112,9 +112,9 @@ When present for basket `1sat`, `customInstructions` MUST be a **UTF-8 JSON obje
 | `name` | string | SHOULD when known | Display name (case-preserving). Preferred over a `name:` tag. |
 | `app` | string | MAY | Application id (may mirror an `app:` tag for display). |
 | `provenance` | object | SHOULD on transfer when available | Provenance remittance; v2 in [BRC-150](./0150.md). |
-| `protocolID` | BRC-43 protocol | MAY | When this wallet manages the lock: derivation protocol for spend. |
-| `keyID` | string | MAY | When this wallet manages the lock: key id under that protocol. |
-| `counterparty` | string | MAY | When this wallet manages the lock: Type-42 counterparty if not self. |
+| `protocolID` | BRC-43 protocol | SHOULD when this wallet manages the lock | Derivation protocol for spend. |
+| `keyID` | string | SHOULD when this wallet manages the lock | Key id under that protocol. |
+| `counterparty` | string | SHOULD when this wallet manages the lock and counterparty is not self | Type-42 counterparty; omit (or `self`) when self. |
 
 Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers that do not understand `provenance` or spend fields MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)).
 

--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -53,13 +53,45 @@ Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hi
 | Tag | Requirement | Meaning |
 |-----|-------------|---------|
 | `ordinal` | SHOULD on conforming transfers and imports | Marks the output as an ordinal/inscription tip under this profile. |
-| `origin:<outpoint>` | SHOULD when origin is known | Claimed inscription origin (`dot` or `underscore` form). |
-| `name:<string>` | MAY | Short display name (implementations SHOULD truncate to ≤ 80 UTF-8 code units when writing). |
-| `app:<string>` | MAY | Creator / application id for filtering (SHOULD truncate to ≤ 40). |
+| `origin` or `origin:<outpoint>` | SHOULD when origin is known | Claimed inscription origin. Two forms — see rules below. |
+| `id:<string>` | SHOULD on outputs the wallet manages | Wallet-local unique id for this inventory row. Opaque to this profile; generation is wallet-defined. MUST be unique among the wallet’s `1sat` outputs. MUST NOT contain spaces. |
+| `type:<type>/<subtype>` | SHOULD when the content type is known | IANA media type of the **origin** inscription (envelope content-type), with parameters removed — the substring before the first `;` (e.g. `type:image/png` from `image/png; charset=binary`). |
+| `name:<string>` | MAY (legacy) | Short display name in a tag. New writers SHOULD put display name in `customInstructions` instead (see [Tags vs customInstructions](#tags-vs-custominstructions)). If written, implementations SHOULD truncate to ≤ 80 UTF-8 code units. |
+| `app:<string>` | MAY | Application id for filtering (SHOULD truncate to ≤ 40). |
 | `collection:<id>` / `collectionId:<id>` | MAY | Collection filter keys (synonyms). |
 | `creator:<id>` / `author:<id>` | MAY | Creator filter keys (synonyms of / complements to `app:`). |
 
-Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md) / BRC-46 spirit). Tag query via `listOutputs` uses existing `tags` / `tagQueryMode` fields.
+Rules:
+
+* **Origin tag** — One tag, two forms:
+  * bare `origin` — this output **is** the origin (mint / chain start).
+  * `origin:<outpoint>` — this output is a later tip; `<outpoint>` is the chain origin (`dot` or `underscore` form; readers MUST treat both as the same outpoint per [Outpoint encoding](#outpoint-encoding)).
+  * On self-keep transfer or re-file: if the source has `origin:<outpoint>`, copy that tag unchanged; if the source has bare `origin`, the spent outpoint **is** the origin — write `origin:<spent outpoint>` on the new output.
+  * The origin tag is a wallet **claim**, not proof of chain membership ([BRC-150](./0150.md)).
+* **`id:`** — Local row key only (list by tag, correlate UI and spends). It is not an origin and MUST NOT be treated as global asset identity. A receiver MAY assign a new `id:` on import. Wallets that do not manage the row (e.g. a pure send to an external lock) need not stamp one on that output.
+* **`type:`** — Describes the origin inscription’s content type, not whatever the current tip’s locking script contains. Self-keep transfers SHOULD copy `type:…` forward with the origin claim rather than re-deriving it from a bare transfer output. Tag matching is exact; there is no prefix or wildcard form.
+* Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md) / BRC-46 spirit). Tag query via `listOutputs` uses existing `tags` / `tagQueryMode` fields.
+
+### Tags vs customInstructions
+
+Both tags and `customInstructions` travel with the output under [BRC-46](../wallet/0046.md) / [BRC-37](../outpoints/0037.md). They serve different jobs:
+
+| | **Tags** | **`customInstructions`** |
+|--|----------|---------------------------|
+| Role | Query and filter keys (`listOutputs` + `tags` / `tagQueryMode`) | Single remittance object: display, optional spend metadata, provenance |
+| Case | Wallet storage commonly lowercases tags | JSON string values can preserve case |
+| Authority | Non-authoritative claims / local metadata | Same for display fields; spend fields only describe how *this* wallet unlocks the lock; provenance is verified per [BRC-150](./0150.md) |
+
+**Writers SHOULD:**
+
+* Put **filterable** facts in tags: `ordinal`, `origin:…`, `id:…`, `type:…`, and when useful `app:`, `collection:…`, `creator:…`.
+* Put the human **display name** in `customInstructions.name` when known (case-preserving).
+* Put **provenance** in `customInstructions.provenance` when available.
+* When this wallet can spend the output, MAY add spend fields to the same JSON object (`protocolID`, `keyID`, `counterparty`, …). Readers that do not understand a key MUST ignore it.
+
+**Writers SHOULD NOT** rely on a `name:` tag as the primary display name. A `name:` tag remains **MAY** so existing deployments stay conforming; new implementations SHOULD prefer CI `name` and MAY omit the tag.
+
+Readers resolving a display name SHOULD prefer `customInstructions.name` when present, and MAY fall back to a `name:` tag.
 
 ### Custom instructions ([BRC-37](../outpoints/0037.md))
 
@@ -69,7 +101,7 @@ When present for basket `1sat`, `customInstructions` MUST be a **UTF-8 JSON obje
 {
   "origin": "<txid_vout>",
   "name": "<display name>",
-  "app": "<optional creator/app id>",
+  "app": "<optional application id>",
   "provenance": { }
 }
 ```
@@ -77,15 +109,18 @@ When present for basket `1sat`, `customInstructions` MUST be a **UTF-8 JSON obje
 | Field | Type | Requirement | Meaning |
 |-------|------|-------------|---------|
 | `origin` | string | SHOULD | Claimed origin outpoint (underscore form preferred). |
-| `name` | string | MAY | Display name. |
-| `app` | string | MAY | Creator / application id. |
+| `name` | string | SHOULD when known | Display name (case-preserving). Preferred over a `name:` tag. |
+| `app` | string | MAY | Application id (may mirror an `app:` tag for display). |
 | `provenance` | object | SHOULD on transfer when available | Provenance remittance; v2 in [BRC-150](./0150.md). |
+| `protocolID` | BRC-43 protocol | MAY | When this wallet manages the lock: derivation protocol for spend. |
+| `keyID` | string | MAY | When this wallet manages the lock: key id under that protocol. |
+| `counterparty` | string | MAY | When this wallet manages the lock: Type-42 counterparty if not self. |
 
-Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers that do not understand `provenance` MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)).
+Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers that do not understand `provenance` or spend fields MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)).
 
 #### Claims vs proof
 
-* `origin`, `name`, `app`, and all tags are **claims**.
+* `origin`, `name`, `app`, `type:`, `id:`, and all other tags are **claims** (or local wallet metadata). `id:` is not an origin claim.
 * A wallet MUST NOT treat a claimed `origin` as proven solely because it appears in tags or `customInstructions`.
 * Proven tip→origin binding is defined by [BRC-150](./0150.md) (v2). When remittance is absent or fails verification, the wallet MUST treat identity as **unproven** and SHOULD avoid presenting sender-supplied `name` / `app` as authoritative for that tip.
 
@@ -124,7 +159,7 @@ Example (non-normative shape):
     "satoshis": 1,
     "outputDescription": "Collectable transfer",
     "basket": "1sat",
-    "tags": ["ordinal", "origin:<txid.vout>", "name:Example"],
+    "tags": ["ordinal", "origin:<txid.vout>", "id:<wallet-unique-id>", "type:image/png"],
     "customInstructions": "{\"origin\":\"<txid_vout>\",\"name\":\"Example\",\"provenance\":{}}"
   }]
 }
@@ -146,7 +181,7 @@ To place an existing tip into basket `1sat`, use BRC-100 `internalizeAction` wit
     "protocol": "basket insertion",
     "insertionRemittance": {
       "basket": "1sat",
-      "tags": ["ordinal", "origin:<txid.vout>"],
+      "tags": ["ordinal", "origin:<txid.vout>", "id:<wallet-unique-id>", "type:image/png"],
       "customInstructions": "{\"origin\":\"<txid_vout>\",\"name\":\"Example\"}"
     }
   }]

--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -120,7 +120,7 @@ Additional JSON keys are permitted and MUST be ignored by readers that do not un
 
 #### Claims vs proof
 
-* `origin`, `name`, `app`, `type:`, `id:`, and all other tags are **claims** (or local wallet metadata). `id:` is not an origin claim.
+* `origin`, `name`, `app`, `type:`, and all tags are **claims**.
 * A wallet MUST NOT treat a claimed `origin` as proven solely because it appears in tags or `customInstructions`.
 * Proven tip→origin binding is defined by [BRC-150](./0150.md) (v2). When remittance is absent or fails verification, the wallet MUST treat identity as **unproven** and SHOULD avoid presenting sender-supplied `name` / `app` as authoritative for that tip.
 


### PR DESCRIPTION
## Summary

Draft proposal for additive clarifications to BRC-147 (Brandon’s basket profile), for discussion before merge.

- **`id:`** SHOULD on managed rows — wallet-unique opaque id (generation not standardized)
- **`type:`** SHOULD when known — full origin inscription MIME (params stripped); copy on self-keep
- **Origin tag** — bare `origin` (this out is origin) vs `origin:<outpoint>` (later tip) + self-keep promote/copy
- **Tags vs customInstructions** — tags for query keys; CI for display name, optional spend fields, provenance; `name:` tag MAY legacy

Intentionally does **not** change basket name, supersede 147, or pull in P1Sat permission-module machinery.

Open threads (also offline with Brandon):
- Duplicating origin/app across tags and CI
- CI origin underscore preference vs BRC-100/SDK dot form
- Provenance size vs wallet-toolbox CI column limits (150 omit-if-large / 156)

## Test plan

- [ ] Review diff with Brandon
- [ ] Align on open threads above
- [ ] Merge when agreed