### PR TITLE
Errata to BRC-145: reject ill-formed kinds, verify every pixel, reject rendering-affecting chunks

### DIFF
--- a/apps/0145.md
+++ b/apps/0145.md
@@ -85,7 +85,9 @@ short = CODE_PREFIX || hex(anchor)[:16] # "ik1" + 16 hex chars = 19 chars
 
 ### 4. Kinds, open, tier-weighted, third-party assignable
 
-A `kind` is any UTF-8 string of at most 255 bytes. By convention it is written `[namespace:]name[@tier]` (e.g. `address`, `acme:invoice@t3`, `acme:vault@t1`) but the anchor (§2) treats it as an opaque byte string, so **any** string is a valid kind. Namespacing (`ns:`) lets adopters avoid clashing without coordination; because the whole string is inside the digest, `acme:invoice` and `beta:invoice` are distinct anchors even over identical data.
+A `kind` is any UTF-8 string of at most 255 bytes. By convention it is written `[namespace:]name[@tier]` (e.g. `address`, `acme:invoice@t3`, `acme:vault@t1`) but the anchor (§2) treats it as an opaque byte string, so any string that encodes as valid UTF-8 is a valid kind. Namespacing (`ns:`) lets adopters avoid clashing without coordination; because the whole string is inside the digest, `acme:invoice` and `beta:invoice` are distinct anchors even over identical data.
+
+A value that cannot be encoded as valid UTF-8 is **not** a kind: an implementation MUST reject it and MUST NOT substitute replacement characters. Substitution is not a lenient reading of this rule, it is a collision. Every unpaired surrogate encodes to the same replacement bytes, so two distinct kinds that differ only in their ill-formed portion would derive one anchor, and a commitment to one would verify against the other.
 
 Presentations (the visual seal, §5) require a `kind` to resolve to geometry parameters `(cells, k, motif)`, where `cells ∈ {24, 48, 72}` is the tier's cell count, `k ∈ 1..7` is a rotational-symmetry order, and `motif` is a 6-bit frame code. Resolution is:
 
