### PR TITLE
docs(153): synthetic reference labels (not persisted)

### DIFF
--- a/wallet/0153.md
+++ b/wallet/0153.md
@@ -28,6 +28,14 @@ Where `<hex>` is the lowercase hexadecimal encoding of the raw bytes of the acti
 
 The prefix is exactly `reference ` (lowercase, single trailing space before the value). The hex value must use only characters `0-9` and `a-f`, with even length and no `0x` prefix.
 
+### Reserved prefix
+
+Labels beginning with `reference ` are reserved for this specification.
+
+- Callers must not supply labels matching this form on `createAction` or `internalizeAction`.
+- If a caller includes such a label, the wallet must reject the request or strip every matching label before persistence.
+- Wallets must not persist the synthetic response label as ordinary action metadata.
+
 ### Response reference label
 
 When `listActions` is called with `includeLabels` set to `true`, each returned action must include exactly one synthetic label:
@@ -43,8 +51,7 @@ derived from that action’s stable wallet reference:
 Rules:
 
 - Include the label only when `includeLabels` is `true`.
-- The label is response-derived metadata and must not be persisted as a normal action label.
-- Do not duplicate it if already present in the returned `labels` array.
+- Before adding it, remove any labels in the result that begin with `reference ` (including stale or caller-forged values), then append the wallet-authored synthetic label.
 - The value must round-trip to the same `reference` accepted by `signAction` and `abortAction` for that action.
 - The underlying reference remains stable for the life of the action record across all statuses exposed by the wallet (including `unsigned`, `nosend`, `sending`, `unproven`, `completed`, and `failed`).
 - The label must satisfy general label constraints in [BRC-100](./0100.md).

--- a/wallet/0153.md
+++ b/wallet/0153.md
@@ -4,19 +4,17 @@ David Case
 
 ## Abstract
 
-This specification defines a backwards-compatible extension to [BRC-100](./0100.md) that requires the wallet to persist each action’s `reference` as an ordinary label of the form `reference <hex>`. No new request or response fields are introduced.
+This specification defines a backwards-compatible extension to [BRC-100](./0100.md) that exposes each action’s wallet `reference` as a synthetic label on `listActions` results. No new request or response fields are introduced, and the label is not persisted as ordinary action metadata.
 
 ## Motivation
 
-Under [BRC-100](./0100.md), `createAction` may return `signableTransaction.reference`. That value is required for subsequent `signAction` and `abortAction` calls. The interface does not include `reference` on action records returned from `listActions`, and some storage providers do not expose `reference` on the list path at all.
+Under [BRC-100](./0100.md), `createAction` may return `signableTransaction.reference`. That value is required for subsequent `signAction` and `abortAction` calls. The interface does not include `reference` on action records returned from `listActions`.
 
 If an application loses the reference after a successful `createAction`—for example because of process failure, lost in-memory scope, or a delayed multi-step signing flow—there is no interoperable way to resume or abort the in-flight action through the public wallet interface.
 
-Adding a new field to action records would change the `listActions` response shape, break WalletWire consumers, and require version or capability negotiation. Injecting a synthetic response-only label would still require the list path to read `reference` from storage—the capability some providers lack.
+Adding a new field to action records would change the `listActions` response shape, break WalletWire consumers, and require version or capability negotiation. Following the special-operation label pattern used by [BRC-114](./0114.md), this specification surfaces `reference` inside the existing `labels` array as response-derived metadata.
 
-Persisting `reference` as a normal label uses the existing label write and read paths that storage providers already implement. `listActions` with `includeLabels` then returns it without API or wire changes.
-
-The BRC-100 reference implementation (`bsv-blockchain` ts-sdk / wallet-toolbox) normalizes labels by trimming and lowercasing before persistence and query matching, as documented in [BRC-100](./0100.md) and [BRC-65](./0065.md). Action `reference` values are `Base64String` and therefore case-sensitive, so the raw base64 value must not be stored in a label. This specification encodes the reference bytes as lowercase hex instead.
+The BRC-100 reference implementation (`bsv-blockchain` ts-sdk / wallet-toolbox) normalizes labels by trimming and lowercasing before persistence and query matching, as documented in [BRC-100](./0100.md) and [BRC-65](./0065.md). Action `reference` values are `Base64String` and therefore case-sensitive, so the synthetic label encodes reference bytes as lowercase hex.
 
 ## Specification
 
@@ -30,15 +28,13 @@ Where `<hex>` is the lowercase hexadecimal encoding of the raw bytes of the acti
 
 The prefix is exactly `reference ` (lowercase, single trailing space before the value). The hex value must use only characters `0-9` and `a-f`, with even length and no `0x` prefix.
 
-Callers must not supply labels matching this form on `createAction` or `internalizeAction`. If a caller includes such a label, the wallet must return an error or strip it and replace it with the canonical wallet-authored label.
+### Response reference label
 
-### Wallet-authored label
-
-On every successful `createAction` and `internalizeAction`, the wallet must persist exactly one label:
+When `listActions` is called with `includeLabels` set to `true`, each returned action must include exactly one synthetic label:
 
 - `reference <hex>`
 
