### PR TITLE
docs(BRC-150): sat-ordering MUSTs + scalability; notes on 158/159/160

### DIFF
--- a/tokens/0150.md
+++ b/tokens/0150.md
@@ -143,6 +143,28 @@ If the real tip is the output that received P, `beefB64` MUST include the fundin
 * Partial BEEF (structurally valid but missing a path transaction or a preceding input source needed for sat ordering) MUST fail verification.
 * [BRC-158](../transactions/0158.md) **Outpoint BEEF** is a binary wire format for the same tip→origin proof (outpoint-subject BEEF envelope). It is an alternative to this JSON remittance, not a `beefB64` encoding option inside it. An Outpoint BEEF used for this remittance MUST still carry the preceding input sources required by BRC-159.
 
+### Scalability (informative)
+
+Remittance correctness needs path txs plus preceding input sources for sat ordering ([BRC-159](./0159.md)). Bundle size therefore grows with tip depth. The hot path is **one new hop**, not a full tip→origin rebuild.
+
+**Prefer**
+
+* **Extend a prior verified remittance** (sender step 2) — prepend the new tip, merge that tip’s tx and any preceding input sources needed for that hop. Cost stays roughly O(1) per send.
+* **Remember a verified package** for the held tip and reuse it on the next send.
+* **Omit provenance** when the package would exceed an implementation size budget (see Compatibility). Unproven is better than a truncated proof.
+* **Pin a local verdict** after a successful cold verify / genesis hydrate, then discard the large assembled BEEF if it will not travel on the wire.
+
+**Avoid**
+
+* Re-walking tip→origin and re-fetching every hop on every send or every inventory refresh when a prior remittance already verifies.
+* Preferring AtomicBEEF (or nesting [BRC-158](../transactions/0158.md) inside `beefB64`) to “save bytes” when that drops funding sources needed for sat ordering — the bag looks smaller and still cannot prove the hop.
+* Shipping inscription *content* inside remittance (already forbidden above) — envelope presence at origin is enough; media stays at content URLs.
+* Blocking the UI on an unbounded genesis hydrate — cap hops, allow cancellation, and treat hydrate as cold-start only.
+
+**Settle / soft-latch:** when the remittance still names spent tip `P` and the receiver holds new tip `T`, include (or link) the preceding input sources for `T` with the package or with `T` so inherit does not force an extra network hunt to run sat ordering on `T → P`.
+
+[BRC-159](./0159.md) / [BRC-160](./0160.md) are not the bottleneck — sat math and envelope parse are cheap. Depth × full BEEF is. Offline proof packaging and size policy live in this BRC (and optionally [BRC-158](../transactions/0158.md) as a parallel wire format).
+
 ## Security considerations
 
 * **Tag spoofing** — Without this remittance, `origin:` tags are forgeable. Receivers that skip verification reintroduce the attack.
@@ -157,7 +179,7 @@ If the real tip is the output that received P, `beefB64` MUST include the fundin
 
 * **HandCash Desktop** (reference): builds and verifies provenance v2 on collectable send / list.  
   Source: `src/wallet/oneSatProvenance.ts`, `src/wallet/oneSatInscription.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).  
-  **≥ 1.2.130** enforces the rules in this revision: BRC-159 sat ordering on every path hop and on settle-style inherit (`T` from parent remittance `P`), preceding input sources in full BEEF, fail closed when sats are missing.
+  **≥ 1.2.130** enforces the rules in this revision: BRC-159 sat ordering on every path hop and on settle-style inherit (`T` from parent remittance `P`), preceding input sources in full BEEF, fail closed when sats are missing. Hot path extends or reuses a prior remittance; full lineage hydrate is cold-start only, with a size budget that omits oversized packages rather than truncating.
 
 ## References
 

--- a/tokens/0150.md
+++ b/tokens/0150.md
@@ -102,52 +102,29 @@ On success, the receiver MAY treat `provenance.origin` as the proven origin for 
 
 ### Hop examples (informative)
 
-**Why this section exists.** Two mistakes look “obviously correct” until you draw the sats:
+These examples show why **spend-as-input ≠ sat continuity**, and why **AtomicBEEF / SPV ancestry ≠ ordinality**. Full sat-ordering walks are in [BRC-159](./0159.md) (*Examples*).
 
-1. *“This tx spends the parent 1-sat, so the child 1-sat must be that ordinal.”* — False. Spending the parent only proves the parent was unlocked. It does not prove *which output* received that sat.
-2. *“The BEEF / AtomicBEEF is valid SPV, so ordinality is proven.”* — False. SPV proves transactions exist and are mined. It does not assign sats from inputs to outputs. Funding spent next to the ordinal is often not an ancestor of the tip, so AtomicBEEF drops it — and then the verifier cannot do the math.
-
-[BRC-159](./0159.md) sat ordering is the math: sats flow in order (inputs left→right, then outputs left→right). The *n*th satoshi spent is the *n*th satoshi created. More examples there under *Examples*.
-
----
-
-**Good hop (usual wallet send).** Token input is first; tip is `o0`. No extra txs needed beyond the path.
+**Pass (canonical — no extra input sources):** token input first, tip at `o0`.
 
 ```
-inputs:   i0 = parent P (1 sat)     i1 = funding (e.g. 10_000)
-outputs:  o0 = tip T (1 sat)        o1 = change …
+inputs:   i0 = 1-sat parent P    i1 = funding …
+outputs:  o0 = 1-sat tip T       change …
 ```
 
-Walk: sats before `i0` = 0, sats before `o0` = 0, and `i0` is 1 sat → **P’s sat lands on T**.  
-A remittance with path `[T, P, …]` is fine. `beefB64` only needs the path transactions.
+Sats before `i0` = 0, sats before `o0` = 0, and `i0` is 1 sat → **P lands on T**. Path edge `T → P` needs only the path txs in `beefB64`.
 
----
-
-**Bad hop (the hole).** Funding is first; someone still claims “`o0` is the ordinal because the tx spends P.”
+**Fail (funding-first — spend alone is not enough):**
 
 ```
