### PR TITLE
BRC-161/162: BSV-21 fungible tokens (JSON + binary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ BRC | Standard
 158  | [Outpoint BEEF](./transactions/0158.md)
 159  | [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 160  | [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
+161  | [BSV-21 Fungible Tokens (JSON / Legacy)](./tokens/0161.md)
+162  | [BSV-21 Fungible Tokens (Binary)](./tokens/0162.md)
 164  | [Output Identity Tags for BRC-100 Wallets](./wallet/0164.md)
 168  | [Verifiable Time Allocation](./apps/0168.md)
 169  | [Universal Handle Addressing and Resolution for the Metanet](./peer-to-peer/0169.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -120,6 +120,8 @@
 * [1Sat Provenance Remittance for Basket `1sat`](./tokens/0150.md)
 * [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 * [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
+* [BSV-21 Fungible Tokens (JSON / Legacy)](./tokens/0161.md)
+* [BSV-21 Fungible Tokens (Binary)](./tokens/0162.md)
 * [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)
 
 ## Overlays

--- a/tokens/0161.md
+++ b/tokens/0161.md
@@ -13,31 +13,31 @@ This document specifies the **legacy JSON wire encoding** of BSV-21 fungible tok
 1. **Fixed supply** — the entire supply is created in one deploy output.
 2. **Auth (authority)** — deploy creates minting authority; later spends of authority mint new supply.
 
-A binary script-prefix encoding is specified separately in [BRC-162](./0162.md).
+A binary script-prefix encoding of the same token model is described in [BRC-162](./0162.md).
 
 ## Motivation
 
-Earlier BSV-20 used ticker-first ("first is first") public minting. That model does not give issuers a stable contract identity or controlled minting. BSV-21 replaces ticker identity with **deploy-outpoint identity** and adds authority-gated minting while keeping a pure UTXO balance model:
+Issuers need fungible tokens that:
 
-* Parallel spends (no global account ledger).
-* Ordinary Bitcoin locking scripts on token outputs.
-* Indexers validate per-token balance and authority rules without an account database.
+* have a **stable id** that is not a global ticker race,
+* move as **UTXOs** (split, merge, parallel spends), and
+* support both **fixed supply** and **issuer-controlled minting**.
 
-This JSON form is what mainnet inventory uses today (`"p": "bsv-20"`, content type `application/bsv-20`). It is not the deprecated ticker-based BSV-20 protocol.
+BSV-21 identifies each token by its **deploy outpoint** and carries balances on outputs. The token fields are a **prefix on the locking script**: they do not replace the spend condition. Any script can follow — P2PKH, multisig, covenants, marketplace templates, and other contract locks — so token value and Bitcoin script stay **composable**. Indexers enforce per-token supply and authority rules; consensus does not run a separate token VM.
+
+The JSON encoding in this document puts those fields in an `ord` inscription (`application/bsv-20`). The envelope and 1-sat output are only the **carrier** ([BRC-160](./0160.md), [BRC-159](./0159.md)). Token identity, transfers, mints, and burns follow the UTXO and authority rules here — **not** 1Sat sat-ordering or origin tracking.
+
+BSV-21 builds on an earlier **BSV-20** inscription format, which is **deprecated**. It keeps the same content type and JSON `"p": "bsv-20"` so existing inventory stays readable.
 
 ## Relationship to other documents
 
 | Concern | Document |
 |---------|----------|
-| Binary encoding | [BRC-162](./0162.md) |
 | UTXOs as tokens (philosophy) | [BRC-45](./0045.md) |
 | 1Sat origin and sat ordering | [BRC-159](./0159.md) |
 | Inscription envelopes | [BRC-160](./0160.md) |
-| Deprecated ticker BSV-20 | [1Sat docs — BSV-20](https://docs.1satordinals.com/fungible-tokens/bsv20) |
 
 This BRC does **not** define marketplace locks, overlay topic naming, or BRC-100 basket profiles for tokens.
-
-Indexers MUST keep supporting this encoding for existing tokens. Token id is the deploy outpoint in both encodings; balances for the same id SHOULD be aggregated across encodings.
 
 ## Specification
 
@@ -118,6 +118,12 @@ Deploy creates **no** token value. The deploy output is the first **authority** 
   "icon": "abc123…def456_0"
 }
 ```
+
+### Deploy under a contract
+
+The **deploy** output may be locked with a covenant (or other contract) in the same transaction that creates the token.
+
+In the fixed-supply model, the whole initial supply is born under the contract’s spend rules. In the authority model, minting capability is born the same way. Later holders still receive ordinary value outputs; what the contract enforces is whatever it locks (deploy, authority, or both).
 
 ### Deploy display fields
 
@@ -321,16 +327,13 @@ Out: 300 + 400
 
 ## Implementations
 
-* **1sat-stack** — Go template `pkg/template/bsv21`, overlay/lookup `pkg/lookup/bsv21`, parse tag `bsv21` ([b-open-io/1sat-stack](https://github.com/b-open-io/1sat-stack)).
-* **1sat-sdk** — TypeScript `@1sat/templates` BSV21, `@1sat/actions` deploy/mint/transfer helpers ([b-open-io/1sat-sdk](https://github.com/b-open-io/1sat-sdk)).
-* Historical docs and ecosystem references: [docs.1satordinals.com](https://docs.1satordinals.com/fungible-tokens/bsv-21).
+* [b-open-io/1sat-stack](https://github.com/b-open-io/1sat-stack)
+* [b-open-io/1sat-sdk](https://github.com/b-open-io/1sat-sdk)
 
 ## References
 
-1. 1Sat Ordinals — BSV-21 — <https://docs.1satordinals.com/fungible-tokens/bsv-21>
-2. 1Sat Ordinals — BSV-20 (deprecated) — <https://docs.1satordinals.com/fungible-tokens/bsv20>
-3. [BRC-36](../outpoints/0036.md) — Format for Bitcoin Outpoints
-4. [BRC-45](./0045.md) — Definition of UTXOs as Bitcoin Tokens
-5. [BRC-159](./0159.md) — 1Sat core
-6. [BRC-160](./0160.md) — 1Sat Ordinals — Inscription Envelopes
-7. B protocol (Bitcom `19HxigV4QyBv3tHpQVcUEQyq1pzZVdoAut`)
+1. [BRC-36](../outpoints/0036.md) — Format for Bitcoin Outpoints
+2. [BRC-45](./0045.md) — Definition of UTXOs as Bitcoin Tokens
+3. [BRC-159](./0159.md) — 1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking
+4. [BRC-160](./0160.md) — 1Sat Ordinals — Inscription Envelopes
+5. B protocol (Bitcom `19HxigV4QyBv3tHpQVcUEQyq1pzZVdoAut`)

--- a/tokens/0161.md
+++ b/tokens/0161.md
@@ -13,7 +13,7 @@ This document specifies the **legacy JSON wire encoding** of BSV-21 fungible tok
 1. **Fixed supply** — the entire supply is created in one deploy output.
 2. **Auth (authority)** — deploy creates minting authority; later spends of authority mint new supply.
 
-**New tokens SHOULD use the binary encoding**, [BRC-162](./0162.md). This JSON encoding remains normative so indexers and wallets can support existing inventory.
+A binary script-prefix encoding is specified separately in [BRC-162](./0162.md).
 
 ## Motivation
 
@@ -23,13 +23,13 @@ Earlier BSV-20 used ticker-first ("first is first") public minting. That model d
 * Ordinary Bitcoin locking scripts on token outputs.
 * Indexers validate per-token balance and authority rules without an account database.
 
-This JSON form is what mainnet inventory uses today (`"p": "bsv-20"`, content type `application/bsv-20`). It is not the deprecated ticker-based BSV-20 protocol. Script-native issuance and contracts should follow the binary encoding ([BRC-162](./0162.md)) instead.
+This JSON form is what mainnet inventory uses today (`"p": "bsv-20"`, content type `application/bsv-20`). It is not the deprecated ticker-based BSV-20 protocol.
 
 ## Relationship to other documents
 
 | Concern | Document |
 |---------|----------|
-| **Preferred encoding for new tokens** | [BRC-162](./0162.md) |
+| Binary encoding | [BRC-162](./0162.md) |
 | UTXOs as tokens (philosophy) | [BRC-45](./0045.md) |
 | 1Sat origin and sat ordering | [BRC-159](./0159.md) |
 | Inscription envelopes | [BRC-160](./0160.md) |

--- a/tokens/0161.md
+++ b/tokens/0161.md
@@ -1,0 +1,336 @@
+# BRC-161: BSV-21 Fungible Tokens (JSON / Legacy)
+
+Open Protocol Labs (info@opl.dev)
+
+**Authors:** David Case (dcase@opl.dev), Luke Rohenaz (luke@opl.dev)
+
+**Contributors:** Kurt Wuckert Jr. (kurt@opl.dev), Michael Boyd (root@opl.dev), Dan Wagner (dan@opl.dev)
+
+## Abstract
+
+This document specifies the **legacy JSON wire encoding** of BSV-21 fungible tokens: an `ord` inscription with content type `application/bsv-20`. Token balances live in UTXOs. Each token is identified by the outpoint of its **deploy** output. Two supply models are supported:
+
+1. **Fixed supply** — the entire supply is created in one deploy output.
+2. **Auth (authority)** — deploy creates minting authority; later spends of authority mint new supply.
+
+**New tokens SHOULD use the binary encoding**, [BRC-162](./0162.md). This JSON encoding remains normative so indexers and wallets can support existing inventory.
+
+## Motivation
+
+Earlier BSV-20 used ticker-first ("first is first") public minting. That model does not give issuers a stable contract identity or controlled minting. BSV-21 replaces ticker identity with **deploy-outpoint identity** and adds authority-gated minting while keeping a pure UTXO balance model:
+
+* Parallel spends (no global account ledger).
+* Ordinary Bitcoin locking scripts on token outputs.
+* Indexers validate per-token balance and authority rules without an account database.
+
+This JSON form is what mainnet inventory uses today (`"p": "bsv-20"`, content type `application/bsv-20`). It is not the deprecated ticker-based BSV-20 protocol. Script-native issuance and contracts should follow the binary encoding ([BRC-162](./0162.md)) instead.
+
+## Relationship to other documents
+
+| Concern | Document |
+|---------|----------|
+| **Preferred encoding for new tokens** | [BRC-162](./0162.md) |
+| UTXOs as tokens (philosophy) | [BRC-45](./0045.md) |
+| 1Sat origin and sat ordering | [BRC-159](./0159.md) |
+| Inscription envelopes | [BRC-160](./0160.md) |
+| Deprecated ticker BSV-20 | [1Sat docs — BSV-20](https://docs.1satordinals.com/fungible-tokens/bsv20) |
+
+This BRC does **not** define marketplace locks, overlay topic naming, or BRC-100 basket profiles for tokens.
+
+Indexers MUST keep supporting this encoding for existing tokens. Token id is the deploy outpoint in both encodings; balances for the same id SHOULD be aggregated across encodings.
+
+## Specification
+
+### Token identification
+
+* A **token id** is the outpoint of the deploy output that created the token.
+* The `id` field MUST use the form `<txid>_<vout>`: 64 lowercase hex txid characters, underscore, non-negative decimal `vout`.
+* That same underscore form is the token id everywhere else — APIs, storage, topic names, comparison. A token id is a BSV-21 identifier, not a general outpoint reference, so it does not take the [BRC-36](../outpoints/0036.md) dot form.
+* The token id is fixed for the life of the token. Transfers never change it.
+
+### UTXO model
+
+BSV-21 balances are carried on transaction outputs. Spending a valid token (or authority) input and creating valid token (or authority) outputs is how supply moves, splits, merges, mints, or burns. Any Bitcoin locking script MAY lock a token output (P2PKH, multisig, covenant, marketplace template, …).
+
+### Content type and inscription
+
+JSON BSV-21 fields live in a 1Sat / `ord` **inscription** on the output locking script:
+
+* Content type MUST be `application/bsv-20`.
+* Body MUST be a JSON object.
+* Protocol field `"p"` MUST be the string `bsv-20`.
+
+Inscription envelope rules are defined in [BRC-160](./0160.md). Unrecognized JSON keys MUST be ignored; only fields defined here affect validity.
+
+### Relationship to 1Sat Ordinals
+
+The `ord` envelope is only the **carrier** for the BSV-21 JSON payload. Token identity, transfers, mints, and burns follow the UTXO balance and authority rules in this document — **not** [BRC-159](./0159.md) sat ordering or origin tracking.
+
+A spend moves tokens because valid value (or authority) inputs fund valid outputs of the same token id. Whether the 1-satoshi lands in a particular output under ordinal theory is irrelevant to BSV-21 admission.
+
+### Supply models
+
+#### Fixed supply — `deploy+mint`
+
+One output creates the token and holds the entire initial supply.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `p` | Yes | `bsv-20` |
+| `op` | Yes | `deploy+mint` |
+| `amt` | Yes | Total supply as decimal string, max `2^64 - 1` |
+| `dec` | No | Decimal precision 0–18; default 0; **string** integer only |
+| `sym` | No | See [Symbol (`sym`)](#symbol-sym) |
+| `icon` | No | See [Icon (`icon`)](#icon-icon) |
+
+```json
+{
+  "p": "bsv-20",
+  "op": "deploy+mint",
+  "amt": "21000000",
+  "sym": "GOLD",
+  "dec": "8",
+  "icon": "abc123…def456_0"
+}
+```
+
+Token id = this output's outpoint.
+
+#### Authority supply — `deploy+auth`
+
+Deploy creates **no** token value. The deploy output is the first **authority** UTXO. Later authority spends mint value.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `p` | Yes | `bsv-20` |
+| `op` | Yes | `deploy+auth` |
+| `dec` | No | Decimals 0–18, default 0 (string) |
+| `sym` | No | See [Symbol (`sym`)](#symbol-sym) |
+| `icon` | No | See [Icon (`icon`)](#icon-icon) |
+| `amt` | No | **MUST NOT** be present |
+
+```json
+{
+  "p": "bsv-20",
+  "op": "deploy+auth",
+  "sym": "STABLE",
+  "dec": "2",
+  "icon": "abc123…def456_0"
+}
+```
+
+### Deploy display fields
+
+`sym`, `icon`, and `dec` are optional **deploy-only** display metadata. They are set on `deploy+mint` / `deploy+auth` and inherited for wallets and indexers on all later operations. They MUST NOT appear as required fields on `mint`, `auth`, `transfer`, or `burn`. Missing or malformed display fields do **not** invalidate the deploy or the token id.
+
+#### Symbol (`sym`)
+
+| | |
+|--|--|
+| Presence | Optional on deploy |
+| Type | JSON string |
+| Meaning | Short human-readable ticker / name for UI |
+| Uniqueness | **Not** enforced. Many tokens MAY share the same `sym`. Applications MUST key tokens by deploy outpoint id, never by symbol alone. |
+
+Empty string and omission are both treated as "no symbol."
+
+#### Icon (`icon`)
+
+| | |
+|--|--|
+| Presence | Optional on deploy |
+| Type | JSON string |
+| Meaning | Pointer to on-chain image bytes used as the token icon |
+
+When present, `icon` MUST be an **outpoint** naming the output that holds the image:
+
+* Format: `<txid>_<vout>` (64 hex txid, underscore, non-negative decimal `vout`).
+* Relative form: `_N` (underscore + decimal vout) MAY be used when the image output is in the **same transaction** as the deploy. Indexers expand this to `<deploy_txid>_N`.
+
+The referenced outpoint MUST be one of:
+
+1. **Inscription** — a 1Sat / `ord` inscription whose body is image (or other display) content ([BRC-160](./0160.md)); or
+2. **B protocol** — a B (B protocol (Bitcom `19HxigV4QyBv3tHpQVcUEQyq1pzZVdoAut`)) file output whose payload is the image bytes.
+
+`icon` is a **pointer only**. It is not embedded image data, not an HTTP(S) URL, and not required for token validity. Wallets resolve the outpoint (e.g. via OrdFS `/content/{outpoint}`) to fetch bytes and content type. If the outpoint is missing, unresolvable, or not image-like, UIs SHOULD fall back to a placeholder; the token remains valid.
+
+Same-tx example (image inscribed on output 0, token deploy on output 1):
+
+```json
+{
+  "p": "bsv-20",
+  "op": "deploy+mint",
+  "amt": "1000",
+  "sym": "TEST",
+  "icon": "_0"
+}
+```
+
+### Operations after deploy
+
+#### `mint`
+
+Creates new supply by spending at least one valid authority input of the same token.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `p` | Yes | `bsv-20` |
+| `op` | Yes | `mint` |
+| `id` | Yes | Token id (`txid_vout` of deploy) |
+| `amt` | Yes | Amount minted in this output (string uint64) |
+
+Any number of `mint` outputs MAY be created from a single authority spend. Minted amounts are **created**, not drawn from input balances.
+
+#### `auth`
+
+Continues, splits, merges, or transfers minting authority. Does not carry token value.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `p` | Yes | `bsv-20` |
+| `op` | Yes | `auth` |
+| `id` | Yes | Token id |
+| `amt` | No | **MUST NOT** be present |
+
+Authority capabilities:
+
+* **Split** — one auth in → many auth out
+* **Combine** — many auth in → one auth out
+* **Transfer** — auth to a new locking script
+* **End** — spend auth with no replacement auth out (that auth is destroyed; minting for the token ends only when **no** auth outputs remain)
+
+#### `transfer`
+
+Moves existing supply.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `p` | Yes | `bsv-20` |
+| `op` | Yes | `transfer` |
+| `id` | Yes | Token id |
+| `amt` | Yes | Amount in this output (string uint64) |
+
+#### `burn`
+
+Explicitly removes supply from circulation. Burn outputs are recorded for supply accounting (mints − burns) but carry **no** spendable token value. Spending a burn output later has no effect on token validation.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `p` | Yes | `bsv-20` |
+| `op` | Yes | `burn` |
+| `id` | Yes | Token id |
+| `amt` | Yes | Amount burned in this output (string uint64) |
+
+### Field validation summary
+
+| Field | Rules |
+|-------|--------|
+| `amt` | Required: `deploy+mint`, `mint`, `transfer`, `burn`. Prohibited: `deploy+auth`, `auth`. Decimal string of uint64 (max 18446744073709551615). |
+| `id` | Required: `mint`, `auth`, `transfer`, `burn`. Format `txid_vout` (valid outpoint). Auto = deploy outpoint for deploy ops. |
+| `dec` | Optional on deploy only. String integer 0–18. Default 0. Numeric JSON numbers are **not** valid. |
+| `sym` | Optional on deploy only. Display string; not unique. See [Symbol](#symbol-sym). |
+| `icon` | Optional on deploy only. Outpoint pointer to an inscription or B-protocol file. See [Icon](#icon-icon). |
+
+### Validation rules
+
+Validation is **per token id** within a transaction. Indexers admit or reject outputs; consensus miners do not enforce BSV-21 rules.
+
+**Deploy** (`deploy+mint`, `deploy+auth`):
+
+* Always valid as genesis (no token-input check).
+* Token id := this output's outpoint.
+
+**Mint**:
+
+* Requires at least one valid **authority** input of the same token.
+* Mint outputs create supply; they are not paid from transfer-input balances.
+
+**Auth**:
+
+* Requires spending a valid authority input of the same token.
+* Auth inputs contribute **0** to token balance.
+
+**Transfer and burn (balance)**:
+
+* Let `I` = sum of amounts on valid **value** inputs of this token (prior admitted `deploy+mint`, `mint`, or `transfer` outputs — not auth, not burn).
+* Let `O_t` = sum of `transfer` output amounts for this token.
+* Let `O_b` = sum of `burn` output amounts for this token.
+* Admit transfer and burn outputs only when `I >= O_t + O_b`.
+* If `O_t + O_b > I`: those outputs are invalid and input tokens are **burned** (no admitted transfer/burn outs from that imbalance).
+* If `I > O_t + O_b`: the excess is burned (implicit burn).
+* Authority inputs do **not** relax transfer balance checks. Presence of auth does not allow unfunded transfers.
+* Burn inputs contribute nothing to `I`.
+
+**Display metadata:**
+
+* `sym`, `icon`, and `dec` are set at deploy only (see [Deploy display fields](#deploy-display-fields)).
+* Later operations need not repeat them; indexers attach deploy metadata when serving balances.
+* Invalid or unresolvable `icon` does not affect balance or authority admission.
+
+### Locking scripts
+
+Any valid locking script is allowed. BSV-21 does not constrain spend conditions beyond the inscription fields and the validation rules above.
+
+### Satoshi value (convention)
+
+By convention in the 1Sat ecosystem, token outputs often hold **1 satoshi**. That is ecosystem practice for indexing and wallet UX, not a consensus rule of this protocol. Validators MAY apply a 1-sat policy when admitting outputs.
+
+### Protocol identifier note
+
+All JSON operations use `"p": "bsv-20"` for backward compatibility. Implementations MUST NOT require `"p": "bsv-21"`. The name **BSV-21** refers to this specification family (deploy-id tokens + auth), not the JSON `p` string.
+
+## Examples
+
+### Fixed supply lifecycle
+
+1. **Deploy** `deploy+mint` with `amt: "10000"`, `dec: "2"` → token `abc…_0` with 10 000 base units (100.00 display).
+2. **Split** — spend deploy; two `transfer` outs of 5 000 each.
+3. **Pay** — spend one 5 000; `transfer` 4 900 to recipient + 100 change.
+
+### Auth lifecycle
+
+1. **Deploy** `deploy+auth` → token `def…_0`, authority at that outpoint.
+2. **Mint** — spend auth; outputs: `mint` 1 000 000 + `auth` (continue).
+3. **Distribute** — `transfer` splits of the mint output.
+4. **Delegate** — spend auth → two `auth` outs (admin A, admin B).
+5. **End auth** — spend an auth with no `auth` out; that authority ends. Minting stops only when the last auth is ended.
+
+### Balance check
+
+Valid:
+
+```
+In:  1000 + 500 transfer
+Out: 800 + 600 + 100 transfer
+```
+
+Invalid (all transfer outs rejected; inputs burned):
+
+```
+In:  500
+Out: 300 + 400
+```
+
+## Security considerations
+
+* **Indexer trust** — validity is not miner-enforced; wallets rely on overlays / indexers that implement these rules.
+* **Symbol collision** — `sym` is not unique; always key tokens by deploy outpoint id.
+* **Auth compromise** — holder of an authority UTXO can mint unbounded supply until that auth is ended.
+* **Over-transfer burn** — creating outputs that exceed inputs burns the inputs; careless tx building destroys balances.
+* **Display spoofing** — `sym` is not unique; `icon` is an unauthenticated outpoint claim. Resolve the pointed inscription/B file independently if display integrity matters.
+
+## Implementations
+
+* **1sat-stack** — Go template `pkg/template/bsv21`, overlay/lookup `pkg/lookup/bsv21`, parse tag `bsv21` ([b-open-io/1sat-stack](https://github.com/b-open-io/1sat-stack)).
+* **1sat-sdk** — TypeScript `@1sat/templates` BSV21, `@1sat/actions` deploy/mint/transfer helpers ([b-open-io/1sat-sdk](https://github.com/b-open-io/1sat-sdk)).
+* Historical docs and ecosystem references: [docs.1satordinals.com](https://docs.1satordinals.com/fungible-tokens/bsv-21).
+
+## References
+
+1. 1Sat Ordinals — BSV-21 — <https://docs.1satordinals.com/fungible-tokens/bsv-21>
+2. 1Sat Ordinals — BSV-20 (deprecated) — <https://docs.1satordinals.com/fungible-tokens/bsv20>
+3. [BRC-36](../outpoints/0036.md) — Format for Bitcoin Outpoints
+4. [BRC-45](./0045.md) — Definition of UTXOs as Bitcoin Tokens
+5. [BRC-159](./0159.md) — 1Sat core
+6. [BRC-160](./0160.md) — 1Sat Ordinals — Inscription Envelopes
+7. B protocol (Bitcom `19HxigV4QyBv3tHpQVcUEQyq1pzZVdoAut`)

--- a/tokens/0161.md
+++ b/tokens/0161.md
@@ -153,10 +153,10 @@ When present, `icon` MUST be an **outpoint** naming the output that holds the im
 * Format: `<txid>_<vout>` (64 hex txid, underscore, non-negative decimal `vout`).
 * Relative form: `_N` (underscore + decimal vout) MAY be used when the image output is in the **same transaction** as the deploy. Indexers expand this to `<deploy_txid>_N`.
 
-The referenced outpoint MUST be one of:
+The referenced outpoint SHOULD be one of:
 
 1. **Inscription** — a 1Sat / `ord` inscription whose body is image (or other display) content ([BRC-160](./0160.md)); or
-2. **B protocol** — a B (B protocol (Bitcom `19HxigV4QyBv3tHpQVcUEQyq1pzZVdoAut`)) file output whose payload is the image bytes.
+2. **B protocol** — a Bitcom B protocol file output (`19HxigV4QyBv3tHpQVcUEQyq1pzZVdoAut`) whose payload is the image bytes.
 
 `icon` is a **pointer only**. It is not embedded image data, not an HTTP(S) URL, and not required for token validity. Wallets resolve the outpoint (e.g. via OrdFS `/content/{outpoint}`) to fetch bytes and content type. If the outpoint is missing, unresolvable, or not image-like, UIs SHOULD fall back to a placeholder; the token remains valid.
 

--- a/tokens/0162.md
+++ b/tokens/0162.md
@@ -1,0 +1,319 @@
+# BRC-162: BSV-21 Fungible Tokens (Binary)
+
+Open Protocol Labs (info@opl.dev)
+
+**Authors:** David Case (dcase@opl.dev)
+
+**Contributors:** Luke Rohenaz (luke@opl.dev), Kurt Wuckert Jr. (kurt@opl.dev), Michael Boyd (root@opl.dev), Dan Wagner (dan@opl.dev)
+
+## Abstract
+
+**BSV-21 (binary)** is a fungible token protocol for Bitcoin SV. Token balances live in UTXOs. Each token is identified by the outpoint of its **deploy** output. Token data is a fixed **script prefix** of data pushes — readable and constructible in Bitcoin script without parsing JSON.
+
+Two supply models:
+
+1. **Fixed supply** — the entire supply is created in one deploy output.
+2. **Authority** — deploy creates minting authority; later authority spends mint new supply.
+
+This encoding is the **preferred path for new tokens**. It succeeds the widely deployed JSON / inscription form of BSV-21 ([BRC-161](./0161.md)), which remains supported. Same deploy-outpoint identity and the same UTXO + authority economics; different wire format, designed so contracts can participate.
+
+## Motivation
+
+BSV-21 already proved out deploy-id fungible tokens on mainnet via JSON inscriptions (`application/bsv-20`). That form works for wallets and indexers, but it is a poor fit for Bitcoin script:
+
+* Building a token output in script means assembling an inscription envelope, quoting JSON, and converting amounts to ASCII decimals.
+* Checking a token output means parsing text instead of reading fixed offsets.
+* Token ids as hex strings use display byte order — the reverse of the 36-byte outpoint layout in sighash preimages — so even an equality check needs convert-and-reverse.
+
+Issuers and apps still need what JSON BSV-21 delivered:
+
+* Stable identity (deploy outpoint, not a global ticker race).
+* UTXO balances that split and merge like satoshis.
+* Controlled minting when issuers need it.
+
+Plus one more: data that **covenants and contracts** can build and check in script. A script-native prefix gives that — amount as a script number, id as a preimage-shaped outpoint, outputs as concatenated pushes — without abandoning the token model users already hold.
+
+Indexers still enforce balance and authority rules off-chain; miners do not. Legacy JSON outputs stay valid and must keep working; this document defines binary fully on its own so implementers do not need the JSON spec to build or validate binary tokens.
+
+## Relationship to other documents
+
+| Concern | Document |
+|---------|----------|
+| UTXOs as tokens (philosophy) | [BRC-45](./0045.md) |
+| Outpoint formats | [BRC-36](../outpoints/0036.md) |
+| Legacy JSON encoding (existing inventory) | [BRC-161](./0161.md) |
+
+This BRC does **not** define marketplace locks, overlay topic naming, or BRC-100 basket profiles.
+
+### Legacy JSON inventory
+
+The earlier inscription-based encoding is specified in [BRC-161](./0161.md). It is not required reading for implementing this document.
+
+* **Indexers and wallets** MUST continue to recognize the legacy JSON encoding so existing token inventory remains usable.
+* Token id is the deploy outpoint in both encodings. Outputs of either encoding for the same deploy outpoint are the **same token**; balances MUST be aggregated by that id.
+* Authority inputs of either encoding gate minting for that token id.
+* Each output validates under the rules of **its** encoding (do not assume identical mint/transfer edge cases across encodings).
+
+## Specification
+
+### Wire format
+
+Every token output begins with:
+
+```
+<push "BSV21"> <push token id | OP_0> OP_2DROP <push amount | OP_0> <push payload | OP_0> OP_2DROP <rest of script>
+```
+
+| Element | Encoding |
+|---------|----------|
+| Tag | Push of UTF-8 `BSV21` (hex `4253563231`) |
+| Token id | Push of 36-byte outpoint (32-byte txid + 4-byte little-endian vout), or `OP_0` on deploys |
+| `OP_2DROP` | Drops tag and id |
+| Amount | Minimally encoded script number (> 0 = value), or `OP_0` for authority |
+| Payload | `OP_0` (empty), or a CBOR map (see [Payload](#payload)) |
+| `OP_2DROP` | Drops amount and payload |
+| Rest | Remainder of the locking script (any valid Bitcoin script — e.g. P2PKH, multisig, covenant, marketplace lock) |
+
+Rules:
+
+* All four pushes are always present; empty values use `OP_0`.
+* The prefix pushes four values and drops all four, so the remainder of the script runs as if alone.
+* A script is a BSV-21 binary token output when the prefix matches this layout (including a valid payload push — `OP_0` or CBOR map). Tag, id, and amount define the role; map **contents** do not affect balance or authority admission.
+* The tag push is the only protocol marker.
+* A decoder consumes the prefix; everything after it is ordinary locking-script content for whatever spend path the output uses.
+
+### Token identification
+
+* A **token id** is the outpoint of the deploy output that created the token.
+* On the wire it is **36 bytes**: txid in natural/internal byte order ‖ `uint32` little-endian vout — the same layout as outpoints in sighash preimages.
+* Deploy leaves the id field empty (`OP_0`); that output's own outpoint **is** the token id.
+* Every later output for the token carries the 36-byte id.
+* The token id is fixed for the life of the token.
+* For display and APIs, the string form is `<txid>_<vout>` (64 hex chars in display txid byte order, **underscore** separator) — the same form used by the JSON encoding ([BRC-161](./0161.md)); this id form is fixed for BSV-21 and is not the general dual-form outpoint convention in [BRC-159](./0159.md), so a token presents identically under either encoding. Converting between 36-byte form and that string reverses the 32 txid bytes only.
+
+### UTXO model
+
+Balances are carried on transaction outputs. Spending valid value or authority inputs and creating valid value or authority outputs is how supply moves, splits, merges, mints, or burns. Any Bitcoin locking script MAY lock a token output (P2PKH, multisig, covenant, marketplace template, …).
+
+### Roles
+
+Each output's role is determined only by whether the token id is present and by the amount:
+
+| Token id | Amount | Role |
+|----------|--------|------|
+| Empty | > 0 | **Deploy (fixed supply)** — entire initial supply in this output |
+| Empty | 0 | **Deploy (authority)** — first minting authority; no initial value |
+| Present | 0 | **Authority** — minting capability for this token |
+| Present | > 0 | **Value** — spendable token balance |
+
+### Amounts
+
+* Bitcoin script numbers: minimally encoded, non-negative, little-endian.
+* Domain: `0` … `2^64 - 1`. The maximum encodes in nine bytes (eight value bytes + high zero sign byte).
+* Amounts above the maximum, negative values, or non-minimal encodings are **invalid**.
+* Amount zero marks **authority**, not value.
+
+### Payload
+
+* The fourth push MUST be either `OP_0` (empty) or a CBOR map ([RFC 8949](https://www.rfc-editor.org/rfc/rfc8949.html)).
+* Encoders SHOULD use deterministic CBOR (RFC 8949 §4.2) when writing a map.
+* A non-empty push that is not a CBOR map is **not** a valid BSV-21 binary token output.
+* Map contents do not affect balance or authority admission. Defined deploy display keys are specified below; unknown keys are ignored.
+
+### Deploy display fields
+
+Optional metadata on the **deploy** output only. Later outputs normally use `OP_0` and inherit display data from deploy. Missing or malformed display fields do **not** invalidate the deploy. These keys have no protocol meaning on non-deploy outputs. Additional keys MAY be defined later.
+
+#### Symbol (`sym`)
+
+| | |
+|--|--|
+| CBOR type | text string |
+| Presence | Optional |
+| Meaning | Short human-readable ticker / name for UI |
+| Uniqueness | **Not** enforced. Applications MUST key tokens by deploy outpoint id. |
+
+#### Icon (`icon`)
+
+| | |
+|--|--|
+| CBOR type | byte string, **4 or 36 bytes** |
+| Presence | Optional |
+| Meaning | Pointer to on-chain image bytes |
+
+| Length | Encoding | Meaning |
+|--------|----------|---------|
+| 36 | 32-byte txid (natural order) ‖ 4-byte little-endian vout | Absolute outpoint |
+| 4 | 4-byte little-endian vout only | Same-transaction relative: output index in the **deploy** transaction |
+
+Indexers expand a 4-byte value by prepending the deploy output's txid, yielding a normal 36-byte outpoint. Any other length is treated as absent.
+
+The referenced outpoint SHOULD hold image (or other display) bytes — commonly a B protocol file (B protocol (`19HxigV4QyBv3tHpQVcUEQyq1pzZVdoAut`)) or an ordinal inscription. `icon` is a pointer only — not embedded image data and not a URL. Wallets resolve the outpoint to fetch content. Unresolvable icons do not affect token validity.
+
+#### Decimals (`dec`)
+
+| | |
+|--|--|
+| CBOR type | unsigned integer |
+| Presence | Optional |
+| Range | 0–18; default 0 |
+
+### Supply models
+
+#### Fixed supply
+
+Deploy with empty id and amount > 0. That amount is the entire initial supply held in the deploy output. No authority is created unless a separate authority deploy is used (a token has one deploy outpoint).
+
+#### Authority supply
+
+Deploy with empty id and amount 0. That output is the first **authority**. Later spends of authority may create value outputs (mint) and/or further authority outputs.
+
+### Authority operations
+
+Authority outputs (id present, amount 0) may be:
+
+* **Split** — one authority in → many authority out
+* **Combine** — many in → one out
+* **Transfer** — re-lock to a new script
+* **End** — spend without a replacement authority out (that authority is destroyed)
+
+Minting for the token ends only when **no** authority outputs remain.
+
+### Value operations
+
+Value outputs (id present, amount > 0) move existing supply or, when an authority input is present, create new supply (mint). Split and merge are ordinary multi-input / multi-output spends under the balance rules below.
+
+### Validation rules
+
+Validation is **per token id** within a transaction. Indexers admit or reject outputs; consensus miners do not enforce these rules.
+
+**Deploy** (empty id):
+
+* Always valid as genesis (no token-input check).
+* Token id := this output's outpoint.
+
+**Authority** (id present, amount 0):
+
+* Valid only when the transaction spends a valid authority of the same token.
+* Deploy with amount 0 is the token's first authority.
+* Authority inputs contribute **0** to token balance.
+
+**Value** (id present, amount > 0):
+
+* If the transaction spends a valid authority for the token: value outputs are valid **without** input balance coverage (mint).
+* Otherwise: let `I` = sum of amounts on valid value inputs of this token; let `O` = sum of amounts on value outputs of this token.
+  * Admit value outputs only when `I >= O` (all value outs for the token, or none — all-or-nothing).
+  * If `O > I`: value outputs are invalid; input tokens are **burned**.
+  * If `I > O`: the difference is burned (implicit burn).
+
+Circulating supply is the sum of admitted unspent value UTXOs.
+
+**Display metadata:**
+
+* `sym`, `icon`, and `dec` are set at deploy only.
+* Invalid or unresolvable `icon` does not affect balance or authority admission.
+
+### Locking scripts
+
+Any valid locking script is allowed after the prefix. This protocol does not constrain spend conditions beyond the prefix fields and the validation rules above.
+
+### Satoshi value (convention)
+
+By convention, token outputs often hold **1 satoshi**. That is ecosystem practice for indexing and wallet UX, not a protocol rule. Validators MAY apply a 1-sat policy when admitting outputs.
+
+## Examples
+
+### Output scripts
+
+Fixed supply deploy (P2PKH), metadata in CBOR payload:
+
+```
+"BSV21" OP_0 OP_2DROP 21000000 <CBOR {"sym":"GOLD","dec":8}> OP_2DROP
+OP_DUP OP_HASH160 <pubkeyhash> OP_EQUALVERIFY OP_CHECKSIG
+```
+
+Authority deploy:
+
+```
+"BSV21" OP_0 OP_2DROP OP_0 <CBOR {"sym":"STABLE","dec":2}> OP_2DROP
+OP_DUP OP_HASH160 <pubkeyhash> OP_EQUALVERIFY OP_CHECKSIG
+```
+
+Value output:
+
+```
+"BSV21" <36-byte token id> OP_2DROP 5000 OP_0 OP_2DROP <locking script>
+```
+
+Authority output:
+
+```
+"BSV21" <36-byte token id> OP_2DROP OP_0 OP_0 OP_2DROP <locking script>
+```
+
+### Fixed supply lifecycle
+
+1. **Deploy** — empty id, amount 10 000 → token id = this outpoint.
+2. **Split** — spend deploy; two value outs of 5 000.
+3. **Pay** — spend one 5 000; value 4 900 to recipient + 100 change.
+
+### Authority lifecycle
+
+1. **Deploy** — empty id, amount 0 (genesis authority).
+2. **Mint** — spend authority; value 1 000 000 + authority (continue).
+3. **Distribute** — split the value output.
+4. **Delegate** — spend authority → two authority outs (admin A, admin B).
+5. **End authority** — spend an authority with no authority out. Minting stops only when the last authority is ended.
+
+### Balance checks
+
+Valid transfer:
+
+```
+In:  1_000 + 500 value
+Out: 800 + 600 + 100 value
+```
+
+Invalid (no authority; outs rejected; inputs burned):
+
+```
+In:  500
+Out: 300 + 400
+```
+
+Implicit burn:
+
+```
+In:  1_000
+Out: 250
+→ 750 burned
+```
+
+Mint (authority present; value need not be covered by value inputs):
+
+```
+In:  authority
+Out: value 1_000_000 + authority
+```
+
+## Security considerations
+
+* **Indexer trust** — validity is not miner-enforced; wallets rely on overlays / indexers that implement these rules.
+* **Symbol collision** — `sym` is not unique; always key tokens by deploy outpoint id.
+* **Auth compromise** — holder of an authority UTXO can mint unbounded supply until that authority is ended.
+* **Over-output burn** — creating value outputs that exceed inputs (without authority) burns the inputs.
+* **Display spoofing** — `sym` / `icon` are unauthenticated claims; resolve icon outpoints independently if display integrity matters.
+
+## Implementations
+
+* Spec source: `bsv21-binary-docs` on [BitcoinSchema/1sat-ordinals](https://github.com/BitcoinSchema/1sat-ordinals).
+* Related experiment: Shrug (`pkg/template/shrug` in 1sat-stack) — similar prefix idea, different tag; **not** interchangeable with tag `BSV21`.
+* Target implementations: 1sat-stack overlay/templates and `@1sat/*` (in progress relative to legacy JSON path).
+
+## References
+
+1. 1sat-ordinals `fungible-tokens/bsv-21-binary.md` (branch `bsv21-binary-docs`)
+2. RFC 8949 — CBOR
+3. [BRC-36](../outpoints/0036.md) — Outpoints
+4. [BRC-45](./0045.md) — UTXOs as tokens
+5. [BRC-161](./0161.md) — BSV-21 Fungible Tokens (JSON / Legacy)

--- a/tokens/0162.md
+++ b/tokens/0162.md
@@ -15,7 +15,7 @@ Two supply models:
 1. **Fixed supply** — the entire supply is created in one deploy output.
 2. **Authority** — deploy creates minting authority; later authority spends mint new supply.
 
-A JSON inscription encoding of the same token model is described in [BRC-161](./0161.md).
+This document is the **binary encoding** of BSV-21. The JSON inscription encoding of the same protocol is [BRC-161](./0161.md). Token id, supply models, and balance/authority economics are the same; only the on-output encoding differs.
 
 ## Motivation
 

--- a/tokens/0162.md
+++ b/tokens/0162.md
@@ -8,32 +8,26 @@ Open Protocol Labs (info@opl.dev)
 
 ## Abstract
 
-**BSV-21 (binary)** is a fungible token protocol for Bitcoin SV. Token balances live in UTXOs. Each token is identified by the outpoint of its **deploy** output. Token data is a fixed **script prefix** of data pushes — readable and constructible in Bitcoin script without parsing JSON.
+**BSV-21 (binary)** is a fungible token protocol for Bitcoin SV. Balances live in UTXOs. Each token is identified by the outpoint of its **deploy** output. Token data is a fixed **script prefix** of data pushes — readable and constructible in Bitcoin script without parsing JSON.
 
 Two supply models:
 
 1. **Fixed supply** — the entire supply is created in one deploy output.
 2. **Authority** — deploy creates minting authority; later authority spends mint new supply.
 
-This encoding is the **preferred path for new tokens**. It succeeds the widely deployed JSON / inscription form of BSV-21 ([BRC-161](./0161.md)), which remains supported. Same deploy-outpoint identity and the same UTXO + authority economics; different wire format, designed so contracts can participate.
+A JSON inscription encoding of the same token model is described in [BRC-161](./0161.md).
 
 ## Motivation
 
-BSV-21 already proved out deploy-id fungible tokens on mainnet via JSON inscriptions (`application/bsv-20`). That form works for wallets and indexers, but it is a poor fit for Bitcoin script:
+Issuers need fungible tokens that:
 
-* Building a token output in script means assembling an inscription envelope, quoting JSON, and converting amounts to ASCII decimals.
-* Checking a token output means parsing text instead of reading fixed offsets.
-* Token ids as hex strings use display byte order — the reverse of the 36-byte outpoint layout in sighash preimages — so even an equality check needs convert-and-reverse.
+* have a **stable id** that is not a global ticker race,
+* move as **UTXOs** (split, merge, parallel spends), and
+* support both **fixed supply** and **issuer-controlled minting**.
 
-Issuers and apps still need what JSON BSV-21 delivered:
+BSV-21 identifies each token by its **deploy outpoint** and carries balances on outputs. The token fields are a **prefix on the locking script**: they do not replace the spend condition. Any script can follow — P2PKH, multisig, covenants, marketplace templates, and other contract locks — so token value and Bitcoin script stay **composable**. Indexers enforce per-token supply and authority rules; consensus does not run a separate token VM.
 
-* Stable identity (deploy outpoint, not a global ticker race).
-* UTXO balances that split and merge like satoshis.
-* Controlled minting when issuers need it.
-
-Plus one more: data that **covenants and contracts** can build and check in script. A script-native prefix gives that — amount as a script number, id as a preimage-shaped outpoint, outputs as concatenated pushes — without abandoning the token model users already hold.
-
-Indexers still enforce balance and authority rules off-chain; miners do not. Legacy JSON outputs stay valid and must keep working; this document defines binary fully on its own so implementers do not need the JSON spec to build or validate binary tokens.
+This document defines a **binary** prefix: tag, token id, amount, and optional payload as fixed pushes (amount as a script number; id as a 36-byte outpoint in sighash preimage order). Wallets and contracts can build and check token outputs in script without assembling an inscription or parsing JSON.
 
 ## Relationship to other documents
 
@@ -41,18 +35,9 @@ Indexers still enforce balance and authority rules off-chain; miners do not. Leg
 |---------|----------|
 | UTXOs as tokens (philosophy) | [BRC-45](./0045.md) |
 | Outpoint formats | [BRC-36](../outpoints/0036.md) |
-| Legacy JSON encoding (existing inventory) | [BRC-161](./0161.md) |
+| JSON inscription encoding | [BRC-161](./0161.md) |
 
 This BRC does **not** define marketplace locks, overlay topic naming, or BRC-100 basket profiles.
-
-### Legacy JSON inventory
-
-The earlier inscription-based encoding is specified in [BRC-161](./0161.md). It is not required reading for implementing this document.
-
-* **Indexers and wallets** MUST continue to recognize the legacy JSON encoding so existing token inventory remains usable.
-* Token id is the deploy outpoint in both encodings. Outputs of either encoding for the same deploy outpoint are the **same token**; balances MUST be aggregated by that id.
-* Authority inputs of either encoding gate minting for that token id.
-* Each output validates under the rules of **its** encoding (do not assume identical mint/transfer edge cases across encodings).
 
 ## Specification
 
@@ -167,6 +152,12 @@ Deploy with empty id and amount > 0. That amount is the entire initial supply he
 #### Authority supply
 
 Deploy with empty id and amount 0. That output is the first **authority**. Later spends of authority may create value outputs (mint) and/or further authority outputs.
+
+### Deploy under a contract
+
+The **deploy** output may be locked with a covenant (or other contract) in the same transaction that creates the token.
+
+In the fixed-supply model, the whole initial supply is born under the contract’s spend rules. In the authority model, minting capability is born the same way. Later holders still receive ordinary value outputs; what the contract enforces is whatever it locks (deploy, authority, or both).
 
 ### Authority operations
 
@@ -306,14 +297,12 @@ Out: value 1_000_000 + authority
 
 ## Implementations
 
-* Spec source: `bsv21-binary-docs` on [BitcoinSchema/1sat-ordinals](https://github.com/BitcoinSchema/1sat-ordinals).
-* Related experiment: Shrug (`pkg/template/shrug` in 1sat-stack) — similar prefix idea, different tag; **not** interchangeable with tag `BSV21`.
-* Target implementations: 1sat-stack overlay/templates and `@1sat/*` (in progress relative to legacy JSON path).
+* [b-open-io/1sat-stack](https://github.com/b-open-io/1sat-stack)
+* [b-open-io/1sat-sdk](https://github.com/b-open-io/1sat-sdk)
 
 ## References
 
-1. 1sat-ordinals `fungible-tokens/bsv-21-binary.md` (branch `bsv21-binary-docs`)
-2. RFC 8949 — CBOR
-3. [BRC-36](../outpoints/0036.md) — Outpoints
-4. [BRC-45](./0045.md) — UTXOs as tokens
-5. [BRC-161](./0161.md) — BSV-21 Fungible Tokens (JSON / Legacy)
+1. RFC 8949 — CBOR
+2. [BRC-36](../outpoints/0036.md) — Outpoints
+3. [BRC-45](./0045.md) — UTXOs as tokens
+4. [BRC-161](./0161.md) — BSV-21 Fungible Tokens (JSON / Legacy)

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -17,4 +17,6 @@ BRC | Standard
 150  | [1Sat Provenance Remittance for Basket `1sat`](./0150.md)
 159  | [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./0159.md)
 160  | [1Sat Ordinals — Inscription Envelopes](./0160.md)
+161  | [BSV-21 Fungible Tokens (JSON / Legacy)](./0161.md)
+162  | [BSV-21 Fungible Tokens (Binary)](./0162.md)
 226  | [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./0226.md)


### PR DESCRIPTION
## Summary

| BRC | File | Content |
|-----|------|---------|
| **161** | `tokens/0161.md` | BSV-21 JSON / legacy (`application/bsv-20` inscription) |
| **162** | `tokens/0162.md` | BSV-21 binary (preferred for new tokens) |

- Token id = deploy outpoint; UTXO balances; fixed supply + authority mint
- 161 uses `ord` envelopes ([BRC-160](tokens/0160.md)); balance rules are BSV-21 UTXO/authority, not 1Sat sat-ordering
- 162 is script-native prefix + CBOR payload

## Test plan
- [ ] Spec review of 161/162