-Where `<hex>` is derived from the reference assigned to that action (the same value returned on `signableTransaction.reference` when present):
+derived from that action’s stable wallet reference:
 
 1. Take the action `reference` as a BRC-100 `Base64String`.
 2. Decode it to raw bytes.
@@ -46,34 +42,32 @@ Where `<hex>` is derived from the reference assigned to that action (the same va
 
 Rules:
 
-- The label is a normal persisted action label, not response-only metadata.
-- It remains stable for the life of the action record across all statuses exposed by the wallet (including `unsigned`, `nosend`, `sending`, `unproven`, `completed`, and `failed`).
-- The wallet must not duplicate it.
+- Include the label only when `includeLabels` is `true`.
+- The label is response-derived metadata and must not be persisted as a normal action label.
+- Do not duplicate it if already present in the returned `labels` array.
+- The value must round-trip to the same `reference` accepted by `signAction` and `abortAction` for that action.
+- The underlying reference remains stable for the life of the action record across all statuses exposed by the wallet (including `unsigned`, `nosend`, `sending`, `unproven`, `completed`, and `failed`).
 - The label must satisfy general label constraints in [BRC-100](./0100.md).
-- Wallet authorship of this label must not bypass ordinary basket, protocol, or other authorization checks for the action itself.
-- This label is exempt from originator label-permission checks that apply to caller-supplied labels; it is wallet metadata, not an application category.
 
 ### listActions
 
-No special list behavior is required beyond BRC-100:
+No other list behavior is required beyond BRC-100. Callers recover references by listing with ordinary application labels and reading the synthetic `reference <hex>` entry when `includeLabels` is `true`.
 
-- When `includeLabels` is `true`, the persisted `reference <hex>` label appears with any other labels on the action.
-- Callers may filter with ordinary label matching, e.g. `listActions({ labels: ["reference <hex>"] })` or combine with application labels.
+How a wallet obtains `reference` internally (for example from local or remote storage) is an implementation concern outside this specification.
 
 ### Recovery
 
-1. Create the action with an ordinary correlator label (e.g. `my-app-flow-xyz`). The wallet also persists `reference <hex>`.
+1. Create the action with an ordinary correlator label (e.g. `my-app-flow-xyz`).
 2. If the in-memory reference is lost, call `listActions({ labels: ["my-app-flow-xyz"], includeLabels: true })`.
 3. Read `reference <hex>` from the matching action’s `labels`.
 4. Decode `<hex>` to bytes, encode those bytes as standard base64, and use the result as `reference` for `signAction` or `abortAction`.
 
 ## Conclusion
 
-By persisting each action’s wallet `reference` as a reserved ordinary hex label at creation time, this specification closes the recovery gap for in-flight BRC-100 actions using existing label storage and `listActions`, without changing the API surface or WalletWire encodings, and without relying on case-sensitive label values.
+By exposing each action’s wallet `reference` as a synthetic `listActions` label, this specification closes the recovery gap for in-flight BRC-100 actions without changing the API surface, WalletWire encodings, or ordinary label storage.
 
 ## References
 
 - [BRC-100](./0100.md) — Unified wallet-to-application interface
 - [BRC-65](./0065.md) — Transaction labels and list actions
-- [BRC-111](./0111.md) — Label permission modules
 - [BRC-114](./0114.md) — Time labels for list actions

--- a/wallet/0153.md
+++ b/wallet/0153.md
@@ -30,11 +30,7 @@ The prefix is exactly `reference ` (lowercase, single trailing space before the 
 
 ### Reserved prefix
 
-Labels beginning with `reference ` are reserved for this specification.
-
-- Callers must not supply labels matching this form on `createAction` or `internalizeAction`.
-- If a caller includes such a label, the wallet must reject the request or strip every matching label before persistence.
-- Wallets must not persist the synthetic response label as ordinary action metadata.
+Labels beginning with `reference ` are reserved for this specification’s response annotation. The synthetic label must not be persisted as ordinary action metadata.
 
 ### Response reference label
 
@@ -51,10 +47,11 @@ derived from that action’s stable wallet reference:
 Rules:
 
 - Include the label only when `includeLabels` is `true`.
-- Before adding it, remove any labels in the result that begin with `reference ` (including stale or caller-forged values), then append the wallet-authored synthetic label.
+- If the returned labels already contain any entry beginning with `reference `, replace those entries with the single wallet-authored synthetic label (do not leave forged or stale values alongside it).
 - The value must round-trip to the same `reference` accepted by `signAction` and `abortAction` for that action.
 - The underlying reference remains stable for the life of the action record across all statuses exposed by the wallet (including `unsigned`, `nosend`, `sending`, `unproven`, `completed`, and `failed`).
 - The label must satisfy general label constraints in [BRC-100](./0100.md).
+
 
 ### listActions
 


### PR DESCRIPTION
## Summary

- Synthetic response-only `reference <hex>` on `listActions` when `includeLabels` is true.
- Overwrites any existing `reference …` labels in the response with the wallet-authored value.
- No new API fields. No create/internalize label rules beyond reserved-prefix documentation.

Impl: https://github.com/bsv-blockchain/ts-stack/pull/446 