-inputs:   i0 = funding (5_000)      i1 = parent P (1 sat)
-outputs:  o0 = 1 sat                o1 = change (≈ 4_999) …
+inputs:   i0 = funding (5_000)   i1 = 1-sat parent P
+outputs:  o0 = 1 sat             o1 = change …
 ```
 
-What actually happens:
+The tx still *spends* P as `i1`, so a spend-only check passes. Sat ordering does not: funding fills `o0` first; P’s sat is `#5001` and lands in `o1` (or as fee), not in `o0`. A remittance that claims path `o0 → P` MUST fail — `o0` is a funding sat wearing the wrong origin.
 
-* Sats `1 … 5000` come from funding → they fill `o0` (1 sat) and then most of `o1`.
-* P’s single sat is sat `#5001` → it lands in `o1` (or is burned as fee), **not** in `o0`.
+If the real tip is the output that received P, `beefB64` MUST include the funding source so the verifier can compute the map. AtomicBEEF often drops that funding tx (it is not a tip ancestor); the bag can still look SPV-valid and still cannot prove ordinality → fail closed.
 
-So:
-
-* The transaction **does** spend P (`i1`). A spend-only check passes.
-* `o0` is **not** P’s sat. It is one sat sliced off the funding. Attaching P’s origin (or inscription) to `o0` is wrong — that is a different coin wearing the wrong name.
-* A remittance whose path says `o0 → P` **MUST fail**.
-* If the real tip is the output that actually received P, the verifier needs the **funding source tx** in the bag to learn that `i0` was 5_000 sats. Without those values, sat ordering cannot run → fail closed. AtomicBEEF that keeps only tip ancestors often **omits** that funding tx (it is not an ancestor of the tip) → the bag looks “valid” and still cannot prove ordinality.
-
----
-
-**Settle / soft-latch inherit (same hole, different packaging).** Soft-latch often ships a remittance that still names the *spent* tip `P`, then the receiver holds new tip `T` and asks: “may I treat T as having P’s proven origin?”
-
-* Checking only “T spends P” is the bad hop above.
-* Step 5 therefore also requires: sat ordering maps that spend onto T’s vout, and the sats of inputs before that vin are known. Otherwise do **not** mark T’s origin as proven.
+**Settle inherit:** soft-latch often proves parent `P`, then the receiver holds new tip `T`. Checking only “`T` spends `P`” accepts the bad `o0` above. Step 5 therefore also requires sat ordering of that vin onto `T`’s vout (preceding sats known).
 
 ### Relationship to companion BRCs
 
@@ -169,8 +146,8 @@ So:
 ## Security considerations
 
 * **Tag spoofing** — Without this remittance, `origin:` tags are forgeable. Receivers that skip verification reintroduce the attack.
-* **Sat ordering vs spend-only** — “This tx spends the parent” is not “this output is the parent’s sat.” A funding input placed before the ordinal can put an unrelated 1-sat in `o0` while the real ordinal sat lands elsewhere. Verifiers that skip BRC-159 sat ordering will accept that fake tip — including when inheriting origin from a parent remittance onto a new tip `T`.
-* **AtomicBEEF omission** — A structurally valid AtomicBEEF proves SPV ancestry of the tip transaction. It does **not** prove ordinality. Funding spent beside the ordinal is often dropped because it is not a tip ancestor; without those input values the sat map cannot be checked. Prefer full BEEF (or AtomicBEEF only when those sources are still present).
+* **Sat ordering vs spend-only** — Spending a 1-sat parent does not prove that output received *that* sat. Verifiers that skip BRC-159 sat ordering can be convinced an unrelated 1-sat output (e.g. a funding slice paid as 1 sat before the ordinal lands) carries the origin — including on settle-style inherit from parent remittance to tip `T`.
+* **AtomicBEEF omission** — AtomicBEEF is an SPV package, not an ordinality package. Do not treat a valid AtomicBEEF as proof that preceding input sources were unnecessary.
 * **Indexer divergence** — Indexers may lag or err. A verified remittance is authoritative for tip↔origin binding; indexers remain useful for discovery and media URLs.
 * **Burn / re-origin** — If a sat is packed into a multi-sat output, 1Sat origin tracking ends. Remittances MUST NOT invent a continuous path across a burn.
 * **Oversized remittance** — Truncating `path` or `beefB64` to fit a size budget invalidates the proof; omit provenance instead.
