### PR TITLE
docs(BRC-150): scalability notes — extend hot path, omit oversized bags

### DIFF
--- a/tokens/0150.md
+++ b/tokens/0150.md
@@ -113,6 +113,28 @@ On success, the receiver MAY treat `provenance.origin` as the proven origin for 
 * Partial BEEF (structurally valid but missing a path transaction or a required input source transaction) MUST fail verification.
 * [BRC-158](../transactions/0158.md) **Outpoint BEEF** is a binary wire format for the same tip→origin proof (outpoint-subject BEEF envelope). It is an alternative to this JSON remittance, not a `beefB64` encoding option inside it.
 
+### Scalability (informative)
+
+Remittance correctness needs path txs plus preceding input sources for sat ordering ([BRC-159](./0159.md)). Bundle size therefore grows with tip depth. The hot path is **one new hop**, not a full tip→origin rebuild.
+
+**Prefer**
+
+* **Extend a prior verified remittance** (sender step 2) — prepend the new tip, merge that tip’s tx and any preceding input sources needed for that hop. Cost stays roughly O(1) per send.
+* **Remember a verified package** for the held tip and reuse it on the next send.
+* **Omit provenance** when the package would exceed an implementation size budget (see Compatibility). Unproven is better than a truncated proof.
+* **Pin a local verdict** after a successful cold verify / genesis hydrate, then discard the large assembled BEEF if it will not travel on the wire.
+
+**Avoid**
+
+* Re-walking tip→origin and re-fetching every hop on every send or every inventory refresh when a prior remittance already verifies.
+* Preferring AtomicBEEF (or nesting [BRC-158](../transactions/0158.md) inside `beefB64`) to “save bytes” when that drops funding sources needed for sat ordering — the bag looks smaller and still cannot prove the hop.
+* Shipping inscription *content* inside remittance (already forbidden above) — envelope presence at origin is enough; media stays at content URLs.
+* Blocking the UI on an unbounded genesis hydrate — cap hops, allow cancellation, and treat hydrate as cold-start only.
+
+**Settle / soft-latch:** when the remittance still names spent tip `P` and the receiver holds new tip `T`, include (or link) the preceding input sources for `T` with the package or with `T` so inherit does not force an extra network hunt to run sat ordering on `T → P`.
+
+[BRC-159](./0159.md) / [BRC-160](./0160.md) are not the bottleneck — sat math and envelope parse are cheap. Depth × full BEEF is.
+
 ## Security considerations
 
 * **Tag spoofing** — Without this remittance, `origin:` tags are forgeable. Receivers that skip verification reintroduce the attack.
@@ -124,7 +146,8 @@ On success, the receiver MAY treat `provenance.origin` as the proven origin for 
 ## Implementations
 
 * **HandCash Desktop** (reference): builds and verifies provenance v2 on collectable send / list.  
-  Source: `src/wallet/oneSatProvenance.ts`, `src/wallet/oneSatInscription.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).
+  Source: `src/wallet/oneSatProvenance.ts`, `src/wallet/oneSatInscription.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).  
+  Hot path extends or reuses a prior remittance; full lineage hydrate is cold-start only, with a size budget that omits oversized packages rather than truncating.
 
 ## References
 


### PR DESCRIPTION
## Summary

Informative **Scalability** section for BRC-150 after #210.

Remittance that includes preceding input sources for sat ordering grows with tip depth. The bottleneck is depth × full BEEF, not BRC-159 math or BRC-160 envelopes.

**Prefer:** extend/reuse a verified remittance (O(1) per send), omit when over budget, pin local verdicts and discard giant cold-start BEEFs, attach settle-hop funding sources with `T`.

**Avoid:** full tip→origin rebuild on every send/list, AtomicBEEF / inlined Outpoint BEEF as a size shortcut that drops funding sources, embedding inscription content, unbounded genesis hydrate on the UI thread.

Complements (does not replace) normative follow-ups in #214.

## Test plan

- [ ] Section is clearly informative (no new MUSTs that conflict with #210)
- [ ] Prefer/Avoid list matches sender step 2 + Compatibility size omit
- [ ] Readers see why AtomicBEEF-as-shortcut is called out without reopening the 158-in-`beefB64` debate


Made with [Cursor](https://cursor.com)