### PR TITLE
feat: add BRC-157 Entropy-Rooted Backup and Recovery with Mnemonics and Backup Shares

### DIFF
--- a/.claude/skills/brcs/SKILL.md
+++ b/.claude/skills/brcs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brcs
-description: Triage and merge open PRs on the bitcoin-sv/BRCs repository. Assigns the lowest available BRC number (filling gaps before extending past the highest), renames files when needed, wires links into README.md / SUMMARY.md / dir README. Use when user says "/brcs", "merge BRC PRs", "triage BRCs", "process BRC pull requests", or wants to drain the open PR queue on the BRCs docs repo.
+description: Triage and merge open PRs on the bitcoin-sv/BRCs repository. Keeps the BRC number each PR assigned itself unless that number is already taken; only then reassigns (with the user's approval) to the lowest available number. Renames files when needed, wires links into README.md / SUMMARY.md / dir README. Use when user says "/brcs", "merge BRC PRs", "triage BRCs", "process BRC pull requests", or wants to drain the open PR queue on the BRCs docs repo.
 user-invocable: true
 allowed-tools:
   - Bash
@@ -41,7 +41,9 @@ gh pr list --state open --limit 50
 
 Read `README.md` "## Standards" table. Highest existing `NNN | [Title](path)` row = `LAST_BRC`.
 
-**Numbers are allocated lowest-available-first, not highest+1.** The range `1..LAST_BRC` has gaps (withdrawn/never-landed BRCs). Compute the free list from the files actually on disk:
+**The PR's own number is authoritative unless it collides.** Authors pick numbers deliberately — often memetic or self-referential (e.g. `0069`, `0100`, matching a sibling BRC). Never renumber just because a lower gap exists or because the number is above `LAST_BRC`. A number is only reassigned when it is *taken*: a file with that number already exists on disk, or an earlier PR in this same run has claimed it.
+
+The `TAKEN` set and the free list both come from the files actually on disk:
 
 ```bash
 find . -path './.git' -prune -o -name "[0-9]*.md" -print \
@@ -51,7 +53,9 @@ comm -23 <(seq 1 "$LAST_BRC" | sort) <(sort /tmp/nums.txt) | sort -n > /tmp/free
 echo "LAST_BRC=$LAST_BRC  next free: $(head -1 /tmp/free_brc.txt)"
 ```
 
-`FREE_LIST` = `/tmp/free_brc.txt` (ascending). Allocate the head of `FREE_LIST` to each new BRC; pop it as you go. When `FREE_LIST` is empty, fall back to `LAST_BRC + 1`.
+`TAKEN` = `/tmp/nums.txt` (every number on disk). `FREE_LIST` = `/tmp/free_brc.txt` (ascending gaps in `1..LAST_BRC`).
+
+`FREE_LIST` is **only** consulted for collisions. It is the fallback allocator, not the default one. When it is empty, fall back to `LAST_BRC + 1`. Add each merged BRC's number to `TAKEN` as you go, so a later PR in the run collides against it correctly.
 
 Also note structure:
 - Per-category dir READMEs: `apps/README.md`, `wallet/README.md`, `transactions/README.md`, `payments/README.md`, `overlays/README.md`, `peer-to-peer/README.md`, `key-derivation/README.md`, `outpoints/README.md`, `opinions/README.md`, `tokens/README.md`, `scripts/README.md`, `state-machines/README.md`.
@@ -86,19 +90,32 @@ PR's latest commit modifies an existing BRC file with non-trivial changes (rewor
 Action: `git merge --no-ff --no-commit pr-<N>`. Resolve conflicts (see Step 4). Also update any title-bearing references in `SUMMARY.md` + dir README if the BRC's title changed. Commit with body referencing PR.
 
 ### (d) New BRC
-PR adds a new `<dir>/NNNN.md`. Compare the proposed number against `ASSIGNED` = head of `FREE_LIST` (Step 1) — the **lowest available** number, falling back to `LAST_BRC + 1` only when no gaps remain.
+PR adds a new `<dir>/NNNN.md` claiming number `PROPOSED`.
 
-- **If proposed number == `ASSIGNED`** → keep number, just merge.
-- **Otherwise** (proposed is taken, is a higher number while gaps exist, or another PR in the queue claims it) → reassign:
-  1. `ASSIGNED` = head of `FREE_LIST`; pop it so the next PR in this run gets the following gap.
+**Default: keep `PROPOSED`.** Check only for collision:
+
+```bash
+grep -qx "$PROPOSED" /tmp/nums.txt && echo COLLISION || echo FREE
+```
+
+(also treat it as a collision if an earlier PR in this run was assigned `PROPOSED`).
+
+- **FREE** → `ASSIGNED = PROPOSED`. Merge as-is. No rename, no `sed`, no session mapping entry. This holds even when `PROPOSED` is far above `LAST_BRC` or leaves gaps below it — leaving gaps is fine and expected.
+- **COLLISION** → the number is genuinely unusable. Before touching anything, **ask the user** via `AskUserQuestion`:
+  - state which existing file/PR holds `PROPOSED`,
+  - offer the lowest available number (head of `FREE_LIST`, else `LAST_BRC + 1`) as the recommended option,
+  - note that authors often pick numbers for a reason, so the user may prefer another number or to ask the author.
+
+  Renumbering is never automatic — a collision is a question, not a decision. On approval:
+  1. `ASSIGNED` = the number the user chose; pop it from `FREE_LIST` if it came from there.
   2. `git mv <dir>/<PROPOSED>.md <dir>/<ASSIGNED>.md` in the PR's branch (or apply rename after merge). Filenames are zero-padded to 4 digits (`0141.md`).
   3. In the renamed doc, `sed -i '' "s/BRC-<PROPOSED>/BRC-<ASSIGNED>/g"` (or Edit) — but **only the document's self-references** (title heading + any "this BRC" / "BRC-XXX" pointers pointing at itself). Do NOT change references to *other* BRCs.
   4. Track the mapping `PROPOSED → ASSIGNED` for this session.
   5. Before merging each subsequent PR, grep its files for any reference to a `PROPOSED` number that has since been remapped and rewrite to `ASSIGNED`.
 
-Action: merge, resolve conflicts, update indices (Step 5), commit. Pop `ASSIGNED` from `FREE_LIST` (or increment `LAST_BRC` if it came from the fallback).
+Action: merge, resolve conflicts, update indices (Step 5), commit. Add `ASSIGNED` to `TAKEN`; bump `LAST_BRC` if `ASSIGNED > LAST_BRC`.
 
-**Note on filling gaps:** a gap may exist because that number was withdrawn or is informally reserved. Mention gap-filling in the final report so the user can object; do not skip a gap on a hunch.
+**Note on gaps:** gaps in `1..LAST_BRC` are left alone. A gap may exist because that number was withdrawn or is informally reserved, so it is only ever filled as the fallback target of an approved collision fix — never proactively, and never to "tidy up" the numbering.
 
 ## Step 3 — Track BRC number mapping
 
@@ -136,7 +153,7 @@ If any PR pulled in unrelated stale changes (e.g. removed sections because its b
 
 Every new BRC needs entries in **three** places (four if there's a dir README beyond the standard set).
 
-**All three indices are sorted ascending by BRC number.** Because numbers are allocated lowest-available-first, a new entry usually goes **in the middle, not at the end** — insert it in sorted position, do not append. Use `Edit` anchored on the surrounding rows (`sed` with `|` delimiters breaks on the table's own pipes).
+**All three indices are sorted ascending by BRC number.** Since the PR keeps its own number, the entry often does sort last — but not always (a number below `LAST_BRC` lands mid-table). Check where it belongs and insert in sorted position rather than assuming append. Use `Edit` anchored on the surrounding rows (`sed` with `|` delimiters breaks on the table's own pipes).
 
 1. **`README.md`** top-level table — insert row into the `BRC | Standard` table in numeric order:
    ```
@@ -153,9 +170,9 @@ Every new BRC needs entries in **three** places (four if there's a dir README be
    * [Title](./<dir>/NNNN.md)
    ```
 
-PR authors usually update some but not all, and they typically append their row at the bottom assuming highest+1. Diff PR's `files` list against this 3-place requirement, move any appended row into sorted position, and add missing entries manually before commit.
+PR authors usually update some but not all. Diff PR's `files` list against this 3-place requirement, move any misplaced row into sorted position, and add missing entries manually before commit.
 
-Caveat for Step 4: the strip-conflict-markers `sed` keeps `HEAD`'s lines then the PR's line — correct only when the new row genuinely sorts last. When filling a gap, strip the markers then move the row into place, or drop the PR's row and re-add it manually in sorted position.
+Caveat for Step 4: the strip-conflict-markers `sed` keeps `HEAD`'s lines then the PR's line — correct only when the new row genuinely sorts last. When the number sorts mid-table, strip the markers then move the row into place, or drop the PR's row and re-add it manually in sorted position.
 
 ## Step 6 — Commit
 
@@ -259,8 +276,10 @@ Remaining open: #Q (reason: draft / blocked / ...)
 
 ## Guardrails
 
+- **Never** renumber a PR whose chosen number is free. Authors pick numbers deliberately (memetic, sequential with a sibling BRC, matching an external reference). A gap below it is not a reason; being above `LAST_BRC` is not a reason. Only a genuine collision is.
+- **Always** ask the user before renumbering, even on a real collision — never silently remap.
 - **Never** modify the substance of a contributor's document beyond:
-  - BRC number reassignment (title heading + self-references only)
+  - BRC number reassignment (title heading + self-references only, after user approval)
   - Cross-reference rewrites for renumbered peers (Step 3)
   - Whitespace/conflict-marker cleanup
 - **Always** confirm with user before closing a PR — closing is an external write under the user's identity.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ BRC | Standard
 154  | [Pluggable Backup Services for BRC-140 Share Vaults](./wallet/0154.md)
 155  | [Pull-Based Receive Discovery](./wallet/0155.md)
 156  | [Latched 1Sat Provenance for Basket `1sat`](./tokens/0156.md)
+157  | [Entropy-Rooted Backup and Recovery with Mnemonics and Backup Shares](./key-derivation/0157.md)
 168  | [Verifiable Time Allocation](./apps/0168.md)
 169  | [Universal Handle Addressing and Resolution for the Metanet](./peer-to-peer/0169.md)
 218  | [Chat-Native Command Grammar for the Metanet](./apps/0218.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -181,6 +181,7 @@
 * [Limitations of BRC-69 Key Linkage Revelation](./key-derivation/0093.md)
 * [Verifiable Revelation of Shared Secrets Using Schnorr Protocol](./key-derivation/0094.md)
 * [Threshold Key Sharing and Backup via Shamir's Secret Sharing Scheme](./key-derivation/0140.md)
+* [Entropy-Rooted Backup and Recovery with Mnemonics and Backup Shares](./key-derivation/0157.md)
 
 ## Outpoints
 

--- a/key-derivation/0157.md
+++ b/key-derivation/0157.md
@@ -1,0 +1,256 @@
+# BRC-157: Entropy-Rooted Backup and Recovery with Mnemonics and Backup Shares
+
+Deggen (d.kellenschwiler@bsvassociation.org)
+
+## Abstract
+
+This standard defines a unified backup and recovery scheme in which **entropy** — not a private key and not a mnemonic phrase — is the fundamental object being backed up. A 32-byte entropy value is represented as a secp256k1 private key so that it can be split into [BRC-140](./0140.md) backup shares, and simultaneously encoded as a BIP-39 mnemonic sentence so that it can be written down as words. Either backup artifact — a quorum of shares, or the mnemonic — recovers the identical entropy, from which a canonical BIP-32 derivation produces the wallet's root key (the private counterparty to the [BRC-100](../wallet/0100.md) identity key) and any number of additional profile keys. This makes the two most widely deployed backup methods interchangeable rather than mutually exclusive, and codifies the `toEntropy()` / `fromEntropy()` methods of the `Mnemonic` class together with the `toBackupShares()` / `fromBackupShares()` methods of the `PrivateKey` class in the BSV TypeScript SDK.
+
+## Motivation
+
+Wallet users fall into two camps. Some prefer mnemonic backups — twelve or twenty-four words on paper, a habit built over a decade of BIP-39 wallets — and some arrive with a mnemonic they already have. Others prefer threshold backup shares ([BRC-140](./0140.md)) — resilient to the loss or compromise of a minority of shares — and some arrive with shares they already hold.
+
+As deployed today these two methods are incompatible, because they anchor to different objects:
+
+- Backup shares assume the thing being backed up is a **private key** (`PrivateKey.toBackupShares()` splits a key; `PrivateKey.fromBackupShares()` reconstructs one).
+- Mnemonics assume the thing being backed up is a **string of words** encoding entropy, from which a seed and then keys are derived.
+
+A wallet that generated its master key directly cannot later hand the user a mnemonic for it, because an arbitrary 32-byte key is not the output of a mnemonic derivation. A wallet restored from a mnemonic cannot cut backup shares that would round-trip back to the same mnemonic. Users are forced to pick one method at wallet creation and are locked in forever.
+
+The resolution is to back up **entropy**. Entropy converts losslessly in both directions: it maps to a private key by interpretation (the bytes *are* the scalar), and it maps to a mnemonic by BIP-39 encoding (which is reversible via the wordlist and checksum). If the wallet's key hierarchy is derived *from* the entropy — rather than the entropy being an afterthought — then shares and mnemonic are two serializations of the same backup, and either one alone is a complete recovery path.
+
+## Specification
+
+### Terminology
+
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in RFC 2119.
+
+- **Entropy** — the 32-byte secret value that is the sole object of backup and recovery.
+- **Entropy key** — the secp256k1 private key whose big-endian 32-byte scalar encoding equals the entropy. It exists only to carry the entropy through [BRC-140](./0140.md) share operations; it MUST NOT be used to sign or to derive anything except as specified below.
+- **Root key** — the wallet's master private key, derived from the entropy as specified below; its public key is the wallet's [BRC-100](../wallet/0100.md) identity key.
+- **Profile key** — an additional root-level private key for a distinct wallet profile, derived from the same entropy at a different index.
+
+### Entropy generation
+
+New wallets MUST generate entropy as a uniformly random secp256k1 private key scalar, i.e. a 32-byte value in the range `[1, n − 1]` where `n` is the secp256k1 group order:
+
+```
+n = 0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141
+```
+
+Generating within `[1, n − 1]` rather than `[0, 2²⁵⁶ − 1]` introduces a bias, but a negligible one: `n` is within `2⁻¹²⁸` of `2²⁵⁶`, so the entropy loss is far below one bit. This trade-off is accepted deliberately — it keeps the entropy directly usable as a BRC-140 share subject with no additional mapping, and the resulting ≈256-bit strength still doubles that of the 128-bit entropy behind the twelve-word mnemonics most users rely on today.
+
+The entropy is serialized as exactly 32 bytes, big-endian, zero-padded on the left. Implementations MUST request the fixed-width encoding explicitly — in the TypeScript SDK this is `privateKey.toArray('be', 32)`; the zero-argument `toArray()` returns a *minimal-length* encoding and silently drops leading zero bytes.
+
+### Validation
+
+Implementations MUST validate both artifacts at every entry point:
+
+**Mnemonic validation** (on import and on recovery):
+
+1. Every word MUST appear in the active BIP-39 wordlist.
+2. The word count MUST be 12, 15, 18, 21, or 24.
+3. The BIP-39 checksum MUST verify: after mapping words to 11-bit indices and splitting off the final `ENT / 32` checksum bits, those bits MUST equal the leading bits of `SHA-256(entropy)`. A sentence failing any of these MUST be rejected — `toEntropy()` MUST throw rather than return unverified bytes.
+
+**Entropy validation** (on generation, on mnemonic decode, and on share recovery):
+
+4. The entropy, interpreted as a big-endian integer, MUST lie in `[1, n − 1]`. Zero MUST be rejected — note that zero is reachable through *valid* BIP-39 sentences (e.g. the twelve-word sentence consisting of eleven repetitions of `abandon` followed by `about` decodes to sixteen `0x00` bytes), and that `PrivateKey` constructors in current SDKs accept a zero scalar without complaint, so this check is the implementation's responsibility. Values `≥ n` are only reachable with 32-byte entropy and MUST likewise be rejected; a generator that produces one MUST redraw.
+
+### Mnemonic encoding
+
+The entropy MUST be encoded to and decoded from a mnemonic sentence exactly as specified by BIP-39, using the English wordlist by default:
+
+- **Encoding** (`Mnemonic.fromEntropy(entropy)`): append the checksum (first `ENT / 32` bits of `SHA-256(entropy)`), split into 11-bit groups, and map each group to a word. 32 bytes of entropy yields a 24-word sentence.
+- **Decoding** (`mnemonic.toEntropy()`): map words back to 11-bit indices, verify the checksum, and return the entropy bytes. Implementations MUST reject sentences with invalid checksums or words outside the wordlist.
+
+Because BIP-39 encoding is a bijection between valid entropy and valid sentences (for a given wordlist), the mnemonic is a faithful serialization of the entropy — this is the property the entire scheme rests on.
+
+### Backup shares
+
+The entropy is interpreted as the entropy key and split with the [BRC-140](./0140.md) threshold scheme:
+
+```
+shares = entropyKey.toBackupShares(threshold, total)
+```
+
+Recovery from any `threshold` shares reconstructs the entropy key, whose 32-byte serialization is the entropy:
+
+```
+entropy = PrivateKey.fromBackupShares(shares).toArray()   // 32 bytes, zero-padded
+```
+
+The BRC-140 integrity tag (HASH160 of the entropy key's compressed public key) binds all shares of one entropy value together and lets recovery software confirm that the reconstructed entropy matches, exactly as in ordinary BRC-140 use.
+
+### Root key derivation
+
+The root key MUST be derived from the entropy as follows:
+
+1. Encode the entropy as a BIP-39 mnemonic (above).
+2. Derive the BIP-39 seed: `PBKDF2-HMAC-SHA512(password = sentence, salt = "mnemonic" + passphrase, 2048 iterations, 64 bytes)`, with an **empty passphrase** (`""`).
+3. Construct a BIP-32 ([BRC-32](./0032.md)) master node from the seed.
+4. Derive the hardened path `m/0'/0'`; the resulting private key is the root key.
+
+```
+rootKey = HD.fromSeed(Mnemonic.fromEntropy(entropy).toSeed()).derive("m/0'/0'").privKey
+```
+
+The root key's compressed public key is the wallet's [BRC-100](../wallet/0100.md) identity key, and all operational keys are derived from the root key using [BRC-42](./0042.md) as usual. The entropy key itself MUST NOT be used as the root key: keeping the backup subject and the spending root separated by a hardened derivation means the recovery artifacts never directly expose a key that has appeared on-chain or in signatures.
+
+A non-empty BIP-39 passphrase MAY be supported as an additional secret, but implementations MUST default to the empty passphrase so that shares and mnemonic alone are sufficient for recovery; any wallet offering a passphrase MUST make clear to the user that it is a third secret which neither shares nor mnemonic can recover.
+
+### Profiles
+
+Additional wallet profiles under the same backup are derived from the same BIP-32 master node at successive hardened indices:
+
+```
+profileKey(i) = HD.fromSeed(Mnemonic.fromEntropy(entropy).toSeed()).derive(`m/0'/${i}'`).privKey
+```
+
+Profile 0 (`m/0'/0'`) is the root key. Profiles 1, 2, 3, … are peers of it — each with its own identity key — all recoverable from the single backed-up entropy with no per-profile backup material.
+
+### Recovery
+
+A conforming implementation MUST accept either recovery artifact and MUST arrive at the same entropy:
+
+- **From shares**: `entropy = PrivateKey.fromBackupShares(shares).toArray()` (zero-padded to 32 bytes).
+- **From mnemonic**: `entropy = Mnemonic.fromString(sentence).toEntropy()`.
+
+After recovery, the wallet MUST be able to re-emit both artifacts — cut fresh shares (BRC-140 splits are non-deterministic, so new shares will differ textually but reconstruct the same entropy) and re-display the identical mnemonic sentence.
+
+### Imported mnemonics of fewer than 24 words
+
+Users bringing an existing BIP-39 mnemonic of 12–21 words carry entropy of 16–28 bytes. Such mnemonics MUST be accepted: `toEntropy()` yields the shorter entropy, which is zero-padded on the left to 32 bytes to form the entropy key, and derivation proceeds identically (the mnemonic seed in step 2 of root key derivation is computed from the sentence the user actually holds).
+
+Recovering such a wallet from *shares* reconstructs the padded 32-byte value, so the original entropy length must be restored before re-encoding — naively re-encoding all 32 bytes would produce a different, 24-word sentence. Round-trip fidelity (shares back to the *exact original words*) is therefore governed by the following rules:
+
+1. **Record the length.** Implementations SHOULD store the entropy length (equivalently, the word count) alongside the wallet and inside any share vault metadata ([BRC-154](../wallet/0154.md)). At recovery time the user can also simply be asked how many words their mnemonic had — they know.
+2. **Trim to length.** On share recovery, take the reconstructed value as 32 bytes big-endian (`toArray('be', 32)`), drop the leading `32 − length` zero bytes, and re-encode the remaining `length` bytes with `Mnemonic.fromEntropy`. Because BIP-39 encoding at a fixed length is deterministic and bijective, this reproduces the identical sentence.
+3. **Fallback heuristic.** If the length was not recorded and cannot be asked, count the leading zero bytes `L` of the 32-byte value and take `length = max(16, roundUpToMultipleOf4(32 − L))`. This guesses correctly unless the user's genuine entropy itself began with 4 or more zero bytes (probability `2⁻³²` per wallet), which is why rule 1 is a SHOULD and this is only a fallback.
+
+New wallets avoid the machinery entirely by generating full 32-byte entropy (24 words).
+
+#### Worked example
+
+Take the BIP-39 test-vector mnemonic:
+
+```
+legal winner thank year wave sausage worth useful legal winner thank yellow
+```
+
+Decoding (12 words × 11 bits = 132 bits = 128 entropy bits + 4 checksum bits) yields 16 bytes of entropy:
+
+```
+entropy       = 7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f
+```
+
+Zero-padding to 32 bytes gives the entropy key:
+
+```
+entropyKey    = 000000000000000000000000000000007f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f
+```
+
+Splitting with `toBackupShares(2, 3)` and recombining any two shares with `fromBackupShares` reconstructs exactly that scalar. Serialized fixed-width:
+
+```
+recovered     = 000000000000000000000000000000007f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f
+```
+
+The recorded length is 16 (or the fallback heuristic observes `L = 16` leading zero bytes and computes `max(16, 32 − 16) = 16`). Dropping the 16 zero bytes and re-encoding the remaining `7f7f…7f` at 16 bytes reproduces, word for word:
+
+```
+legal winner thank year wave sausage worth useful legal winner thank yellow
+```
+
+Had the implementation instead re-encoded the full 32 bytes, the user would be shown this unrelated-looking 24-word sentence — a different backup that would derive a different root key:
+
+```
+abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon
+abandon abstract wave sausage worth useful legal winner thank year wave sausage
+worth upgrade
+```
+
+(The eleven leading `abandon`s are the encoding of the padding zeros — a red flag reviewers and test suites can watch for.)
+
+Either way the entropy round-trips; only the trim step decides whether the *presentation* matches the user's paper backup. The root key is unaffected by any of this at recovery-from-mnemonic time, since it is derived from the sentence the user holds; with correct trimming, share recovery converges on the same sentence and therefore the same root key:
+
+```
+rootKey (m/0'/0') = 27e442c8015fc055789d6628f3b30461e8b2598aff74dc87ceef00dd8e670e55
+```
+
+## Reference implementation
+
+Using `@bsv/sdk`:
+
+```ts
+import { PrivateKey, Mnemonic, HD } from '@bsv/sdk'
+
+// --- Wallet creation ---
+const entropy = PrivateKey.fromRandom()            // 32 bytes of entropy, carried as a key
+const mnemonic = Mnemonic.fromEntropy(entropy.toArray('be', 32))
+const hd = HD.fromSeed(mnemonic.toSeed())
+const rootKey = hd.derive("m/0'/0'").privKey       // private counterparty to the identity key
+
+// --- Backup: hand the user EITHER (or both) ---
+const shares = entropy.toBackupShares(2, 3)        // any 2 of 3 recover
+const words = mnemonic.mnemonic                    // 24 words
+
+// --- Recovery path A: from shares ---
+const entropyA = PrivateKey.fromBackupShares(shares.slice(0, 2))
+const mnemonicA = Mnemonic.fromEntropy(entropyA.toArray('be', 32))
+
+// --- Recovery path B: from mnemonic ---
+const mnemonicB = Mnemonic.fromString(words)       // throws on bad word / count / checksum
+const entropyB = new PrivateKey(mnemonicB.toEntropy())
+
+// Both paths converge on the same entropy, hence the same root key:
+// entropyA == entropyB == entropy, and
+// HD.fromSeed(mnemonicA.toSeed()).derive("m/0'/0'").privKey == rootKey
+
+// --- Profiles ---
+const profile2 = hd.derive("m/0'/2'").privKey      // second additional profile, same backup
+```
+
+Importing a 12-word mnemonic and round-tripping through shares back to the exact same words:
+
+```ts
+// --- Import: user brings their own 12-word mnemonic ---
+const words12 = 'legal winner thank year wave sausage worth useful legal winner thank yellow'
+const imported = Mnemonic.fromString(words12)      // validates wordlist membership + checksum
+const ent = imported.toEntropy()                   // 16 bytes: 7f7f…7f
+const entLength = ent.length                       // 16 — RECORD THIS (or the word count, 12)
+
+const entropyKey = new PrivateKey(ent)             // scalar 0x0000…00007f7f…7f
+const shares = entropyKey.toBackupShares(2, 3)
+
+// --- Recovery from shares, back to the exact original words ---
+const recovered = PrivateKey.fromBackupShares(shares.slice(0, 2))
+const full = recovered.toArray('be', 32)           // MUST be fixed-width: 32 bytes
+const trimmed = full.slice(32 - entLength)         // drop the 16 padding zero bytes
+const again = Mnemonic.fromEntropy(trimmed)
+// again.mnemonic === words12                      // exact same 12 words
+
+// Root key is identical from either artifact:
+const rootKey = HD.fromSeed(again.toSeed()).derive("m/0'/0'").privKey
+// 27e442c8015fc055789d6628f3b30461e8b2598aff74dc87ceef00dd8e670e55
+```
+
+## Security considerations
+
+- **Entropy is the master secret.** Anyone holding the mnemonic, or a quorum of shares, controls every profile of the wallet. Both artifacts warrant the same handling users already apply to seed phrases.
+- **Two live backup channels widen the attack surface.** A wallet offering both methods gives an attacker two independent artifacts to hunt for. Users who want only one method should be permitted to use only one; this standard makes them interchangeable, not both mandatory.
+- **The entropy key never signs.** Because the entropy key is separated from all operational keys by hardened BIP-32 derivation and BRC-42, no signature or on-chain data reveals information about the backup subject.
+- **Share recovery reassembles the secret in one place.** All BRC-140 caveats apply: recovery software sees the full entropy, and the integrity tag is a checksum, not an authentication mechanism.
+- **Bias from the group order.** Restricting entropy to `[1, n − 1]` forfeits under `2⁻¹²⁸` of a bit of entropy relative to the full 256-bit space — cryptographically irrelevant.
+
+## Relationship to other BRCs
+
+- [BRC-140](./0140.md) supplies the threshold sharing scheme and share serialization; this standard changes only *what* is shared — entropy rather than an operational key.
+- [BRC-75](./0075.md) maps a mnemonic to a single master key via `SHA-256(seed)`; this standard supersedes that construction for new wallets by making entropy recoverable from the mnemonic (BRC-75's hash is one-way, so it cannot interoperate with shares) and by using standard BIP-32 hardened derivation to reach the root key.
+- [BRC-32](./0032.md) specifies the BIP-32 derivation used for `m/0'/0'` and profile paths.
+- [BRC-42](./0042.md) governs all key derivation below the root key.
+- [BRC-100](../wallet/0100.md) defines the wallet interface whose identity key is the public counterparty of the root key derived here.
+- [BRC-154](../wallet/0154.md) backup services can vault the shares produced under this scheme unchanged.
+
+## Implementations
+
+- The BSV TypeScript SDK (`@bsv/sdk`) implements `PrivateKey.toBackupShares` / `fromBackupShares` ([BRC-140](./0140.md)) and the `Mnemonic` class with `fromEntropy`, `toEntropy`, `fromString`, and `toSeed`.

--- a/key-derivation/README.md
+++ b/key-derivation/README.md
@@ -16,3 +16,4 @@ BRC | Standard
 93   | [Limitations of BRC-69 Key Linkage Revelation](./0093.md)
 94   | [Verifiable Revelation of Shared Secrets Using Schnorr Protocol](./0094.md)
 140  | [Threshold Key Sharing and Backup via Shamir's Secret Sharing Scheme](./0140.md)
+157  | [Entropy-Rooted Backup and Recovery with Mnemonics and Backup Shares](./0157.md)


### PR DESCRIPTION
## What

Adds **BRC-157: Entropy-Rooted Backup and Recovery with Mnemonics and Backup Shares** ([key-derivation/0157.md](https://github.com/bsv-blockchain/BRCs/blob/brc-157-entropy-backup/key-derivation/0157.md)), plus index entries in README.md, SUMMARY.md, and key-derivation/README.md.

## Why

BRC-140 backup shares assume the backup subject is a private key; BIP-39 mnemonics assume it is a word sentence. The two are incompatible today, forcing users to pick one method at wallet creation. BRC-157 makes **entropy** the fundamental object of backup: a 32-byte value carried as a secp256k1 private key (so `toBackupShares`/`fromBackupShares` work) and encoded as a BIP-39 mnemonic (so words work). Either artifact recovers the identical entropy, from which the wallet root key — the private counterparty to the BRC-100 identity key — is derived at `m/0'/0'`, with profiles at `m/0'/i'`.

## For reviewers

- **Depends on a new SDK method**: `Mnemonic.toEntropy()` (BIP-39 decode with checksum verification) is being added to `@bsv/sdk`; everything else already exists.
- All hex values, the worked example, and the exact-words round trip were verified by executing against the current `@bsv/sdk` (with `toEntropy` simulated per the BIP-39 spec).
- **Validation section** requires rejecting zero entropy — reachable via a *valid* mnemonic (`abandon` ×11 + `about`) — because current SDK `PrivateKey` constructors accept a zero scalar and will even cut shares for it.
- **Fixed-width serialization** is normative: `toArray('be', 32)`, since bare `toArray()` drops leading zero bytes.
- **Imported 12-word mnemonics** round-trip to the exact original words by recording entropy length (or asking the user their word count) and trimming padding zeros on share recovery; a leading-zero heuristic is specified as fallback (fails only with probability 2⁻³² per wallet). Worked example uses the BIP-39 test vector `legal winner thank year …`.
- Number 157 is the lowest free BRC number; no collision with open PRs (#200 claims 300–307).

🤖 Generated with [Claude Code](https://claude.com/claude-code)