@@ -180,7 +157,7 @@ So:
 
 * **HandCash Desktop** (reference): builds and verifies provenance v2 on collectable send / list.  
   Source: `src/wallet/oneSatProvenance.ts`, `src/wallet/oneSatInscription.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).  
-  **≥ 1.2.130** already implements this revision’s rules so wallets do not ship the hole above: every path hop and settle-style inherit (`T` from parent remittance `P`) must pass BRC-159 sat ordering; preceding input sources stay in full BEEF; missing sats → unproven. That is why HandCash prefers full BEEF over AtomicBEEF for remittance.
+  **≥ 1.2.130** enforces the rules in this revision: BRC-159 sat ordering on every path hop and on settle-style inherit (`T` from parent remittance `P`), preceding input sources in full BEEF, fail closed when sats are missing.
 
 ## References
 

--- a/tokens/0150.md
+++ b/tokens/0150.md
@@ -102,27 +102,52 @@ On success, the receiver MAY treat `provenance.origin` as the proven origin for 
 
 ### Hop examples (informative)
 
-These examples exist so implementers do not re-learn the #210 hole the hard way: **spend-as-input ≠ sat continuity**, and **AtomicBEEF/SPV ancestry ≠ ordinality**. Full sat-ordering walks are in [BRC-159](./0159.md) (*Examples*).
+**Why this section exists.** Two mistakes look “obviously correct” until you draw the sats:
 
-**Pass (canonical — no extra input sources):** token input first, tip at `o0`.
+1. *“This tx spends the parent 1-sat, so the child 1-sat must be that ordinal.”* — False. Spending the parent only proves the parent was unlocked. It does not prove *which output* received that sat.
+2. *“The BEEF / AtomicBEEF is valid SPV, so ordinality is proven.”* — False. SPV proves transactions exist and are mined. It does not assign sats from inputs to outputs. Funding spent next to the ordinal is often not an ancestor of the tip, so AtomicBEEF drops it — and then the verifier cannot do the math.
 
-```
-inputs:   i0 = 1-sat parent P    i1 = funding …
-outputs:  o0 = 1-sat tip T       change …
-```
+[BRC-159](./0159.md) sat ordering is the math: sats flow in order (inputs left→right, then outputs left→right). The *n*th satoshi spent is the *n*th satoshi created. More examples there under *Examples*.
 
-`sum(in before i0)=0`, `sum(out before o0)=0`, `i0` is 1 sat → `P` lands on `T`. Path edge `T → P` needs only the path txs in `beefB64`.
+---
 
-**Fail (funding-first — spend alone is not enough):**
+**Good hop (usual wallet send).** Token input is first; tip is `o0`. No extra txs needed beyond the path.
 
 ```
-inputs:   i0 = funding (N sats)    i1 = 1-sat parent P
-outputs:  o0 = 1 sat               o1 = change …
+inputs:   i0 = parent P (1 sat)     i1 = funding (e.g. 10_000)
+outputs:  o0 = tip T (1 sat)        o1 = change …
 ```
 
-`T` may still *spend* `P` as `i1`, but sat ordering maps funding onto `o0` and `P` onto a later output (or burns it). A remittance that claims path `o0 → P` MUST fail. If the tip is really `o1` (or whichever vout receives `P`), `beefB64` MUST include the funding source so the verifier can compute the mapping — AtomicBEEF that drops that non-ancestor source is not sufficient.
+Walk: sats before `i0` = 0, sats before `o0` = 0, and `i0` is 1 sat → **P’s sat lands on T**.  
+A remittance with path `[T, P, …]` is fine. `beefB64` only needs the path transactions.
 
-**Settle inherit:** the same fail pattern applies when inheriting origin from parent remittance `P` onto held tip `T`. Checking only “`T` spends `P`” would accept the bad `o0` above; step 5 therefore requires sat ordering on `T → P`.
+---
+
+**Bad hop (the hole).** Funding is first; someone still claims “`o0` is the ordinal because the tx spends P.”
+
+```
+inputs:   i0 = funding (5_000)      i1 = parent P (1 sat)
+outputs:  o0 = 1 sat                o1 = change (≈ 4_999) …
+```
+
+What actually happens:
+
+* Sats `1 … 5000` come from funding → they fill `o0` (1 sat) and then most of `o1`.
+* P’s single sat is sat `#5001` → it lands in `o1` (or is burned as fee), **not** in `o0`.
+
+So:
+
+* The transaction **does** spend P (`i1`). A spend-only check passes.
+* `o0` is **not** P’s sat. It is one sat sliced off the funding. Attaching P’s origin (or inscription) to `o0` is wrong — that is a different coin wearing the wrong name.
+* A remittance whose path says `o0 → P` **MUST fail**.
+* If the real tip is the output that actually received P, the verifier needs the **funding source tx** in the bag to learn that `i0` was 5_000 sats. Without those values, sat ordering cannot run → fail closed. AtomicBEEF that keeps only tip ancestors often **omits** that funding tx (it is not an ancestor of the tip) → the bag looks “valid” and still cannot prove ordinality.
+
+---
+
+**Settle / soft-latch inherit (same hole, different packaging).** Soft-latch often ships a remittance that still names the *spent* tip `P`, then the receiver holds new tip `T` and asks: “may I treat T as having P’s proven origin?”
+
+* Checking only “T spends P” is the bad hop above.
+* Step 5 therefore also requires: sat ordering maps that spend onto T’s vout, and the sats of inputs before that vin are known. Otherwise do **not** mark T’s origin as proven.
 
 ### Relationship to companion BRCs
 
@@ -144,8 +169,8 @@ outputs:  o0 = 1 sat               o1 = change …
 ## Security considerations
 
 * **Tag spoofing** — Without this remittance, `origin:` tags are forgeable. Receivers that skip verification reintroduce the attack.
-* **Sat ordering vs spend-only** — Spending a 1-sat parent does not prove that output received *that* sat. Verifiers that skip BRC-159 sat ordering can be convinced an unrelated 1-sat output (e.g. a funding slice paid as 1 sat before the ordinal lands) carries the origin — including on settle-style inherit from parent remittance to tip `T`.
-* **AtomicBEEF omission** — AtomicBEEF is an SPV package, not an ordinality package. Do not treat a valid AtomicBEEF as proof that preceding input sources were unnecessary.
+* **Sat ordering vs spend-only** — “This tx spends the parent” is not “this output is the parent’s sat.” A funding input placed before the ordinal can put an unrelated 1-sat in `o0` while the real ordinal sat lands elsewhere. Verifiers that skip BRC-159 sat ordering will accept that fake tip — including when inheriting origin from a parent remittance onto a new tip `T`.
+* **AtomicBEEF omission** — A structurally valid AtomicBEEF proves SPV ancestry of the tip transaction. It does **not** prove ordinality. Funding spent beside the ordinal is often dropped because it is not a tip ancestor; without those input values the sat map cannot be checked. Prefer full BEEF (or AtomicBEEF only when those sources are still present).
 * **Indexer divergence** — Indexers may lag or err. A verified remittance is authoritative for tip↔origin binding; indexers remain useful for discovery and media URLs.
 * **Burn / re-origin** — If a sat is packed into a multi-sat output, 1Sat origin tracking ends. Remittances MUST NOT invent a continuous path across a burn.
 * **Oversized remittance** — Truncating `path` or `beefB64` to fit a size budget invalidates the proof; omit provenance instead.
