### PR TITLE
docs(153): synthetic action reference labels on listActions

### DIFF
--- a/wallet/0153.md
+++ b/wallet/0153.md
@@ -16,7 +16,7 @@ Adding a new field to action records would change the `listActions` response sha
 
 Persisting `reference` as a normal label uses the existing label write and read paths that storage providers already implement. `listActions` with `includeLabels` then returns it without API or wire changes.
 
-BRC-100 labels are normalized by trimming and lowercasing. Action `reference` values are `Base64String` and therefore case-sensitive, so the raw base64 value must not be stored in a label. This specification encodes the reference bytes as lowercase hex instead.
+The BRC-100 reference implementation (`bsv-blockchain` ts-sdk / wallet-toolbox) normalizes labels by trimming and lowercasing before persistence and query matching, as documented in [BRC-100](./0100.md) and [BRC-65](./0065.md). Action `reference` values are `Base64String` and therefore case-sensitive, so the raw base64 value must not be stored in a label. This specification encodes the reference bytes as lowercase hex instead.
 
 ## Specification
 

--- a/wallet/0153.md
+++ b/wallet/0153.md
@@ -4,7 +4,7 @@ David Case
 
 ## Abstract
 
-This specification defines a backwards-compatible extension to [BRC-100](./0100.md) that requires the wallet to persist each action’s `reference` as an ordinary label of the form `reference <Base64String>`. No new request or response fields are introduced.
+This specification defines a backwards-compatible extension to [BRC-100](./0100.md) that requires the wallet to persist each action’s `reference` as an ordinary label of the form `reference <hex>`. No new request or response fields are introduced.
 
 ## Motivation
 
@@ -16,17 +16,19 @@ Adding a new field to action records would change the `listActions` response sha
 
 Persisting `reference` as a normal label uses the existing label write and read paths that storage providers already implement. `listActions` with `includeLabels` then returns it without API or wire changes.
 
+BRC-100 labels are normalized by trimming and lowercasing. Action `reference` values are `Base64String` and therefore case-sensitive, so the raw base64 value must not be stored in a label. This specification encodes the reference bytes as lowercase hex instead.
+
 ## Specification
 
 ### Reserved label form
 
 This specification reserves labels of the form:
 
-- `reference <Base64String>`
+- `reference <hex>`
 
-Where `<Base64String>` is the action’s wallet reference as defined by BRC-100 (`signableTransaction.reference`, and the `reference` argument to `signAction` / `abortAction`).
+Where `<hex>` is the lowercase hexadecimal encoding of the raw bytes of the action’s wallet `reference` (`Base64String` decoded to bytes). That `reference` is the value defined by BRC-100 (`signableTransaction.reference`, and the `reference` argument to `signAction` / `abortAction`).
 
-The prefix is exactly `reference ` (lowercase, single trailing space before the value).
+The prefix is exactly `reference ` (lowercase, single trailing space before the value). The hex value must use only characters `0-9` and `a-f`, with even length and no `0x` prefix.
 
 Callers must not supply labels matching this form on `createAction` or `internalizeAction`. If a caller includes such a label, the wallet must return an error or strip it and replace it with the canonical wallet-authored label.
 
