### PR TITLE
BRC-158: Outpoint BEEF

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -71,6 +71,7 @@
 * [Scalable Transaction Processing in the BSV Network](./transactions/0083.md)
 * [Atomic BEEF Transactions](./transactions/0095.md)
 * [BEEF V2 Txid Only Extension](./transactions/0096.md)
+* [1Sat BEEF](./transactions/0158.md)
 * [SubTree Unified Merkle Path (STUMP) Format](./transactions/0119.md)
 * [Multicast Transaction Frame Format](./transactions/0124.md)
 * [Multicast Transaction NACK Retransmission Protocol](./transactions/0126.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -71,7 +71,7 @@
 * [Scalable Transaction Processing in the BSV Network](./transactions/0083.md)
 * [Atomic BEEF Transactions](./transactions/0095.md)
 * [BEEF V2 Txid Only Extension](./transactions/0096.md)
-* [1Sat BEEF](./transactions/0158.md)
+* [Outpoint BEEF](./transactions/0158.md)
 * [SubTree Unified Merkle Path (STUMP) Format](./transactions/0119.md)
 * [Multicast Transaction Frame Format](./transactions/0124.md)
 * [Multicast Transaction NACK Retransmission Protocol](./transactions/0126.md)

--- a/transactions/0158.md
+++ b/transactions/0158.md
@@ -1,0 +1,149 @@
+# BRC-158: 1Sat BEEF
+
+David Case / b-open-io (david.case@shruggr.cloud)
+
+With credit to Brandon Cryderman / HandCash (brandongcryderman@gmail.com) for
+[BRC-150](../tokens/0150.md) 1Sat provenance remittance, which motivated this
+format.
+
+## Abstract
+
+This BRC defines **1Sat BEEF**, a binary envelope around [BRC-62](./0062.md)
+BEEF whose **subject is a 1-sat outpoint** (tip), not a transaction id. It is
+the outpoint-oriented counterpart to [BRC-95](./0095.md) Atomic BEEF.
+
+A conforming 1Sat BEEF carries enough transactions for a verifier to walk the
+1Sat ordinal from the tip back to its origin and recover origin identity and
+optional content type—without a separate path list.
+
+## Motivation
+
+Atomic BEEF ([BRC-95](./0095.md)) names a **transaction**. 1Sat provenance
+names an **outpoint** (`txid` + `vout`): the current tip of an inscription
+ownership chain.
+
+[BRC-150](../tokens/0150.md) embeds tip→origin proof in basket
+`customInstructions` as JSON (including base64 beef). HTTP gateways and other
+binary transports need a first-class byte format whose subject is the tip
+outpoint and whose BEEF body is sufficient to **calculate the ordinal** at
+each hop—not only to show that a parent outpoint appears as some input.
+
+## Specification
+
+### Byte layout
+
+| Field | Size | Description |
+|-------|------|-------------|
+| Prefix | 4 bytes | Fixed constant `0x16a7beef` (big-endian), marks 1Sat BEEF |
+| Subject TXID | 32 bytes | Tip transaction id (same byte order as Atomic BEEF subject TXID) |
+| Subject vout | 4 bytes | Tip output index, unsigned little-endian uint32 |
+| BEEF | variable | Standard [BRC-62](./0062.md) BEEF structure (`0x0100beef` …) |
+
+The prefix is the same width as the Atomic BEEF prefix (`0x01010101`). The
+subject is 36 bytes (outpoint) instead of 32 (txid only), because the proven
+object is an outpoint.
+
+```
+16a7beef
+// 32-byte tip TXID
+// 4-byte tip vout (uint32 LE)
+0100beef
+// … standard BEEF …
+```
+
+### Subject
+
+- The subject outpoint is the **tip**: the 1-satoshi UTXO whose origin is being
+  proven.
+- The BEEF MUST include the tip transaction.
+- The BEEF MUST include, for every hop visited by the origin walk below, the
+  source transaction for every input before the transferred ordinal on that
+  hop, so a verifier can calculate the ordinal.
+
+### Origin walk
+
+Given subject tip outpoint `T` and the embedded BEEF, a verifier recovers
+origin (and content type) as follows:
+
+```
+function proveOrigin(tip, beef):
+    current = tip
+
+    loop:
+        tx = load current's transaction from beef
+        if missing: fail
+
+        if tx.outputs[current.vout].satoshis != 1: fail
+
+        outAcc = 0
+        for j in 0 .. current.vout-1:
+            outAcc += tx.outputs[j].satoshis
+
+        inAcc = 0
+        for each input of tx:
+            sourceTx = load input's source transaction from beef
+            if missing: fail
+            inSats = sourceTx.outputs[input.vout].satoshis
+
+            // Input entirely before our sat — skip.
+            if inAcc + inSats <= outAcc:
+                inAcc += inSats
+                continue
+
+            // This input covers our sat.
+            if inSats == 1 and inAcc == outAcc:
+                current = input's source outpoint
+                continue outer loop
+
+            break   // not a 1→1 hop
+
+        // Stopped walking — this outpoint is the origin.
+        contentType = from ord envelope if present, else empty
+        return origin = current, contentType
+```
+
+Notes:
+
+- A pure **1→1** hop (one-sat output funded exactly by a one-sat input at the
+  same sat offset) continues the walk backward.
+- Otherwise the current outpoint is the **origin**. An `ord` envelope is not
+  required to *define* origin; it only supplies `contentType` when present.
+- Failure to load a required transaction fails verification.
+
+### Validation
+
+1. Prefix MUST be `0x16a7beef`.
+2. BEEF MUST parse and pass structural validation per [BRC-62](./0062.md).
+3. Subject tip transaction MUST be present in the BEEF.
+4. `proveOrigin(tip, beef)` MUST succeed.
+5. Headers / merkle roots SHOULD be checked per [BRC-67](./0067.md) when a
+   chain tracker is available.
+
+### Relationship to other BRCs
+
+| Format | Subject | Prefix |
+|--------|---------|--------|
+| BEEF ([BRC-62](./0062.md)) | (none) | `0x0100beef` version field inside structure |
+| Atomic BEEF ([BRC-95](./0095.md)) | TXID | `0x01010101` + 32-byte TXID |
+| **1Sat BEEF (this BRC)** | outpoint | `0x16a7beef` + 32-byte TXID + 4-byte vout |
+
+[BRC-150](../tokens/0150.md) may embed 1Sat BEEF bytes (e.g. base64) as the
+provenance package body, or continue to carry raw BEEF with a separate tip
+field. This BRC does not change BRC-150’s JSON schema by itself.
+
+## Security considerations
+
+* **Tag spoofing** — Origin tags without a verified walk remain claims.
+* **Incomplete BEEF** — Omitting input source txs on multi-in hops makes
+  ordinal calculation impossible; verification MUST fail closed.
+* **Burns** — Leaving the 1→1 path (multi-sat input funding the tip sat) stops
+  the walk at that outpoint as origin; do not invent continuity across a burn.
+
+## References
+
+1. [BRC-62](./0062.md) — Background Evaluation Extended Format (BEEF)
+2. [BRC-95](./0095.md) — Atomic BEEF Transactions
+3. [BRC-67](./0067.md) — Simplified Payment Verification
+4. [BRC-150](../tokens/0150.md) — 1Sat Provenance Remittance (Brandon Cryderman / HandCash)
+5. [BRC-147](../tokens/0147.md) — 1Sat Ordinals Basket Profile
+6. 1Sat Ordinals — <https://docs.1satordinals.com>

--- a/transactions/0158.md
+++ b/transactions/0158.md
@@ -1,4 +1,4 @@
-# BRC-158: 1Sat BEEF
+# BRC-158: Outpoint BEEF
 
 David Case / b-open-io (david.case@shruggr.cloud)
 
@@ -8,25 +8,24 @@ format.
 
 ## Abstract
 
-This BRC defines **1Sat BEEF**, a binary envelope around [BRC-62](./0062.md)
-BEEF whose **subject is a 1-sat outpoint** (tip), not a transaction id. It is
-the outpoint-oriented counterpart to [BRC-95](./0095.md) Atomic BEEF.
+This BRC defines **Outpoint BEEF**, a binary envelope around [BRC-62](./0062.md)
+BEEF whose **subject is an outpoint**, not a transaction id. It is the
+outpoint-oriented counterpart to [BRC-95](./0095.md) Atomic BEEF.
 
-A conforming 1Sat BEEF carries enough transactions for a verifier to walk the
-1Sat ordinal from the tip back to its origin and recover origin identity and
-optional content type—without a separate path list.
+The envelope is profile-agnostic: it names a subject outpoint and carries a
+BEEF. What the BEEF must contain—and how to interpret it—is defined by the
+profile using the format. This document specifies the bytes and, as the first
+profile, **1Sat ordinal provenance** (tip→origin).
 
 ## Motivation
 
-Atomic BEEF ([BRC-95](./0095.md)) names a **transaction**. 1Sat provenance
-names an **outpoint** (`txid` + `vout`): the current tip of an inscription
-ownership chain.
+Atomic BEEF ([BRC-95](./0095.md)) names a **transaction**. Many protocols need
+to prove something about a specific **outpoint** (`txid` + `vout`).
 
-[BRC-150](../tokens/0150.md) embeds tip→origin proof in basket
-`customInstructions` as JSON (including base64 beef). HTTP gateways and other
-binary transports need a first-class byte format whose subject is the tip
-outpoint and whose BEEF body is sufficient to **calculate the ordinal** at
-each hop—not only to show that a parent outpoint appears as some input.
+[BRC-150](../tokens/0150.md) embeds tip→origin proof for 1Sat tips in basket
+`customInstructions` as JSON. Binary transports need a first-class byte format
+whose subject is that tip outpoint. The same envelope can carry other
+outpoint-scoped proofs later without a new header family.
 
 ## Specification
 
@@ -34,36 +33,54 @@ each hop—not only to show that a parent outpoint appears as some input.
 
 | Field | Size | Description |
 |-------|------|-------------|
-| Prefix | 4 bytes | Fixed constant `0x16a7beef` (big-endian), marks 1Sat BEEF |
-| Subject TXID | 32 bytes | Tip transaction id (same byte order as Atomic BEEF subject TXID) |
-| Subject vout | 4 bytes | Tip output index, unsigned little-endian uint32 |
+| Prefix | 4 bytes | Fixed constant `0x16a7beef` (big-endian), marks Outpoint BEEF |
+| Subject TXID | 32 bytes | Subject transaction id (same byte order as Atomic BEEF subject TXID) |
+| Subject vout | 4 bytes | Subject output index, unsigned little-endian uint32 |
 | BEEF | variable | Standard [BRC-62](./0062.md) BEEF structure (`0x0100beef` …) |
 
 The prefix is the same width as the Atomic BEEF prefix (`0x01010101`). The
-subject is 36 bytes (outpoint) instead of 32 (txid only), because the proven
-object is an outpoint.
+subject is 36 bytes (outpoint) instead of 32 (txid only).
 
 ```
 16a7beef
-// 32-byte tip TXID
-// 4-byte tip vout (uint32 LE)
+// 32-byte subject TXID
+// 4-byte subject vout (uint32 LE)
 0100beef
 // … standard BEEF …
 ```
 
-### Subject
+### Common validation
 
-- The subject outpoint is the **tip**: the 1-satoshi UTXO whose origin is being
-  proven.
+1. Prefix MUST be `0x16a7beef`.
+2. BEEF MUST parse and pass structural validation per [BRC-62](./0062.md).
+3. The subject outpoint’s transaction MUST be present in the BEEF.
+4. Headers / merkle roots SHOULD be checked per [BRC-67](./0067.md) when a
+   chain tracker is available.
+5. Profile-specific rules (below or in a referencing BRC) MUST also pass.
+
+### Relationship to other BRCs
+
+| Format | Subject | Prefix |
+|--------|---------|--------|
+| BEEF ([BRC-62](./0062.md)) | (none) | version inside structure |
+| Atomic BEEF ([BRC-95](./0095.md)) | TXID | `0x01010101` + 32-byte TXID |
+| **Outpoint BEEF (this BRC)** | outpoint | `0x16a7beef` + 32-byte TXID + 4-byte vout |
+
+---
+
+## Profile: 1Sat ordinal provenance
+
+When Outpoint BEEF is used to prove a **1Sat tip→origin** binding (as in
+[BRC-150](../tokens/0150.md)):
+
+- The subject outpoint is the **tip** (1-satoshi UTXO being proven).
 - The BEEF MUST include the tip transaction.
-- The BEEF MUST include, for every hop visited by the origin walk below, the
-  source transaction for every input before the transferred ordinal on that
-  hop, so a verifier can calculate the ordinal.
+- The BEEF MUST include, for every hop visited by the walk below, the source
+  transaction for every input before the transferred ordinal on that hop, so a
+  verifier can calculate the ordinal.
+- Verification MUST run `proveOrigin` successfully.
 
 ### Origin walk
-
-Given subject tip outpoint `T` and the embedded BEEF, a verifier recovers
-origin (and content type) as follows:
 
 ```
 function proveOrigin(tip, beef):
@@ -106,38 +123,22 @@ Notes:
 
 - A pure **1→1** hop (one-sat output funded exactly by a one-sat input at the
   same sat offset) continues the walk backward.
-- Otherwise the current outpoint is the **origin**. An `ord` envelope is not
-  required to *define* origin; it only supplies `contentType` when present.
+- Otherwise the current outpoint is the **origin**. An `ord` envelope does not
+  define origin; it only supplies `contentType` when present.
 - Failure to load a required transaction fails verification.
 
-### Validation
-
-1. Prefix MUST be `0x16a7beef`.
-2. BEEF MUST parse and pass structural validation per [BRC-62](./0062.md).
-3. Subject tip transaction MUST be present in the BEEF.
-4. `proveOrigin(tip, beef)` MUST succeed.
-5. Headers / merkle roots SHOULD be checked per [BRC-67](./0067.md) when a
-   chain tracker is available.
-
-### Relationship to other BRCs
-
-| Format | Subject | Prefix |
-|--------|---------|--------|
-| BEEF ([BRC-62](./0062.md)) | (none) | `0x0100beef` version field inside structure |
-| Atomic BEEF ([BRC-95](./0095.md)) | TXID | `0x01010101` + 32-byte TXID |
-| **1Sat BEEF (this BRC)** | outpoint | `0x16a7beef` + 32-byte TXID + 4-byte vout |
-
-[BRC-150](../tokens/0150.md) may embed 1Sat BEEF bytes (e.g. base64) as the
-provenance package body, or continue to carry raw BEEF with a separate tip
-field. This BRC does not change BRC-150’s JSON schema by itself.
+[BRC-150](../tokens/0150.md) may embed Outpoint BEEF bytes (e.g. base64) as
+the provenance package body, or carry raw BEEF with a separate tip field.
 
 ## Security considerations
 
-* **Tag spoofing** — Origin tags without a verified walk remain claims.
-* **Incomplete BEEF** — Omitting input source txs on multi-in hops makes
-  ordinal calculation impossible; verification MUST fail closed.
-* **Burns** — Leaving the 1→1 path (multi-sat input funding the tip sat) stops
-  the walk at that outpoint as origin; do not invent continuity across a burn.
+* **Profile confusion** — Bytes alone do not say which profile applies.
+  Callers MUST know they are verifying 1Sat provenance (or another defined
+  profile), not “any outpoint BEEF.”
+* **Incomplete BEEF** — Omitting required input source txs makes ordinal
+  calculation impossible; 1Sat verification MUST fail closed.
+* **Burns** — Leaving the 1→1 path stops the walk at that outpoint as origin;
+  do not invent continuity across a burn.
 
 ## References
 


### PR DESCRIPTION
## Summary

**BRC-158: Outpoint BEEF** — outpoint-subject counterpart to Atomic BEEF (BRC-95).

| | Atomic BEEF | Outpoint BEEF |
|--|-------------|---------------|
| Prefix | `0x01010101` | `0x16a7beef` |
| Subject | TXID (32) | outpoint (32 + 4 vout LE) |
| Body | BEEF | BEEF |

Format is **profile-agnostic**. First profile: **1Sat ordinal provenance** (`proveOrigin` tip→origin, input source txs required to calculate the ordinal).

Credits **Brandon Cryderman / HandCash** (BRC-150). Does not rewrite BRC-150 schema.

## Test plan

- [ ] Spec review (BEEF-family + 1Sat implementers)
- [ ] Confirm prefix `0x16a7beef` is unused
- [ ] Cross-link from BRC-150 when ready