@@ -155,7 +180,7 @@ outputs:  o0 = 1 sat               o1 = change …
 
 * **HandCash Desktop** (reference): builds and verifies provenance v2 on collectable send / list.  
   Source: `src/wallet/oneSatProvenance.ts`, `src/wallet/oneSatInscription.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).  
-  **≥ 1.2.130** enforces the rules in this revision: BRC-159 sat ordering on every path hop and on settle-style inherit (`T` from parent remittance `P`), preceding input sources in full BEEF, fail closed when sats are missing. That closes the spend-only / AtomicBEEF tradeoffs described above — without them a funding-first hop can spend the claimed parent while a different 1-sat output inherits the origin.
+  **≥ 1.2.130** already implements this revision’s rules so wallets do not ship the hole above: every path hop and settle-style inherit (`T` from parent remittance `P`) must pass BRC-159 sat ordering; preceding input sources stay in full BEEF; missing sats → unproven. That is why HandCash prefers full BEEF over AtomicBEEF for remittance.
 
 ## References
 

--- a/tokens/0150.md
+++ b/tokens/0150.md
@@ -100,6 +100,30 @@ Given a candidate tip outpoint `T` and `customInstructions.provenance` with `v =
 
 On success, the receiver MAY treat `provenance.origin` as the proven origin for tip `T` and MAY use indexer metadata keyed by that origin for display.
 
+### Hop examples (informative)
+
+These examples exist so implementers do not re-learn the #210 hole the hard way: **spend-as-input ≠ sat continuity**, and **AtomicBEEF/SPV ancestry ≠ ordinality**. Full sat-ordering walks are in [BRC-159](./0159.md) (*Examples*).
+
+**Pass (canonical — no extra input sources):** token input first, tip at `o0`.
+
+```
+inputs:   i0 = 1-sat parent P    i1 = funding …
+outputs:  o0 = 1-sat tip T       change …
+```
+
+`sum(in before i0)=0`, `sum(out before o0)=0`, `i0` is 1 sat → `P` lands on `T`. Path edge `T → P` needs only the path txs in `beefB64`.
+
+**Fail (funding-first — spend alone is not enough):**
+
+```
+inputs:   i0 = funding (N sats)    i1 = 1-sat parent P
+outputs:  o0 = 1 sat               o1 = change …
+```
+
+`T` may still *spend* `P` as `i1`, but sat ordering maps funding onto `o0` and `P` onto a later output (or burns it). A remittance that claims path `o0 → P` MUST fail. If the tip is really `o1` (or whichever vout receives `P`), `beefB64` MUST include the funding source so the verifier can compute the mapping — AtomicBEEF that drops that non-ancestor source is not sufficient.
+
+**Settle inherit:** the same fail pattern applies when inheriting origin from parent remittance `P` onto held tip `T`. Checking only “`T` spends `P`” would accept the bad `o0` above; step 5 therefore requires sat ordering on `T → P`.
+
 ### Relationship to companion BRCs
 
 | Concern | Defined by |
@@ -130,7 +154,8 @@ On success, the receiver MAY treat `provenance.origin` as the proven origin for 
 ## Implementations
 
 * **HandCash Desktop** (reference): builds and verifies provenance v2 on collectable send / list.  
-  Source: `src/wallet/oneSatProvenance.ts`, `src/wallet/oneSatInscription.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).
+  Source: `src/wallet/oneSatProvenance.ts`, `src/wallet/oneSatInscription.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).  
+  **≥ 1.2.130** enforces the rules in this revision: BRC-159 sat ordering on every path hop and on settle-style inherit (`T` from parent remittance `P`), preceding input sources in full BEEF, fail closed when sats are missing. That closes the spend-only / AtomicBEEF tradeoffs described above — without them a funding-first hop can spend the claimed parent while a different 1-sat output inherits the origin.
 
 ## References
 

--- a/tokens/0150.md
+++ b/tokens/0150.md
@@ -4,7 +4,7 @@ Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
 ## Abstract
 
-This BRC defines the **provenance remittance** carried in [BRC-37](../outpoints/0037.md) `customInstructions` for outputs in the companion basket profile `1sat` ([BRC-147](./0147.md)). It specifies an offline-verifiable package that binds a current 1-sat outpoint (*tip*) to a 1Sat Ordinals *origin* ([BRC-159](./0159.md)), using BEEF or AtomicBEEF, and requires that origin's locking script contain a valid first `ord` envelope ([BRC-160](./0160.md)).
+This BRC defines the **provenance remittance** carried in [BRC-37](../outpoints/0037.md) `customInstructions` for outputs in the companion basket profile `1sat` ([BRC-147](./0147.md)). It specifies an offline-verifiable package that binds a current 1-sat outpoint (*tip*) to a 1Sat Ordinals *origin* ([BRC-159](./0159.md)), using BEEF (or AtomicBEEF when it still covers the hop), **BRC-159 sat ordering on every path hop**, and a valid first `ord` envelope on the origin ([BRC-160](./0160.md)).
 
 Together with [BRC-147](./0147.md), this enables interoperable 1Sat hold/transfer while preventing forgeable `origin:` tags from being treated as proof. Verification does not require a global ordinals indexer.
 