@@ -34,9 +36,13 @@ Callers must not supply labels matching this form on `createAction` or `internal
 
 On every successful `createAction` and `internalizeAction`, the wallet must persist exactly one label:
 
-- `reference <Base64String>`
+- `reference <hex>`
 
-Where `<Base64String>` is the reference assigned to that action (the same value returned on `signableTransaction.reference` when present).
+Where `<hex>` is derived from the reference assigned to that action (the same value returned on `signableTransaction.reference` when present):
+
+1. Take the action `reference` as a BRC-100 `Base64String`.
+2. Decode it to raw bytes.
+3. Encode those bytes as lowercase hex.
 
 Rules:
 
@@ -51,18 +57,19 @@ Rules:
 
 No special list behavior is required beyond BRC-100:
 
-- When `includeLabels` is `true`, the persisted `reference <Base64String>` label appears with any other labels on the action.
-- Callers may filter with ordinary label matching, e.g. `listActions({ labels: ["reference <Base64String>"] })` or combine with application labels.
+- When `includeLabels` is `true`, the persisted `reference <hex>` label appears with any other labels on the action.
+- Callers may filter with ordinary label matching, e.g. `listActions({ labels: ["reference <hex>"] })` or combine with application labels.
 
 ### Recovery
 
-1. Create the action with an ordinary correlator label (e.g. `my-app-flow-xyz`). The wallet also persists `reference <Base64String>`.
+1. Create the action with an ordinary correlator label (e.g. `my-app-flow-xyz`). The wallet also persists `reference <hex>`.
 2. If the in-memory reference is lost, call `listActions({ labels: ["my-app-flow-xyz"], includeLabels: true })`.
-3. Read `reference <Base64String>` from the matching action’s `labels` and resume with `signAction` or `abortAction`.
+3. Read `reference <hex>` from the matching action’s `labels`.
+4. Decode `<hex>` to bytes, encode those bytes as standard base64, and use the result as `reference` for `signAction` or `abortAction`.
 
 ## Conclusion
 
-By persisting each action’s wallet `reference` as a reserved ordinary label at creation time, this specification closes the recovery gap for in-flight BRC-100 actions using existing label storage and `listActions`, without changing the API surface or WalletWire encodings.
+By persisting each action’s wallet `reference` as a reserved ordinary hex label at creation time, this specification closes the recovery gap for in-flight BRC-100 actions using existing label storage and `listActions`, without changing the API surface or WalletWire encodings, and without relying on case-sensitive label values.
 
 ## References
 

--- a/wallet/0153.md
+++ b/wallet/0153.md
@@ -1,115 +1,72 @@
-# BRC-153: Action References for BRC-100 Wallets
+# BRC-153: Action Reference Labels for BRC-100 Wallets
 
 David Case
 
 ## Abstract
 
-This specification defines a backwards-compatible extension to [BRC-100](./0100.md) that allows the caller to optionally supply the action `reference` on `createAction` and `internalizeAction`, requires `reference` on action records from `listActions`, and adds a `getAction` method for single-item lookup by reference.
+This specification defines a backwards-compatible extension to [BRC-100](./0100.md) that requires the wallet to persist each action’s `reference` as an ordinary label of the form `reference <Base64String>`. No new request or response fields are introduced.
 
 ## Motivation
 
-Under [BRC-100](./0100.md), `createAction` may return `signableTransaction.reference`. That value is required for subsequent `signAction` and `abortAction` calls. The interface does not include `reference` on action records returned from `listActions`, and it does not define a way to fetch one action by `reference`.
+Under [BRC-100](./0100.md), `createAction` may return `signableTransaction.reference`. That value is required for subsequent `signAction` and `abortAction` calls. The interface does not include `reference` on action records returned from `listActions`, and some storage providers do not expose `reference` on the list path at all.
 
 If an application loses the reference after a successful `createAction`—for example because of process failure, lost in-memory scope, or a delayed multi-step signing flow—there is no interoperable way to resume or abort the in-flight action through the public wallet interface.
 
-Application-level correlators (labels or output tags) can aid discovery of completed or basket-tracked outputs, but they do not substitute for the wallet’s action reference: tags are not the key used by `signAction` and `abortAction`, and they do not make the wallet reference itself recoverable through the standard interface.
+Adding a new field to action records would change the `listActions` response shape, break WalletWire consumers, and require version or capability negotiation. Injecting a synthetic response-only label would still require the list path to read `reference` from storage—the capability some providers lack.
 
-`internalizeAction` also creates wallet-tracked action state. The same optional caller-supplied reference rules apply.
+Persisting `reference` as a normal label uses the existing label write and read paths that storage providers already implement. `listActions` with `includeLabels` then returns it without API or wire changes.
 
 ## Specification
 
-This BRC extends the [BRC-100](./0100.md) wallet interface. Unless stated otherwise, types, permission behavior, and error structure are those of BRC-100.
+### Reserved label form
 
-### Action reference
+This specification reserves labels of the form:
 
-- The canonical field name is `reference`, consistent with `signableTransaction.reference`, `signAction`, and `abortAction` in BRC-100.
-- Values use the BRC-100 `Base64String` type.
-- `createAction` accepts an optional `reference` on the request. If omitted, the wallet generates a unique `reference`.
-- `internalizeAction` accepts an optional `reference` on the request under the same rules.
-- For a given wallet user, `reference` values must be unique across action records. If the caller supplies a `reference` that already exists, the wallet must return an error.
-- The `reference` remains stable for the life of the action record across all action statuses exposed by the wallet (including `unsigned`, `nosend`, `sending`, `unproven`, `completed`, and `failed`).
+- `reference <Base64String>`
 
-### createAction
+Where `<Base64String>` is the action’s wallet reference as defined by BRC-100 (`signableTransaction.reference`, and the `reference` argument to `signAction` / `abortAction`).
 
-| Field | Required | Description |
-| ----- | -------- | ----------- |
-| `reference` | no | Caller-supplied action reference (`Base64String`). If omitted, the wallet generates one. |
+The prefix is exactly `reference ` (lowercase, single trailing space before the value).
 
-When the result includes `signableTransaction`, `signableTransaction.reference` is the assigned action reference (caller-supplied or wallet-generated).
+Callers must not supply labels matching this form on `createAction` or `internalizeAction`. If a caller includes such a label, the wallet must return an error or strip it and replace it with the canonical wallet-authored label.
 
-### internalizeAction
+### Wallet-authored label
 
-| Field | Required | Description |
-| ----- | -------- | ----------- |
-| `reference` | no | Caller-supplied action reference (`Base64String`). If omitted, the wallet generates one. |
+On every successful `createAction` and `internalizeAction`, the wallet must persist exactly one label:
+
+- `reference <Base64String>`
+
+Where `<Base64String>` is the reference assigned to that action (the same value returned on `signableTransaction.reference` when present).
+
+Rules:
+
+- The label is a normal persisted action label, not response-only metadata.
+- It remains stable for the life of the action record across all statuses exposed by the wallet (including `unsigned`, `nosend`, `sending`, `unproven`, `completed`, and `failed`).
+- The wallet must not duplicate it.
+- The label must satisfy general label constraints in [BRC-100](./0100.md).
+- Wallet authorship of this label must not bypass ordinary basket, protocol, or other authorization checks for the action itself.
+- This label is exempt from originator label-permission checks that apply to caller-supplied labels; it is wallet metadata, not an application category.
 
 ### listActions
 
-Each action record must include `reference`.
+No special list behavior is required beyond BRC-100:
 
-### getAction
+- When `includeLabels` is `true`, the persisted `reference <Base64String>` label appears with any other labels on the action.
+- Callers may filter with ordinary label matching, e.g. `listActions({ labels: ["reference <Base64String>"] })` or combine with application labels.
 
-`getAction` fetches a single action by `reference`.
+### Recovery
 
-| Field | Required | Description |
-| ----- | -------- | ----------- |
-| `reference` | yes | Action reference (`Base64String`) |
-| `includeLabels` | no | Same meaning as `listActions` |
-| `includeInputs` | no | Same meaning as `listActions` |
-| `includeInputSourceLockingScripts` | no | Same meaning as `listActions` |
-| `includeInputUnlockingScripts` | no | Same meaning as `listActions` |
-| `includeOutputs` | no | Same meaning as `listActions` |
-| `includeOutputLockingScripts` | no | Same meaning as `listActions` |
-| `seekPermission` | no | Same meaning as `listActions` |
-
-The successful result is a single action object with the same shape as an element of `listActions.actions`.
-
-If no action exists for `reference`, or the action is not visible under ordinary permission rules, the wallet must return an error.
-
-### Required behavior
-
-- `getAction` must enforce the same originator and permission checks that apply when inspecting the corresponding record via `listActions`.
-- Supplying `reference` on `createAction` or `internalizeAction` must not bypass basket, protocol, or other authorization checks.
-- A second `createAction` or `internalizeAction` that supplies a `reference` already used by an existing action for the user must fail. Wallets must not overwrite the existing action.
-
-### Errors
-
-Errors use the uniform structure defined in [BRC-100](./0100.md):
-
-- `status` — always `"error"`
-- `code` — a short machine-readable string
-- `description` — a human-readable explanation
-- `context` — optional additional data
-
-As in BRC-100, wallets may choose their own `code` naming conventions provided `description` clearly identifies the failure. Illustrative examples:
-
-```json
-{
-  "status": "error",
-  "code": "ERR_DUPLICATE_REFERENCE",
-  "description": "An action with the supplied reference already exists."
-}
-```
-
-```json
-{
-  "status": "error",
-  "code": "ERR_ACTION_NOT_FOUND",
-  "description": "No action was found for the supplied reference."
-}
-```
-
-### Validation rules
-
-- Optional request `reference` values must be valid `Base64String` values under BRC-100.
-- Wallet-generated `reference` values must be valid `Base64String` values and must not collide with existing action references for the user.
+1. Create the action with an ordinary correlator label (e.g. `my-app-flow-xyz`). The wallet also persists `reference <Base64String>`.
+2. If the in-memory reference is lost, call `listActions({ labels: ["my-app-flow-xyz"], includeLabels: true })`.
+3. Read `reference <Base64String>` from the matching action’s `labels` and resume with `signAction` or `abortAction`.
 
 ## Conclusion
 
-By making action `reference` optionally caller-supplied, unique, present on action records, and fetchable via `getAction`, this specification closes the recovery gap for in-flight BRC-100 actions.
+By persisting each action’s wallet `reference` as a reserved ordinary label at creation time, this specification closes the recovery gap for in-flight BRC-100 actions using existing label storage and `listActions`, without changing the API surface or WalletWire encodings.
 
 ## References
 
 - [BRC-100](./0100.md) — Unified wallet-to-application interface
 - [BRC-65](./0065.md) — Transaction labels and list actions
-- [BRC-116](./0116.md) — Wallet permissions and counterparty trust
+- [BRC-111](./0111.md) — Label permission modules
+- [BRC-114](./0114.md) — Time labels for list actions


### PR DESCRIPTION
## Summary

- Revises BRC-153 after review: no new `listActions` fields, no `getAction`, no caller-supplied references, **no persisted reference label**.
- When `includeLabels` is true, each action includes a synthetic label `reference <hex>` (hex of reference bytes; base64 is case-sensitive under reference-impl label lowercasing).
- Recovery: app correlator label → `listActions` + `includeLabels` → decode hex → base64 → `signAction` / `abortAction`.
- How the wallet loads `reference` from storage is out of scope (WalletStorage is not a BRC).

## Test plan

- [ ] Spec review against BRC-100 / BRC-114 special-label pattern
- [ ] Confirm synthetic (non-persisted) label is preferred over wallet-authored stored label
- [ ] Follow-up: wallet-toolbox storage/list path injects the label when `includeLabels` is true