@@ -137,6 +139,10 @@ keyword(latin-1) || 0x00 || 0x00(comp flag) || 0x00(comp method) || 0x00(empty l
 ```
 
 **Verification of a presented seal.** To verify a seal claimed to be `(data, kind)`: recompute the anchor and the canonical seal; decode the presented PNG to native RGB; if it is an exact integer multiple of the canonical size, integer-downscale it, otherwise reject; compare pixel-for-pixel. Result is GENUINE iff equal. Re-encoding and integer upscales are tolerated; a resampled, cropped, or otherwise different image is rejected. Verification MUST NOT trust embedded metadata.
+
+**Downscaling is a check, not a resize.** When the presented image is an integer upscale by factor *s*, the verifier MUST confirm that every pixel of each *s×s* block is identical before reducing that block to one pixel. Sampling one pixel per block and discarding the rest satisfies a pixel-for-pixel comparison of the reduced image while leaving *s²−1* of every *s²* pixels unexamined and under the presenter's control: at *s* = 8 that is 63 of every 64 pixels, 98.44% of what the viewer actually sees, free to carry a different mark entirely. A block whose pixels are not uniform MUST be reported as a verification failure in its own right, never as a size error and never as GENUINE.
+
+**Rendering-affecting chunks MUST be rejected.** A presented PNG carrying `tRNS`, `gAMA`, `iCCP`, `sRGB`, `cHRM`, `sBIT`, `bKGD`, or the APNG chunks `acTL`, `fcTL`, `fdAT` MUST be rejected. These change what a conformant viewer draws without changing the stored pixel values the comparison reads, so an image that is byte-identical under comparison can present as a different mark. The constraint above on the canonical seal binds what a writer emits; this binds what a verifier accepts, and the two are not the same requirement. Chunks that cannot alter rendering (`tEXt`, `iTXt`, `pHYs`, `tIME`) remain tolerated.
 
 ### 6. Tamper fingerprint (build / running-code provenance digest)
 
@@ -205,6 +211,9 @@ For a canary, absence, `STALE`, or `INVALID` is itself the warning.
 
 - An anchor is re-derived, never received: a verifier presented with `(data, kind)` and a claimed code/seal MUST recompute `SHA-256(seed)` per §2 and compare, and MUST NOT trust any embedded code or metadata.
 - A code MUST be version-checked before its body is interpreted as a SHA-256 digest (§3).
+- A value that is not valid UTF-8 MUST be rejected as a kind, never substituted; substitution collapses distinct kinds onto one anchor (§4).
+- An integer upscale MUST be reduced only after confirming every pixel of each block is identical; sampling one pixel per block leaves the rest unexamined and presenter-controlled (§5).
+- A presented image carrying a rendering-affecting ancillary chunk MUST be rejected, because it changes what is drawn without changing the pixels compared (§5).
 - An on-chain record MUST be re-verified offline (signature + freshness) after parsing; the chain is trusted only for immutability and timestamp ordering (§7).
 
 ### 9. Versioning and parity


### PR DESCRIPTION
## Errata to BRC-145: three corrections the published text does not carry

BRC-145 merged on 2026-08-02. This PR brings `apps/0145.md` in line with three corrections to the
underlying standard, which reached it two different ways:

- **E10 and E12** are dated **2026-08-04**, two days after the merge, so the published text simply
  predates them.
- **E4** is dated **2026-07-31**, two days *before* the merge. That erratum was already adopted when
  this BRC was submitted, and §4 went out carrying text the standard had superseded. Worth stating
  plainly rather than filing E4 under the same heading as the other two.

All three are already implemented, each with a test that fails against the pre-fix behaviour. This is
the specification catching up to shipped code, not a proposal for new behaviour. Precisely:

- **E4** is in all three reference implementations, since it constrains the anchor derivation every
  implementation performs.
- **E10 and E12** are in the Python reference. They are verification rules, and as the Implementations
  section of this BRC already records, the Python implementation is the only one carrying a
  verification path; the other two are a renderer and a rendering port.

**No test vector changes:** none of these alter an anchor, a code, a canonical seal, or a signature.
They constrain what a verifier *accepts*.

Two of the three are security-relevant.

### E10 (§5): downscaling is a check, not a resize

The merged text says to integer-downscale an exact multiple and compare pixel-for-pixel, without
saying **how** to downscale. Sampling one pixel per block satisfies that wording exactly, while
leaving `s²−1` of every `s²` pixels unexamined and under the presenter's control.

At `s = 8` that is 63 of every 64 pixels, **98.44% of what the viewer actually sees**, free to carry
a different mark entirely while the verifier reports GENUINE. For a visual trust mark, where the
whole guarantee is "the image in front of you is the real one", that is the failure that matters.

The PR specifies the downscale as a check: every pixel of each block MUST be confirmed identical
before the block is reduced, and a non-uniform block is a verification failure in its own right,
never a size error and never GENUINE.

### E12 (§5): rendering-affecting chunks MUST be rejected

The merged text constrains the **canonical** seal to carry no ancillary chunks. It does not constrain
what a verifier **accepts**, and those are different requirements.

A presented PNG carrying `tRNS`, `gAMA`, `iCCP`, `sRGB`, `cHRM`, `sBIT`, `bKGD`, or the APNG chunks
changes what a conformant viewer draws without changing the stored pixel values the comparison reads.
So an image that is byte-identical under comparison can present as a different mark. Such an image
MUST be rejected. Chunks that cannot alter rendering (`tEXt`, `iTXt`, `pHYs`, `tIME`) remain
tolerated.

### E4 (§4): an ill-formed kind is not a kind

The merged text reads: the anchor "treats it as an opaque byte string, so **any** string is a valid
kind." A value that cannot be encoded as valid UTF-8 MUST be rejected and MUST NOT have replacement
characters substituted.

Substitution is not a lenient reading of the rule, it is a collision: every unpaired surrogate encodes
to the same replacement bytes, so two distinct kinds differing only in their ill-formed portion derive
one anchor, and a commitment to one verifies against the other. This one is a contradiction in the
published text rather than an omission.

### Also

§8's verification-requirements summary gains a bullet for each, since that list is where an
implementer looks for the checklist.

### Scope

Two further errata from the same date (a canary record's field shape, and `MALFORMED` versus
`INVALID` for an unparseable key or signature) concern the warrant canary, which BRC-145 does not
specify. They are deliberately not in this PR.