@@ -50,7 +50,7 @@ Wallets that do not implement this BRC MUST still store and forward unknown `cus
 | `origin` | string | MUST | Inscription origin outpoint in underscore form `txid_vout`. |
 | `tip` | string | MUST | Current outpoint being proven, underscore form. MUST equal `path[0]`. |
 | `path` | string[] | MUST | Ordered outpoints tip → … → origin, inclusive. Length ≥ 1. |
-| `beefB64` | string | MUST | Base64 encoding of **AtomicBEEF** ([BRC-95](../transactions/0095.md)) preferred, rooted at the tip transaction id; or BEEF ([BRC-62](../transactions/0062.md)) covering all transactions required to validate `path`. |
+| `beefB64` | string | MUST | Base64 encoding of **BEEF** ([BRC-62](../transactions/0062.md)) covering every `path` transaction **and** every preceding input source required for BRC-159 sat ordering on each hop. AtomicBEEF ([BRC-95](../transactions/0095.md)) is allowed only when it still covers that set. |
 | `contentType` | string | OPTIONAL | Hint from the origin `ord` envelope content-type field when known. |
 
 Outpoint normalization (dot ↔ underscore) follows [BRC-147](./0147.md).
@@ -64,10 +64,10 @@ Provenance objects with `v !== 2`, or path-only packages without `beefB64`, are 
 A conforming sender transferring a `1sat` tip under [BRC-147](./0147.md) SHOULD:
 
 1. Determine the true `origin` of the tip (indexer-assisted discovery is allowed for *building* the package).
-2. **Prefer extending a prior remittance** when the tip (or its immediate parent tip) already carries a verified v2 package: prepend the tip being proven to `path` and merge that tip’s transaction into `beefB64`. Do **not** re-walk full tip→origin lineage when an inductive extension verifies.
-3. Otherwise construct `path` tip→origin such that each consecutive pair with different transaction ids is related by a spend of the parent outpoint as an input to the child transaction.
-4. Assemble `beefB64` covering every transaction id appearing in `path`. For each hop on `path`, `beefB64` MUST also include the source transaction for every input before the transferred ordinal on that hop, so a verifier can calculate the ordinal.
-5. Prefer a **full** BEEF serialization for remittance ancestry when AtomicBEEF would drop path parents or those input source transactions (mined tips with no recursive dependencies). AtomicBEEF ([BRC-95](../transactions/0095.md)) remains allowed when it still covers the full `path` and required input sources.
+2. **Prefer extending a prior remittance** when the tip (or its immediate parent tip) already carries a verified v2 package: prepend the tip being proven to `path` and merge that tip’s transaction **plus preceding input sources needed for BRC-159 sat ordering** into `beefB64`. Do **not** re-walk full tip→origin lineage when an inductive extension verifies.
+3. Otherwise construct `path` tip→origin such that each consecutive pair with different transaction ids is a **BRC-159 1→1 transfer hop**: the parent 1-sat outpoint is the child input `vin` whose satoshis land on the child `vout` under sat ordering (`sum(input sats before vin) === sum(output sats before vout)`, and that input is exactly 1 satoshi). A mere spend of the parent as *some* input is not sufficient — funding inputs that precede the ordinal `vin` can assign a different sat to the claimed vout.
+4. Assemble `beefB64` covering every transaction id appearing in `path`, **and** the source transaction of every input that precedes (and including) the ordinal-mapping `vin` on each hop, so a verifier can calculate the ordinal. Canonical transfers (`i0` 1-sat → `o0` 1-sat) add nothing beyond the path transactions. Complex hops (funding before the ordinal input, ordinal paid to `o1`+, etc.) MUST include those preceding input sources. Missing sats → the hop cannot be proven; omit provenance rather than guessing.
+5. Prefer a **full** BEEF serialization ([BRC-62](../transactions/0062.md)) for remittance ancestry. AtomicBEEF ([BRC-95](../transactions/0095.md)) keeps only the subject and its recursive SPV dependencies; mined path parents and **non-ancestor preceding input sources** (funding spent alongside the ordinal) are dropped. AtomicBEEF remains allowed only when it still covers the full `path` *and* every preceding input source required for sat ordering.
 6. Self-verify using the Receiver rules below before broadcast.
 7. If a valid v2 package cannot be produced, the sender MUST NOT claim a verified origin via tags alone. The sender MAY omit `provenance`; receivers MUST then treat identity as unverified per [BRC-147](./0147.md).
 
@@ -81,14 +81,18 @@ Given a candidate tip outpoint `T` and `customInstructions.provenance` with `v =
 2. **Structure** — The BEEF MUST pass structural validation (e.g. `Beef.verifyValid`). Use of txid-only entries ([BRC-96](../transactions/0096.md)) is allowed only when the receiver already trusts those transactions by other means.
 3. **Atomic subject (when AtomicBEEF)** — If the bytes are AtomicBEEF, the subject txid MUST equal the tip’s transaction id (the tip named by `provenance.tip` after normalization).
 4. **Tip binding (direct)** — If `provenance.tip` and `path[0]` equal tip outpoint `T` after normalization, continue with steps 5–9 for that package.
-5. **Tip binding (parent remittance — settle-style)** — If step 4 fails, receivers **SHOULD** accept the package when all of the following hold (soft-latch / pre-broadcast remittance):
+5. **Tip binding (parent remittance — settle-style)** — If step 4 fails, receivers **SHOULD** accept the package when all of the following hold (soft-latch / pre-broadcast remittance that inherits origin onto held tip `T`):
    * `provenance.tip` and `path[0]` name a parent outpoint `P` (not `T`);
    * the package verifies under steps 5–9 with held outpoint `P` (direct tip binding to `P`);
-   * transaction `T` spends `P` as a 1-satoshi input;
-   * output `T` is 1 satoshi.
-   This inductive hop exists because settle-style transfers often embed remittance for the *spent* tip before the new tip’s txid is known. Receivers that omit this step remain conforming for direct tip-bound packages but will treat settle-style remittances as unproven unless they rebuild lineage themselves.
+   * transaction `T` spends `P` as an input `vin`;
+   * output `T` is 1 satoshi;
+   * BRC-159 sat ordering maps that `vin` onto `T`’s vout. Preceding input source sats for `T` MUST be known (in `beefB64`, linked on `T`, or otherwise available with `T`) — fail closed if missing.
+   This inductive hop exists because settle-style transfers often embed remittance for the *spent* tip before the new tip’s txid is known. Receivers that omit this step remain conforming for direct tip-bound packages but will treat settle-style remittances as unproven unless they rebuild lineage themselves. Receivers that only check “`T` spends `P`” without sat ordering MUST NOT treat origin as proven for `T`.
 6. **Origin binding** — `path[path.length - 1]` MUST equal `provenance.origin`.
-7. **Ordinal continuity** — For each consecutive pair `(child, parent)` in `path` with different transaction ids, the child transaction in the BEEF MUST spend `parent` as an input, and calculating the ordinal on the child (using the included input source transactions) MUST show the parent sat continues to the child path outpoint per [BRC-159](./0159.md) sat ordering / transfer resolution. For parent-remittance acceptance (step 5), the spend `T → P` is checked against transaction `T` (which MAY be obtained outside `beefB64`). An informative outpoint→origin walk is in [BRC-159](./0159.md) (*Finding origin from an outpoint*).
+7. **Ordinal continuity** — For each consecutive pair `(child, parent)` in `path` with different transaction ids:
+   * the child transaction in the BEEF MUST spend `parent` as some input `vin`;
+   * that `vin` MUST be the BRC-159 ordinal input for the child vout (`sum(input sats before vin) === sum(output sats before vout)`, input satoshis === 1).
+   If any preceding input’s satoshi value is unknown (source tx missing from the BEEF and not otherwise known), verification MUST fail. For parent-remittance acceptance (step 5), the spend **and** sat-ordering check `T → P` are applied to transaction `T` (which MAY be obtained outside `beefB64`, but preceding input sources for `T` still MUST be available). An informative outpoint→origin walk is in [BRC-159](./0159.md) (*Finding origin from an outpoint*).
 8. **One-sat** — For each outpoint in `path` present in the BEEF with a known satoshi value, that value MUST be `1`.
 9. **Inscription** — The locking script of `origin` MUST contain a valid first `ord` envelope as defined by [BRC-160](./0160.md) on a 1-sat output. Subsequent envelopes on the same sat MUST be ignored for origin identity ([BRC-159](./0159.md) / [BRC-160](./0160.md)).
 
@@ -108,14 +112,16 @@ On success, the receiver MAY treat `provenance.origin` as the proven origin for 
 
 ### Compatibility
 
-* This BRC does not alter BRC-62/95 encodings; it only constrains how they are used inside `customInstructions.provenance`.
-* Deep histories may produce large remittances. Implementations SHOULD prefer AtomicBEEF and MAY refuse to embed packages above an implementation-defined size, falling back to “unproven” rather than truncated proofs.
-* Partial BEEF (structurally valid but missing a path transaction or a required input source transaction) MUST fail verification.
-* [BRC-158](../transactions/0158.md) **Outpoint BEEF** is a binary wire format for the same tip→origin proof (outpoint-subject BEEF envelope). It is an alternative to this JSON remittance, not a `beefB64` encoding option inside it.
+* This BRC does not alter BRC-62/95 encodings; it only constrains how they are used inside `customInstructions.provenance`. BEEF/AtomicBEEF prove SPV ancestry, not BRC-159 sat ordering by themselves.
+* Deep histories may produce large remittances. Implementations SHOULD prefer full BEEF when AtomicBEEF would drop path parents or preceding input sources, and MAY refuse to embed packages above an implementation-defined size, falling back to “unproven” rather than truncated proofs.
+* Partial BEEF (structurally valid but missing a path transaction or a preceding input source needed for sat ordering) MUST fail verification.
+* [BRC-158](../transactions/0158.md) **Outpoint BEEF** is a binary wire format for the same tip→origin proof (outpoint-subject BEEF envelope). It is an alternative to this JSON remittance, not a `beefB64` encoding option inside it. An Outpoint BEEF used for this remittance MUST still carry the preceding input sources required by BRC-159.
 
 ## Security considerations
 
 * **Tag spoofing** — Without this remittance, `origin:` tags are forgeable. Receivers that skip verification reintroduce the attack.
+* **Sat ordering vs spend-only** — Spending a 1-sat parent does not prove that output received *that* sat. Verifiers that skip BRC-159 sat ordering can be convinced an unrelated 1-sat output (e.g. a funding slice paid as 1 sat before the ordinal lands) carries the origin — including on settle-style inherit from parent remittance to tip `T`.
+* **AtomicBEEF omission** — AtomicBEEF is an SPV package, not an ordinality package. Do not treat a valid AtomicBEEF as proof that preceding input sources were unnecessary.
 * **Indexer divergence** — Indexers may lag or err. A verified remittance is authoritative for tip↔origin binding; indexers remain useful for discovery and media URLs.
 * **Burn / re-origin** — If a sat is packed into a multi-sat output, 1Sat origin tracking ends. Remittances MUST NOT invent a continuous path across a burn.
 * **Oversized remittance** — Truncating `path` or `beefB64` to fit a size budget invalidates the proof; omit provenance instead.

--- a/tokens/0150.md
+++ b/tokens/0150.md
@@ -71,8 +71,6 @@ A conforming sender transferring a `1sat` tip under [BRC-147](./0147.md) SHOULD:
 6. Self-verify using the Receiver rules below before broadcast.
 7. If a valid v2 package cannot be produced, the sender MUST NOT claim a verified origin via tags alone. The sender MAY omit `provenance`; receivers MUST then treat identity as unverified per [BRC-147](./0147.md).
 
-Senders MUST NOT *additionally* embed inscription *content* outside `beefB64` (extra remittance keys or parallel blobs). The origin transaction in `beefB64` already carries the locking script that holds the [BRC-160](./0160.md) envelope; verification reads that envelope in place. Optional `contentType` is only a hint. For display, wallets MAY unpack the origin script from the BEEF or serve media from content URLs / OrdFS.
-
 ### Receiver requirements
 
 Given a candidate tip outpoint `T` and `customInstructions.provenance` with `v === 2`, a conforming receiver MUST verify as follows. On any failure, the receiver MUST treat origin identity as **unproven** and MUST NOT adopt sender `name` / `app` / `origin:` tags as authoritative for that tip ([BRC-147](./0147.md) claims rule).
@@ -158,7 +156,6 @@ Remittance correctness needs path txs plus preceding input sources for sat order
 
 * Re-walking tip→origin and re-fetching every hop on every send or every inventory refresh when a prior remittance already verifies.
 * Preferring AtomicBEEF (or nesting [BRC-158](../transactions/0158.md) inside `beefB64`) to “save bytes” when that drops funding sources needed for sat ordering — the bag looks smaller and still cannot prove the hop.
-* Duplicating inscription *content* outside `beefB64` — the origin tx in the BEEF already holds the envelope; do not ship a second body. Display MAY read the script from the bag or use content URLs / OrdFS.
 * Blocking the UI on an unbounded genesis hydrate — cap hops, allow cancellation, and treat hydrate as cold-start only.
 
 **Settle / soft-latch:** when the remittance still names spent tip `P` and the receiver holds new tip `T`, include (or link) the preceding input sources for `T` with the package or with `T` so inherit does not force an extra network hunt to run sat ordering on `T → P`.

--- a/tokens/0150.md
+++ b/tokens/0150.md
@@ -71,7 +71,7 @@ A conforming sender transferring a `1sat` tip under [BRC-147](./0147.md) SHOULD:
 6. Self-verify using the Receiver rules below before broadcast.
 7. If a valid v2 package cannot be produced, the sender MUST NOT claim a verified origin via tags alone. The sender MAY omit `provenance`; receivers MUST then treat identity as unverified per [BRC-147](./0147.md).
 
-Senders MUST NOT embed full inscription *content* solely for this remittance; envelope presence at origin is sufficient.
+Senders MUST NOT *additionally* embed inscription *content* outside `beefB64` (extra remittance keys or parallel blobs). The origin transaction in `beefB64` already carries the locking script that holds the [BRC-160](./0160.md) envelope; verification reads that envelope in place. Optional `contentType` is only a hint. For display, wallets MAY unpack the origin script from the BEEF or serve media from content URLs / OrdFS.
 
 ### Receiver requirements
 
@@ -158,7 +158,7 @@ Remittance correctness needs path txs plus preceding input sources for sat order
 
 * Re-walking tip→origin and re-fetching every hop on every send or every inventory refresh when a prior remittance already verifies.
 * Preferring AtomicBEEF (or nesting [BRC-158](../transactions/0158.md) inside `beefB64`) to “save bytes” when that drops funding sources needed for sat ordering — the bag looks smaller and still cannot prove the hop.
-* Shipping inscription *content* inside remittance (already forbidden above) — envelope presence at origin is enough; media stays at content URLs.
+* Duplicating inscription *content* outside `beefB64` — the origin tx in the BEEF already holds the envelope; do not ship a second body. Display MAY read the script from the bag or use content URLs / OrdFS.
 * Blocking the UI on an unbounded genesis hydrate — cap hops, allow cancellation, and treat hydrate as cold-start only.
 
 **Settle / soft-latch:** when the remittance still names spent tip `P` and the receiver holds new tip `T`, include (or link) the preceding input sources for `T` with the package or with `T` so inherit does not force an extra network hunt to run sat ordering on `T → P`.

--- a/tokens/0159.md
+++ b/tokens/0159.md
@@ -168,6 +168,7 @@ outputs:
 * **Coin selection** — Do not spend 1Sat token outputs in ordinary payments unless a transfer is intended.
 * **Output order** — Builders must place each token satoshi in the intended 1-satoshi output.
 * **Claimed origins** — A string `origin: …` is not proof.
+* **Proof packages** — Offline tip→origin proofs, bundle size, and send hot paths are specified in [BRC-150](./0150.md) (and optionally [BRC-158](../transactions/0158.md)). Sat ordering itself is O(inputs+outputs) per hop and is not the scalability bottleneck.
 
 ## Implementations
 
@@ -182,3 +183,5 @@ outputs:
 3. [BRC-36](../outpoints/0036.md) — Format for Bitcoin Outpoints
 4. [BRC-45](./0045.md) — Definition of UTXOs as Bitcoin Tokens
 5. [BRC-160](./0160.md) — 1Sat Ordinals — Inscription Envelopes
+6. [BRC-150](./0150.md) — 1Sat Provenance Remittance for Basket `1sat`
+7. [BRC-158](../transactions/0158.md) — Outpoint BEEF

--- a/tokens/0160.md
+++ b/tokens/0160.md
@@ -163,7 +163,7 @@ Those may require [BRC-159](./0159.md), this envelope BRC, or both.
 
 * **Content authenticity** — An envelope proves data was in a script at an outpoint; it does not by itself prove the token's current outpoint still descends from that origin (see [BRC-159](./0159.md) and [BRC-150](./0150.md)).
 * **Parent without spend** — Field 3 alone is not proof of parentage; only spending the claimed parent in the same transaction establishes the link.
-* **Large bodies** — Very large pushes affect relay and storage; application limits are out of scope here but implementers should plan for them. A [BRC-150](./0150.md) package that covers the origin transaction already carries that origin’s locking script inside `beefB64`, so the envelope body is present in the BEEF — there is no separate “inscription body” field to add. Do **not** duplicate the body outside the BEEF (extra remittance keys, parallel blobs). Oversized origins inflate the bag; wallets MAY omit remittance rather than truncate, and SHOULD serve media for display from content URLs / OrdFS when they are not unpacking the BEEF for UI.
+* **Large bodies** — Very large pushes affect relay and storage (including [BRC-150](./0150.md) bags that cover the origin tx). Application limits are out of scope here.
 * **Content selection** — Showing the wrong envelope for a given app (e.g. latest vs origin) is an application concern, not fixed by this BRC.
 
 ## Implementations

--- a/tokens/0160.md
+++ b/tokens/0160.md
@@ -163,7 +163,7 @@ Those may require [BRC-159](./0159.md), this envelope BRC, or both.
 
 * **Content authenticity** — An envelope proves data was in a script at an outpoint; it does not by itself prove the token's current outpoint still descends from that origin (see [BRC-159](./0159.md) and [BRC-150](./0150.md)).
 * **Parent without spend** — Field 3 alone is not proof of parentage; only spending the claimed parent in the same transaction establishes the link.
-* **Large bodies** — Very large pushes affect relay and storage; application limits are out of scope here but implementers should plan for them. Do not put inscription bodies into [BRC-150](./0150.md) remittance — envelope presence at origin is enough; serve media from content URLs / OrdFS.
+* **Large bodies** — Very large pushes affect relay and storage; application limits are out of scope here but implementers should plan for them. A [BRC-150](./0150.md) package that covers the origin transaction already carries that origin’s locking script inside `beefB64`, so the envelope body is present in the BEEF — there is no separate “inscription body” field to add. Do **not** duplicate the body outside the BEEF (extra remittance keys, parallel blobs). Oversized origins inflate the bag; wallets MAY omit remittance rather than truncate, and SHOULD serve media for display from content URLs / OrdFS when they are not unpacking the BEEF for UI.
 * **Content selection** — Showing the wrong envelope for a given app (e.g. latest vs origin) is an application concern, not fixed by this BRC.
 
 ## Implementations

--- a/tokens/0160.md
+++ b/tokens/0160.md
@@ -163,7 +163,7 @@ Those may require [BRC-159](./0159.md), this envelope BRC, or both.
 
 * **Content authenticity** — An envelope proves data was in a script at an outpoint; it does not by itself prove the token's current outpoint still descends from that origin (see [BRC-159](./0159.md) and [BRC-150](./0150.md)).
 * **Parent without spend** — Field 3 alone is not proof of parentage; only spending the claimed parent in the same transaction establishes the link.
-* **Large bodies** — Very large pushes affect relay and storage; application limits are out of scope here but implementers should plan for them.
+* **Large bodies** — Very large pushes affect relay and storage; application limits are out of scope here but implementers should plan for them. Do not put inscription bodies into [BRC-150](./0150.md) remittance — envelope presence at origin is enough; serve media from content URLs / OrdFS.
 * **Content selection** — Showing the wrong envelope for a given app (e.g. latest vs origin) is an application concern, not fixed by this BRC.
 
 ## Implementations

--- a/transactions/0158.md
+++ b/transactions/0158.md
@@ -23,3 +23,10 @@ David Case (david.case@shruggr.cloud)
 0200beef                                                 // BEEF V2 (example)
 ...
 ```
+
+## Notes (informative)
+
+* The embedded BEEF MAY include transactions that are not ancestors of the subject tx (e.g. funding spent beside a 1Sat tip). That is intentional for profiles such as [BRC-150](../tokens/0150.md).
+* Completeness is profile-defined. Outpoint BEEF alone does not define sat ordering or inscription rules — see [BRC-159](../tokens/0159.md) / [BRC-160](../tokens/0160.md) / [BRC-150](../tokens/0150.md).
+* Bundle size grows with whatever the profile requires. For 1Sat tip→origin remittance, prefer extending a prior package and omitting oversized bags rather than dropping required input sources; see [BRC-150](../tokens/0150.md) (*Scalability*).
+* Do not nest this envelope inside BRC-150 `beefB64`. Basket remittance stays the JSON object; Outpoint BEEF is a parallel binary wire format (gateways, other transports).


### PR DESCRIPTION
## Summary

Single follow-up to #210 (supersedes #215).

### BRC-150 (normative + informative)

1. **Path edges** MUST be BRC-159 1→1 hops (not mere spends).
2. **Settle inherit** MUST require sat ordering on `T→P` + known preceding sats.
3. **`beefB64`** prefers full BEEF with preceding sources; AtomicBEEF only when that set survives.
4. Short Pass / Fail / Settle hop examples.
5. **Scalability (informative):** Prefer extend/reuse/omit/pin; Avoid full re-walks, AtomicBEEF-as-shortcut, content in remittance, unbounded hydrate.

### Other BRCs (light notes only)

* **158** — profile may include non-ancestors; size grows with profile; do not nest in `beefB64`; see 150 *Scalability*.
* **159** — sat math is cheap; proof packages / size live in 150.
* **160** — large bodies stay off remittance; use content URLs.

## Test plan

- [ ] 150 receiver steps 5 + 7 and sender path construction
- [ ] Scalability Prefer/Avoid readable without prior Discord context
- [ ] 158 notes do not re-open putting Outpoint BEEF inside `beefB64`
- [ ] 159/160 changes stay informative one-liners