### PR TITLE
docs(tokens): BRC-163 BSV-21 basket profile (BRC-46/100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ BRC | Standard
 158  | [Outpoint BEEF](./transactions/0158.md)
 159  | [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 160  | [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
+163  | [BSV-21 Basket Profile for BRC-46 / BRC-100](./tokens/0163.md)
 168  | [Verifiable Time Allocation](./apps/0168.md)
 169  | [Universal Handle Addressing and Resolution for the Metanet](./peer-to-peer/0169.md)
 210  | [Derived Collectibles](./apps/0210.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -119,6 +119,7 @@
 * [1Sat Provenance Remittance for Basket `1sat`](./tokens/0150.md)
 * [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 * [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
+* [BSV-21 Basket Profile for BRC-46 / BRC-100](./tokens/0163.md)
 * [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)
 
 ## Overlays

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -49,8 +49,9 @@ This profile’s normative remittance examples use the JSON carrier ([BRC-161](.
 
 * BRC-100 wire `outpoint` fields use **dot** form: `txid.vout`.
 * BSV-21 **token ids** use **underscore** form only: `txid_vout` ([BRC-161](./0161.md)).
-* Inside this profile’s `customInstructions`, `id` MUST use underscore form. Tags MAY use either form after the `id:` prefix; readers MUST normalize before comparison.
-* Tip outpoints in tags MAY use either form; readers MUST normalize.
+* Inside this profile’s `customInstructions`, the BSV-21 token field `id` MUST use underscore form.
+* The output tag for token id is `bsv21:<tokenId>` (see Tags). After the `bsv21:` prefix, tags MAY use either outpoint form; readers MUST normalize before comparison.
+* Tip outpoints in other tags MAY use either form; readers MUST normalize.
 
 ### Tags
 
@@ -58,12 +59,14 @@ Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hi
 
 | Tag | Requirement | Meaning |
 |-----|-------------|---------|
-| `bsv21` | SHOULD on conforming transfers and imports | Marks the output as a BSV-21 value tip under this profile. |
-| `id:<tokenId>` | SHOULD when known | Token id (`txid_vout` of deploy). |
+| `bsv21` | SHOULD on conforming transfers and imports | Marks the output as a BSV-21 value tip under this profile (no suffix). |
+| `bsv21:<tokenId>` | SHOULD when known | Token id (`txid_vout` of deploy). Distinct from the bare `bsv21` marker. |
 | `amt:<string>` | SHOULD when known | Token amount in this output (decimal string, integer units). |
 | `sym:<string>` | MAY | Display symbol from deploy (not unique). |
 | `op:<string>` | MAY | Last known op (`transfer`, `mint`, …). |
 | `cosign:<pubkeyHex>` | SHOULD when the tip is cosigner-gated | Compressed cosigner pubkey (33-byte hex). |
+
+Conforming writers MUST NOT use `id:<…>` for the BSV-21 token id. The tag prefix `id:` is reserved for a per-output identity key (wallet / basket stack lookup of a specific output) and MUST NOT be overloaded here. Token id in inscription / `customInstructions` JSON remains the BRC-161 field name `id`.
 
 Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md)).
 
@@ -196,7 +199,7 @@ To place an existing value tip into basket `bsv21`, use BRC-100 `internalizeActi
     "protocol": "basket insertion",
     "insertionRemittance": {
       "basket": "bsv21",
-      "tags": ["bsv21", "id:<txid_vout>", "amt:<amt>"],
+      "tags": ["bsv21", "bsv21:<txid_vout>", "amt:<amt>"],
       "customInstructions": "{\"p\":\"bsv-20\",\"op\":\"transfer\",\"id\":\"<txid_vout>\",\"amt\":\"<amt>\"}"
     }
   }]

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -63,6 +63,7 @@ Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hi
 | `amt:<string>` | SHOULD when known | Token amount in this output (decimal string, integer units). |
 | `sym:<string>` | MAY | Display symbol from deploy (not unique). |
 | `op:<string>` | MAY | Last known op (`transfer`, `mint`, …). |
+| `cosign:<pubkeyHex>` | SHOULD when the tip is cosigner-gated | Compressed cosigner pubkey (33-byte hex). |
 
 Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md)).
 
@@ -78,7 +79,12 @@ When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON obj
   "amt": "<uint64 decimal string>",
   "sym": "<optional>",
   "icon": "<optional txid_vout>",
-  "dec": "<optional 0-18 string>"
+  "dec": "<optional 0-18 string>",
+  "cosign": {
+    "pubkey": "<33-byte compressed pubkey hex>",
+    "endpoint": "<optional https host or base URL>",
+    "feeAddress": "<optional>"
+  }
 }
 ```
 
@@ -91,8 +97,57 @@ When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON obj
 | `sym` | string | MAY | Display symbol (inherited from deploy; not unique). |
 | `icon` | string | MAY | Deploy icon outpoint (`txid_vout`). |
 | `dec` | string | MAY | Deploy decimals `0`–`18` as a decimal string. |
+| `cosign` | object | MAY | Optional cosigner gate (see below). Omit for plain P2PKH value tips. |
 
 Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)).
+
+### Optional cosigner gate
+
+Some BSV-21 value tips (e.g. regulated stables such as MNEE) require a **service cosigner** in addition to the owner key. Cosigning is **optional** in this profile: plain owner-only tips remain valid. When present, cosign MUST be an explicit spend path — never a silent fallthrough to bare P2PKH `createAction`.
+
+#### On-chain template (informative)
+
+After the [BRC-160](./0160.md) inscription envelope, a common cosigned lock is:
+
+1. Owner P2PKH branch ending in `OP_CHECKSIGVERIFY` (not `OP_CHECKSIG`).
+2. Push of a 33-byte compressed **cosigner pubkey**.
+3. `OP_CHECKSIG`.
+
+Hex suffix shape (after the inscription prefix):
+
+`76a914` ‖ `<20-byte pkhash>` ‖ `88ad21` ‖ `<33-byte pubkey>` ‖ `ac`
+
+Other templates MAY exist; wallets detect cosign by script inspection and/or remittance.
+
+#### Remittance
+
+When a tip is cosigner-gated, conforming writers SHOULD:
+
+* Set `customInstructions.cosign.pubkey` to the cosigner compressed pubkey hex.
+* Set tag `cosign:<pubkeyHex>`.
+* MAY set `cosign.endpoint` (HTTPS base for the issuer’s transfer API) and `cosign.feeAddress` when known.
+
+Receivers that do not implement cosign MUST still store and forward these fields, and MUST NOT spend the tip as if it were plain P2PKH.
+
+#### Spend paths (tagged)
+
+| Path | When | Behavior |
+|------|------|----------|
+| `plain` | Tip lock is owner-only (or remittance has no cosign and script is plain) | Normal BRC-100 spend of the value tip; conserve `amt` for `id`. |
+| `cosigned` | Tip requires cosigner (script and/or remittance) **and** wallet has a cosigner client for that pubkey/endpoint | Build transfer outs with the same cosign template; owner signs with a sighash the cosigner can complete (commonly `SIGHASH_ALL\|ANYONECANPAY\|FORKID`); submit partial tx to the cosigner; broadcast only the cosigner-finalized transaction. |
+| `refuse` | Tip is cosigned but no cosigner client is available, or the lock is unknown | Fail closed. Do not attempt plain unlock. Surface a named reason (e.g. `cosigner_required`). |
+
+Wallets MUST NOT catch a cosigner / script failure and retry as `plain`.
+
+#### Cosigner API (informative)
+
+Issuers MAY expose an HTTP transfer API. A widely deployed shape (MNEE) is:
+
+* `POST /v2/transfer` with `{ "rawtx": "<base64 partial tx>", "callback_url"?: "..." }` → ticket id
+* `GET /v2/ticket?ticketID=...` → status / final hex
+* `GET /v1/config` → `approver` pubkey, fee address, token id, fee policy
+
+This profile does not mandate that API; it only requires the remittance fields and fail-closed path split when a tip is cosigned.
 
 #### Claims vs admission
 
@@ -170,11 +225,13 @@ Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0
 * **Symbol collision** — `sym` is not unique; always key balances by token id.
 * **Basket pollution** — Non-value or multi-sat outs in `bsv21` confuse list UIs; re-check `satoshis` and inscription rules.
 * **Over-transfer burn** — Building outputs whose `amt` sum exceeds *spent inputs* burns value ([BRC-161](./0161.md)). Local send paths SHOULD conserve the sender's inputs.
+* **Cosigner bypass** — Spending a cosigned tip with a plain P2PKH unlock fails on-chain and MUST be refused in the wallet. Do not fall through from `cosigned` to `plain`.
 
 ## Implementations
 
-* **HandCash Desktop** (reference, in progress): basket `bsv21` list / import under Collect (not Pay); JSON carrier aligned with [BRC-161](./0161.md).  
-  Source: `src/wallet/bsv21.ts`, `src/wallet/fungibles.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).
+* **HandCash Desktop** (reference, in progress): basket `bsv21` list / import under Collect (not Pay); optional cosign detect + remittance; cosigned send refuses until a cosigner client is configured.  
+  Source: `src/wallet/bsv21.ts`, `src/wallet/bsv21TipKind.ts`, `src/wallet/fungibles.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).
+* **HandCash Cloud**: MNEE cosigner instrument path (`mneeCosignerService`, `mneeFactory`) — production cosigned send for the MNEE token as a Pay currency.
 
 ## References
 

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -4,7 +4,7 @@ Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
 ## Abstract
 
-This BRC defines the **application basket profile** for [BRC-161](./0161.md) BSV-21 fungible **value** outputs under [BRC-46](../wallet/0046.md) / [BRC-100](../wallet/0100.md). It reserves the basket name `bsv21`, specifies eligibility, documents the **tag** vocabulary for filtering, [BRC-37](../outpoints/0037.md) `customInstructions` for **derivation** (and case-preserving display), and describes normative hold / list / transfer / import flows.
+This BRC defines the **application basket profile** for [BRC-161](./0161.md) BSV-21 fungible **value** outputs under [BRC-46](../wallet/0046.md) / [BRC-100](../wallet/0100.md). It reserves the basket name `bsv21`, specifies eligibility, documents **tags** for `listOutputs` filters, [BRC-37](../outpoints/0037.md) `customInstructions` for **load-bearing token fields** and **derivation**, and describes normative hold / list / transfer / import flows.
 
 It does **not** redefine BSV-21 token economics (deploy, auth, mint, transfer, burn). Those live in [BRC-161](./0161.md) (JSON) and [BRC-162](./0162.md) (binary).
 
@@ -16,7 +16,7 @@ It does **not** redefine BSV-21 token economics (deploy, auth, mint, transfer, b
 
 1. Hold the same token UTXOs in a common basket (separate from spendable BSV and from `1sat` collectables).
 2. List and aggregate balances by token id for apps and UI.
-3. Transfer value outputs while preserving filter tags and unlock metadata the receiver needs.
+3. Transfer value outputs while preserving remittance (`customInstructions` + filter tags) the receiver needs.
 4. Import historical tips via `internalizeAction` with interoperable basket insertion.
 
 This profile records that convention so independent wallets can interoperate without trusting a single vendor. It is the fungible counterpart to [BRC-147](./0147.md) for collectables.
@@ -48,9 +48,9 @@ This profile’s normative remittance examples use the JSON carrier ([BRC-161](.
 ### Outpoint and token id encoding
 
 * BRC-100 wire `outpoint` fields use **dot** form: `txid.vout`.
-* BSV-21 **token ids** use **underscore** form only: `txid_vout` ([BRC-161](./0161.md)). That form is the value after the `bsv21:` tag prefix and in on-chain fields — not a `customInstructions` requirement.
-* After the `bsv21:` tag prefix, writers MUST use underscore form for the token id. Readers MUST still accept and normalize either outpoint form before comparison.
-* Other outpoint-shaped tag values (e.g. `icon:`): writers SHOULD use underscore form; readers MUST normalize either form.
+* BSV-21 **token ids** use **underscore** form only: `txid_vout` ([BRC-161](./0161.md)) — in on-chain fields, in CI `id`, and after the `bsv21:` tag prefix.
+* Writers MUST use underscore form for those token-id strings. Readers MUST still accept and normalize either outpoint form before comparison.
+* Other outpoint-shaped values (e.g. CI / tag `icon`): writers SHOULD use underscore form; readers MUST normalize either form.
 
 ### Tags vs customInstructions
 
@@ -58,34 +58,34 @@ Both tags and `customInstructions` travel with the output under [BRC-46](../wall
 
 | | **Tags** | **`customInstructions`** |
 |--|----------|---------------------------|
-| Role | **Searchable / filterable** keys (`listOutputs` + `tags` / `tagQueryMode`) | How *this* wallet unlocks the tip (**derivation**), plus case-preserving display |
-| Case | Reference validation **trims and lowercases** each tag ([BRC-100](../wallet/0100.md)) | JSON string values **preserve case** |
-| Typical content | Token id, amount, decimals, icon outpoint, deploy/auth markers, issuer filter, [BRC-164](../wallet/0164.md) `id:` | `protocolID` / `keyID` / `counterparty`; `sym` when known |
+| Role | **Exact-match filters** for `listOutputs` (`tags` / `tagQueryMode`) | **Load-bearing remittance** for this tip: token fields apps read by key, plus **derivation** when this wallet locked it |
+| Case | Trimmed and **lowercased** before store/match ([BRC-100](../wallet/0100.md)) | JSON string values **preserve case** |
+| Typical content | `bsv21:<tokenId>`, optional kind markers / issuer / BRC-164 `id:` | `id`, `amt`, `op`, `sym`, `dec`, `icon`, and `protocolID` / `keyID` / `counterparty` when derived |
 
-On-chain token fields remain defined by [BRC-161](./0161.md) / [BRC-162](./0162.md). Tags are the wallet’s filter index for those facts; CI is not a second inscription document.
+On-chain token fields remain defined by [BRC-161](./0161.md) / [BRC-162](./0162.md). CI is a **compact remittance object** for the tip — not a paste of the full inscription JSON (`p` and other wire-only keys need not appear).
 
 **Placement:**
 
-* **Tags** — filterable facts: `bsv21:<tokenId>`, `amt:<…>`, and when useful `dec:…`, `icon:…`, `bsv21:deploy` / `bsv21:auth`, `issuer:…`, plus `id:<key>` per [BRC-164](../wallet/0164.md).
-* **`customInstructions`** — derivation when this wallet created the lock (`protocolID`, `keyID`, `counterparty`, …) and **case-preserving** `sym` when known.
+* **`customInstructions`** — token fields apps need without scanning tags or re-parsing script on every UI read: at least `id` and `amt`; `op`, `sym`, `dec`, `icon` when applicable; plus derivation when this wallet created the lock.
+* **Tags** — values useful as **exact** `listOutputs` queries (primarily `bsv21:<tokenId>`). Optional kind / issuer / list-key tags as below.
 
-Readers resolving a display symbol SHOULD prefer `customInstructions.sym` when present, and MAY fall back to a `sym:` tag or overlay metadata.
+**Reader priority** for token id, amount, and display metadata: `customInstructions` → tags (legacy / compat) → locking script / local history.
 
 ### Tags
 
-Tags are optional BRC-46 / BRC-100 output tags used for **filtering**. They are **non-authoritative for balances** (script / local history admit value). Because the reference client lowercases tags, writers MUST treat tag equality as **case-insensitive** and SHOULD write tags in a lowercase-safe alphabet (hex outpoints, decimal `amt`, ASCII ops).
+Tags are optional BRC-46 / BRC-100 output tags used for **exact-match filtering**. Tag equality is **case-insensitive**. Writers SHOULD use a lowercase-safe alphabet (hex outpoints, ASCII markers).
 
 | Tag | Requirement | Meaning |
 |-----|-------------|---------|
-| `bsv21:<tokenId>` | SHOULD | Token id (`txid_vout` of deploy) from the tip. Primary filter key for “which token.” |
-| `amt:<string>` | SHOULD | Token amount in this output (decimal string, integer units) from the tip. |
-| `dec:<string>` | SHOULD when known | Deploy decimals `0`–`18` (filter / UI hint). |
-| `icon:<outpoint>` | SHOULD when known | Deploy icon outpoint (underscore form preferred). Pointer only — see **Icon media**. |
-| `sym:<string>` | MAY | Lowercased symbol filter. Prefer CI `sym` for display case. |
-| `bsv21:deploy` | MAY | Marks a deploy output under this profile. |
-| `bsv21:auth` | MAY | Marks an authority UTXO filed in this basket (if the wallet tracks auth here). |
-| `issuer:<pubkeyHex>` | MAY when issuer is known | Compressed issuer identity pubkey (hex). Filter mirror — verify Sigma on-chain. |
-| `id:<string>` | MAY | Wallet-local per-output list key per [BRC-164](../wallet/0164.md). Token id uses `bsv21:<tokenId>` above. |
+| `bsv21:<tokenId>` | SHOULD | Token id (`txid_vout` of deploy). Primary filter: “UTXOs of this token.” |
+| `bsv21:deploy` | MAY | Deploy output under this profile. |
+| `bsv21:auth` | MAY | Authority UTXO filed in this basket (if tracked here). |
+| `op:<string>` | MAY | Last known op filter (`transfer`, `mint`, `deploy+mint`, …). |
+| `issuer:<pubkeyHex>` | MAY when issuer is known | Issuer pubkey hex for filters. Verify Sigma on-chain for proof. |
+| `id:<string>` | MAY | Wallet-local per-output list key per [BRC-164](../wallet/0164.md). Token id is CI `id` / tag `bsv21:<tokenId>`. |
+| `amt:<string>` | MAY | Legacy / compat amount filter. Prefer CI `amt` for reads; exact tag match is rarely useful for balances. |
+| `sym:<string>` | MAY | Legacy lowercased symbol filter. Prefer CI `sym` for display. |
+| `dec:<string>` / `icon:<outpoint>` | MAY | Legacy / compat mirrors of CI fields. |
 
 Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md)). Receivers that adopt BRC-164 stamp their own `id:` on import.
 
@@ -93,35 +93,45 @@ Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoin
 
 When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON object serialized as a string**.
 
-Conforming writers SHOULD emit derivation fields when this wallet locked the tip, and `sym` when known:
+Conforming writers SHOULD emit a **compact** object — load-bearing token fields plus derivation when this wallet locked the tip:
 
 ```json
 {
+  "id": "<txid_vout>",
+  "amt": "<uint64 decimal string>",
+  "op": "transfer",
+  "sym": "<case-preserving ticker>",
+  "dec": "<optional 0-18 string>",
+  "icon": "<optional txid_vout>",
   "protocolID": [0, "onesat"],
   "keyID": "<wallet-defined>",
-  "counterparty": "self",
-  "sym": "<optional case-preserving ticker>"
+  "counterparty": "self"
 }
 ```
 
 | Field | Type | Requirement | Meaning |
 |-------|------|-------------|---------|
-| `protocolID` | array | SHOULD when wallet-derived | BRC-43 protocol used to derive the locking key. |
-| `keyID` | string | SHOULD when wallet-derived | BRC-43 key id for this output (only when that key was used to lock). |
-| `counterparty` | string | SHOULD when wallet-derived | BRC-43 counterparty (`self`, identity key, …). |
+| `id` | string | SHOULD | Token id, underscore form ([BRC-161](./0161.md)). |
+| `amt` | string | SHOULD | Amount in this UTXO (integer units as decimal string). |
+| `op` | string | SHOULD when known | Value op for this output (`transfer`, `mint`, `deploy+mint`, …). |
 | `sym` | string | SHOULD when known | Display symbol (**case-preserving**). |
+| `dec` | string | SHOULD when known | Deploy decimals `0`–`18`. |
+| `icon` | string | SHOULD when known | Deploy icon outpoint (`txid_vout`). Pointer only — see **Icon media**. |
+| `protocolID` | array | SHOULD when wallet-derived | BRC-43 protocol used to derive the locking key. |
+| `keyID` | string | SHOULD when wallet-derived | BRC-43 key id (only when that key locked the output). |
+| `counterparty` | string | SHOULD when wallet-derived | BRC-43 counterparty (`self`, identity key, …). |
 
 Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)), subject to the reference client’s size limits.
 
-When the tip is locked with a **literal** script or external address and this wallet has no derivation triple, CI MAY be omitted or hold only `sym` (and similar display claims).
+When the tip is locked with a **literal** script or external address and this wallet has no derivation triple, omit derivation fields and still SHOULD carry `id` / `amt` / display fields the sender knows.
 
 ### Icon media (P2P — no content indexer)
 
-BRC-161 `icon` is an **outpoint** of a prior image inscription (B-protocol / `ord` envelope), not a URL. The outpoint is known from the **deploy script** (and MAY be mirrored as tag `icon:<outpoint>` for filters).
+BRC-161 `icon` is an **outpoint** of a prior image inscription (B-protocol / `ord` envelope), not a URL. Conforming remittance carries that pointer in CI `icon` (and MAY mirror a tag).
 
 * **Writers SHOULD** include the icon inscription transaction in the **BEEF** that accompanies transfer / import (`inputBEEF`, AtomicBEEF subject parents, or equivalent known-tx set) whenever they know that transaction (minting wallet, prior holder with stored BEEF).
 * **Receivers SHOULD** prefer decoding icon bytes from local BEEF / locking script (`ord` envelope field 0 + content-type) and MAY cache them keyed by the icon outpoint.
-* The stable pointer is the on-chain / tag outpoint; media bytes travel in BEEF (keep CI under the 1000-byte `internalizeAction` cap).
+* Media bytes travel in BEEF (keep CI under the 1000-byte `internalizeAction` cap).
 * When no icon outpoint is present, or icon bytes cannot be recovered locally, wallets MAY show a deterministic hash tile (identicon) from token id / `sym` — a UI fallback, not on-chain metadata.
 * Content HTTP APIs remain an optional **recovery** aid when local BEEF is missing.
 
@@ -131,17 +141,17 @@ BRC-161 `icon` is an **outpoint** of a prior image inscription (B-protocol / `or
 
 * **Proof (normative when claimed):** the deploy transaction SHOULD carry a [Sigma](https://docs.sigmaidentity.com/) signature over the value tip, signed with the issuer’s identity key (prefer **BRC-77** so the pubkey is recoverable; **BSM** is acceptable when the remittance carries the matching compressed pubkey). This matches `js-1sat-ord` `deployBsv21Token({ signer: { idKey } })`.
 * **Filter tag:** writers MAY set tag `issuer:<pubkeyHex>` for `listOutputs` filters.
-* **Tags are not proof.** Receivers SHOULD verify Sigma on the tip when present. **Unsigned deploys remain fully valid** value tips under this profile — issuer attestation is optional. When an issuer is shown, wallets SHOULD distinguish a Sigma-matched claim from a tag-only claim; when no issuer is known, omit issuer UI rather than framing the tip as defective.
-* Do **not** use tag `id:` for issuer or for the BSV-21 token id ([BRC-164](../wallet/0164.md)). Token id remains tag `bsv21:<tokenId>` and the on-chain token id field.
+* **Tags / CI are not proof.** Receivers SHOULD verify Sigma on the tip when present. **Unsigned deploys remain fully valid** value tips under this profile — issuer attestation is optional. When an issuer is shown, wallets SHOULD distinguish a Sigma-matched claim from a remittance-only claim; when no issuer is known, omit issuer UI rather than framing the tip as defective.
+* Token id remains CI `id` / tag `bsv21:<tokenId>` / on-chain token id. Per-output list keys use [BRC-164](../wallet/0164.md) `id:`.
 * Display SHOULD key by `(issuer, tokenId)` with `sym` as a nickname only.
 
 #### Claims vs admission
 
-* Tags and non-derivation CI fields are **claims** for filter / display convenience.
+* CI token fields and tags are **claims** for remittance / filter convenience.
 * Token **admission** for a tip the wallet holds is local: valid script / history the wallet verifies for that tip. Global supply audits and indexers are optional.
-* A wallet MUST NOT treat `amt` / token id as proven solely because they appear in tags from an untrusted sender — prefer script parse and local history.
+* A wallet MUST NOT treat `amt` / token id as proven solely because they appear in CI or tags from an untrusted sender — prefer script parse and local history when trust matters.
 * Issuers (especially authority-mint tokens) are trusted for mint policy under this profile.
-* Issuer pubkey in tags/CI is a claim until Sigma (or equivalent on-chain attestation) verifies.
+* Issuer pubkey in tags is a claim until Sigma (or equivalent on-chain attestation) verifies.
 
 ### Non-plain locks (out of scope for this profile’s send path)
 
@@ -163,20 +173,20 @@ Applications list held tips with BRC-100 `listOutputs`:
 }
 ```
 
-UI SHOULD aggregate by token id (from tag `bsv21:<tokenId>` and/or script parse) and sum `amt:` (or script amounts) for balances. Wallets MAY require basket permission per BRC-46 / BRC-100 before returning outputs.
+UI SHOULD aggregate by token id and sum amounts from **CI** (`id` / `amt`), with tag / script fallbacks per [Reader priority](#tags-vs-custominstructions). Filter held tips of one token with tag `bsv21:<tokenId>`. Wallets MAY require basket permission per BRC-46 / BRC-100 before returning outputs.
 
 ### Transfer (send)
 
 A conforming transfer of held `bsv21` value SHOULD use BRC-100 `createAction` with:
 
-1. One or more **inputs** spending value tips (`satoshis === 1`) whose token id matches the token being sent (script and/or tags).
-2. One or more **outputs** with `satoshis: 1`, `basket: "bsv21"`, tags per this profile (`bsv21:<tokenId>`, `amt:…`, …), and `customInstructions` for **derivation** when this wallet locks the output (plus `sym` when known).
+1. One or more **inputs** spending value tips (`satoshis === 1`) whose token id matches the token being sent (CI / script / tags).
+2. One or more **outputs** with `satoshis: 1`, `basket: "bsv21"`, filter tags (at least `bsv21:<tokenId>`), and `customInstructions` with load-bearing fields (`id`, `amt`, …) plus derivation when this wallet locks the output.
 3. Output amounts MUST NOT exceed input amounts for that token id under [BRC-161](./0161.md) conservation (excess burns). Change SHOULD return to the sender as another `bsv21` output when needed.
 4. Prefer supplying `inputBEEF` / BEEF for spent tips when available so the receiver can validate the spend graph ([BRC-62](../transactions/0062.md), [BRC-95](../transactions/0095.md)).
 5. When an icon outpoint is known for the token, SHOULD merge the **icon inscription transaction** into that BEEF so the receiver can decode ticker media offline (see Icon media).
 6. Action `labels` MAY include `bsv21`; labels are non-normative for balances. Held spends MAY use [BRC-164](../wallet/0164.md) list keys in labels when a permission module is present; that is out of scope for this profile’s remittance rules.
 
-Self-kept change MUST carry tags for the new `amt` and MUST record derivation CI when the wallet derived the lock. Senders MUST NOT invent a different token id for the same economic tip.
+Self-kept change SHOULD carry updated CI `amt` (and filter tag `bsv21:<tokenId>`) and derivation CI when the wallet derived the lock. Senders MUST NOT invent a different token id for the same economic tip.
 
 ### Import / receive (`internalizeAction`)
 
@@ -192,14 +202,14 @@ To place an existing value tip into basket `bsv21`, use BRC-100 `internalizeActi
     "protocol": "basket insertion",
     "insertionRemittance": {
       "basket": "bsv21",
-      "tags": ["bsv21:<txid_vout>", "amt:<amt>"],
-      "customInstructions": "{\"sym\":\"DEMO\"}"
+      "tags": ["bsv21:<txid_vout>"],
+      "customInstructions": "{\"id\":\"<txid_vout>\",\"amt\":\"<amt>\",\"op\":\"transfer\",\"sym\":\"DEMO\"}"
     }
   }]
 }
 ```
 
-Import CI is optional and MUST stay within the reference client’s **1000-byte** cap. Prefer tags for filter keys; parse token id / amount from the tip script when verifying admission. Derivation fields apply only if this wallet will unlock the tip with a known triple.
+Import CI MUST stay within the reference client’s **1000-byte** cap. Prefer CI for token fields; use tag `bsv21:<tokenId>` so later `listOutputs` can filter; parse the tip script when verifying admission. Derivation fields apply only if this wallet will unlock the tip with a known triple.
 
 ### Payment separation (wallet policy guidance)
 
@@ -220,7 +230,7 @@ Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0
 ## Security considerations
 
 * **Indexer trust** — Display MUST NOT depend on HTTP content indexers for `icon` when BEEF was supplied. Indexers are optional recovery only (see Icon media).
-* **Tag spoofing** — `bsv21:` / `amt:` / `sym` claims are forgeable. Receivers SHOULD verify tip script / history for outs they accept; do not treat tags alone as admission.
+* **Remittance spoofing** — CI `id` / `amt` / `sym` and filter tags are forgeable. Receivers SHOULD verify tip script / history for outs they accept; do not treat remittance alone as admission.
 * **Trusted issuer** — This profile does not require wallets to prove a global supply cap. Over-mint by an authority issuer is an issuer/policy risk accepted by holders of that token.
 * **Symbol collision** — `sym` is not unique; always key balances by token id.
 * **Basket pollution** — Non-value or multi-sat outs in `bsv21` confuse list UIs; re-check `satoshis` and inscription rules.

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -89,6 +89,7 @@ Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hi
 | `amt:<string>` | SHOULD when known | Token amount in this output (decimal string, integer units). |
 | `op:<string>` | MAY | Last known op (`transfer`, `mint`, `deploy+mint`, …). |
 | `sym:<string>` | MAY (legacy / filter only) | Lowercased symbol hint. New writers SHOULD put display symbol in `customInstructions.sym` instead. |
+| `issuer:<pubkeyHex>` | SHOULD when issuer is known | Compressed issuer identity pubkey (hex). Filter mirror only — verify Sigma on-chain. |
 | `id:<string>` | MAY | Wallet-local per-output list key (see below). **Not** the BSV-21 token id. |
 
 Conforming writers MUST NOT use `id:<…>` for the BSV-21 token id. The tag prefix `id:` is reserved for a **per-output** identity / list key across the wallet stack (so a specific output can be found without scanning every basket row). Generation is wallet-defined; it is not global asset identity. Token id in inscription / `customInstructions` JSON remains the BRC-161 field name `id`.
@@ -120,8 +121,19 @@ When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON obj
 | `sym` | string | SHOULD when known | Display symbol (case-preserving; not unique). Preferred over a `sym:` tag. |
 | `icon` | string | MAY | Deploy icon outpoint (`txid_vout`). |
 | `dec` | string | MAY | Deploy decimals `0`–`18` as a decimal string. |
+| `issuer` | string | SHOULD when known | Compressed issuer identity pubkey hex (33-byte). Remittance **mirror** of on-chain attestation — not the proof. |
 
 Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)), subject to the reference client’s size limits above.
+
+### Issuer attestation
+
+`sym` is not unique. Meaningful tokens bind a **deploy** to an **issuer identity**.
+
+* **Proof (normative when claimed):** the deploy transaction SHOULD carry a [Sigma](https://docs.sigmaidentity.com/) signature over the value tip, signed with the issuer’s identity key (prefer **BRC-77** so the pubkey is recoverable; **BSM** is acceptable when the remittance carries the matching compressed pubkey). This matches `js-1sat-ord` `deployBsv21Token({ signer: { idKey } })`.
+* **Remittance mirror:** writers SHOULD set `customInstructions.issuer` to that compressed pubkey hex and MAY set tag `issuer:<pubkey>` (lowercase-safe) for `listOutputs` filters.
+* **CI/tags are not proof.** Receivers SHOULD verify Sigma on the tip when present. **Unsigned deploys remain fully valid** value tips under this profile — issuer attestation is optional. When an issuer is shown, wallets SHOULD distinguish a Sigma-matched claim from a remittance-only claim; when no issuer is known, omit issuer UI rather than framing the tip as defective.
+* Do **not** use tag `id:` for issuer or for the BSV-21 token id. Token id remains `bsv21:<tokenId>` / CI field `id`.
+* Display SHOULD key by `(issuer, tokenId)` with `sym` as a nickname only.
 
 #### Claims vs admission
 
@@ -129,6 +141,7 @@ Additional JSON keys are permitted and MUST be ignored by readers that do not un
 * Token **admission** for a tip the wallet holds is local: valid inscription / remittance fields plus any history the wallet verifies for that tip. Global supply audits and indexers are optional.
 * A wallet MUST NOT treat `amt` / `id` as proven solely because they appear in remittance from an untrusted sender.
 * Issuers (especially authority-mint tokens) are trusted for mint policy under this profile.
+* Issuer pubkey in remittance is a claim until Sigma (or equivalent on-chain attestation) verifies.
 
 ### Non-plain locks (out of scope for this profile’s send path)
 

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -82,7 +82,7 @@ Tags are optional BRC-46 / BRC-100 output tags used for **exact-match filtering*
 | `bsv21:auth` | SHOULD when applicable | Authority UTXO filed in this basket (if tracked here). |
 | `op:<string>` | MAY | Last known op filter (`transfer`, `mint`, `deploy+mint`, …). |
 | `issuer:<pubkeyHex>` | MAY when issuer is known | Issuer pubkey hex for filters. Verify Sigma on-chain for proof. |
-| `id:<string>` | MAY | Wallet-local per-output list key per [BRC-164](../wallet/0164.md). Token id is CI `id` / tag `bsv21:<tokenId>`. |
+| `id:<string>` | SHOULD when adopting [BRC-164](../wallet/0164.md) | Per-output list key (wallet-local). Not the BSV-21 token id. |
 | `amt:<string>` | MAY | Legacy / compat amount filter. Prefer CI `amt` for reads; exact tag match is rarely useful for balances. |
 | `sym:<string>` | MAY | Legacy lowercased symbol filter. Prefer CI `sym` for display. |
 | `dec:<string>` / `icon:<outpoint>` | MAY | Legacy / compat mirrors of CI fields. |

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -110,7 +110,6 @@ Conforming writers SHOULD emit derivation fields when this wallet locked the tip
 | `keyID` | string | SHOULD when wallet-derived | BRC-43 key id for this output (only when that key was used to lock). |
 | `counterparty` | string | SHOULD when wallet-derived | BRC-43 counterparty (`self`, identity key, …). |
 | `sym` | string | SHOULD when known | Display symbol (**case-preserving**). |
-| `issuer` | string | MAY when known | Compressed issuer pubkey hex — display mirror; not proof. |
 
 Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)), subject to the reference client’s size limits.
 
@@ -131,8 +130,8 @@ BRC-161 `icon` is an **outpoint** of a prior image inscription (B-protocol / `or
 `sym` is not unique. Meaningful tokens bind a **deploy** to an **issuer identity**.
 
 * **Proof (normative when claimed):** the deploy transaction SHOULD carry a [Sigma](https://docs.sigmaidentity.com/) signature over the value tip, signed with the issuer’s identity key (prefer **BRC-77** so the pubkey is recoverable; **BSM** is acceptable when the remittance carries the matching compressed pubkey). This matches `js-1sat-ord` `deployBsv21Token({ signer: { idKey } })`.
-* **Optional mirrors:** writers MAY set tag `issuer:<pubkey>` (lowercase-safe) for `listOutputs` filters and/or `customInstructions.issuer` as a display mirror.
-* **CI/tags are not proof.** Receivers SHOULD verify Sigma on the tip when present. **Unsigned deploys remain fully valid** value tips under this profile — issuer attestation is optional. When an issuer is shown, wallets SHOULD distinguish a Sigma-matched claim from a remittance-only claim; when no issuer is known, omit issuer UI rather than framing the tip as defective.
+* **Filter tag:** writers MAY set tag `issuer:<pubkeyHex>` for `listOutputs` filters.
+* **Tags are not proof.** Receivers SHOULD verify Sigma on the tip when present. **Unsigned deploys remain fully valid** value tips under this profile — issuer attestation is optional. When an issuer is shown, wallets SHOULD distinguish a Sigma-matched claim from a tag-only claim; when no issuer is known, omit issuer UI rather than framing the tip as defective.
 * Do **not** use tag `id:` for issuer or for the BSV-21 token id ([BRC-164](../wallet/0164.md)). Token id remains tag `bsv21:<tokenId>` and the on-chain token id field.
 * Display SHOULD key by `(issuer, tokenId)` with `sym` as a nickname only.
 

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -50,8 +50,8 @@ This profile’s normative remittance examples use the JSON carrier ([BRC-161](.
 * BRC-100 wire `outpoint` fields use **dot** form: `txid.vout`.
 * BSV-21 **token ids** use **underscore** form only: `txid_vout` ([BRC-161](./0161.md)).
 * Inside this profile’s `customInstructions`, the BSV-21 token field `id` MUST use underscore form.
-* The output tag for token id is `bsv21:<tokenId>` (see Tags). After the `bsv21:` prefix, tags MAY use either outpoint form; readers MUST normalize before comparison.
-* Tip outpoints in other tags MAY use either form; readers MUST normalize.
+* The output tag for token id is `bsv21:<tokenId>` (see Tags). After the `bsv21:` prefix, writers MUST use underscore form for the token id. Readers MUST still accept and normalize either outpoint form before comparison.
+* Tip outpoints in other tags: writers SHOULD use underscore form when the value is an outpoint; readers MUST normalize either form.
 
 ### Tags vs customInstructions
 
@@ -90,9 +90,9 @@ Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hi
 | `op:<string>` | MAY | Last known op (`transfer`, `mint`, `deploy+mint`, …). |
 | `sym:<string>` | MAY (legacy / filter only) | Lowercased symbol hint. New writers SHOULD put display symbol in `customInstructions.sym` instead. |
 | `issuer:<pubkeyHex>` | SHOULD when issuer is known | Compressed issuer identity pubkey (hex). Filter mirror only — verify Sigma on-chain. |
-| `id:<string>` | MAY | Wallet-local per-output list key (see below). **Not** the BSV-21 token id. |
+| `id:<string>` | MAY | Wallet-local per-output list key per [BRC-164](../wallet/0164.md). **Not** the BSV-21 token id. |
 
-Conforming writers MUST NOT use `id:<…>` for the BSV-21 token id. The tag prefix `id:` is reserved for a **per-output** identity / list key across the wallet stack (so a specific output can be found without scanning every basket row). Generation is wallet-defined; it is not global asset identity. Token id in inscription / `customInstructions` JSON remains the BRC-161 field name `id`.
+Conforming writers MUST NOT use `id:<…>` for the BSV-21 token id. Ordinary `id:<key>` tags are defined by **[BRC-164](../wallet/0164.md)** (stable per-row handles for `listOutputs`). This profile MUST NOT treat `id:` as token id, issuer, or global asset identity. Receivers MUST ignore a counterparty-supplied `id:` and stamp their own if they adopt BRC-164. Token id in inscription / `customInstructions` JSON remains the BRC-161 field name `id`.
 
 Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md)).
 
@@ -143,7 +143,7 @@ BRC-161 `icon` is an **outpoint** of a prior image inscription (B-protocol / `or
 * **Proof (normative when claimed):** the deploy transaction SHOULD carry a [Sigma](https://docs.sigmaidentity.com/) signature over the value tip, signed with the issuer’s identity key (prefer **BRC-77** so the pubkey is recoverable; **BSM** is acceptable when the remittance carries the matching compressed pubkey). This matches `js-1sat-ord` `deployBsv21Token({ signer: { idKey } })`.
 * **Remittance mirror:** writers SHOULD set `customInstructions.issuer` to that compressed pubkey hex and MAY set tag `issuer:<pubkey>` (lowercase-safe) for `listOutputs` filters.
 * **CI/tags are not proof.** Receivers SHOULD verify Sigma on the tip when present. **Unsigned deploys remain fully valid** value tips under this profile — issuer attestation is optional. When an issuer is shown, wallets SHOULD distinguish a Sigma-matched claim from a remittance-only claim; when no issuer is known, omit issuer UI rather than framing the tip as defective.
-* Do **not** use tag `id:` for issuer or for the BSV-21 token id. Token id remains `bsv21:<tokenId>` / CI field `id`.
+* Do **not** use tag `id:` for issuer or for the BSV-21 token id ([BRC-164](../wallet/0164.md)). Token id remains `bsv21:<tokenId>` / CI field `id`.
 * Display SHOULD key by `(issuer, tokenId)` with `sym` as a nickname only.
 
 #### Claims vs admission
@@ -226,6 +226,7 @@ Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0
 * Wallets that do not implement this profile MUST still store and forward unknown baskets’ `customInstructions` and tags unchanged ([BRC-37](../outpoints/0037.md)).
 * Basket `1sat` remains collectables only ([BRC-147](./0147.md)); BSV-21 value MUST NOT be filed there.
 * Deprecated tick-based BSV-20 inventory is out of scope.
+* Fine-grained [BRC-99](../wallet/0099.md) permission schemes for `bsv21` (e.g. `p bsv21 …` view/spend modules) are **out of scope** for this profile. This document is the plain basket / remittance contract only.
 
 ## Security considerations
 
@@ -249,7 +250,8 @@ Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0
 1. [BRC-161](./0161.md) — BSV-21 Fungible Tokens (JSON / Legacy)
 2. [BRC-162](./0162.md) — BSV-21 Fungible Tokens (Binary)
 3. [BRC-147](./0147.md) — 1Sat Ordinals Basket Profile
-4. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions
-5. [BRC-46](../wallet/0046.md) — Output Baskets
-6. [BRC-100](../wallet/0100.md) — Wallet-to-Application Interface
-7. [BRC-159](./0159.md) / [BRC-160](./0160.md) — 1Sat carrier (not FT admission)
+4. [BRC-164](../wallet/0164.md) — Output Identity Tags (`id:`)
+5. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions
+6. [BRC-46](../wallet/0046.md) — Output Baskets
+7. [BRC-100](../wallet/0100.md) — Wallet-to-Application Interface
+8. [BRC-159](./0159.md) / [BRC-160](./0160.md) — 1Sat carrier (not FT admission)

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -79,8 +79,8 @@ Tags are optional BRC-46 / BRC-100 output tags used for **filtering**. They are 
 |-----|-------------|---------|
 | `bsv21:<tokenId>` | SHOULD | Token id (`txid_vout` of deploy) from the tip. Primary filter key for “which token.” |
 | `amt:<string>` | SHOULD | Token amount in this output (decimal string, integer units) from the tip. |
-| `dec:<string>` | MAY | Deploy decimals `0`–`18` (filter / UI hint). |
-| `icon:<outpoint>` | MAY | Deploy icon outpoint (underscore form preferred). Pointer only — see **Icon media**. |
+| `dec:<string>` | SHOULD when known | Deploy decimals `0`–`18` (filter / UI hint). |
+| `icon:<outpoint>` | SHOULD when known | Deploy icon outpoint (underscore form preferred). Pointer only — see **Icon media**. |
 | `sym:<string>` | MAY | Lowercased symbol filter. Prefer CI `sym` for display case. |
 | `bsv21:deploy` | MAY | Marks a deploy output under this profile. |
 | `bsv21:auth` | MAY | Marks an authority UTXO filed in this basket (if the wallet tracks auth here). |

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -4,7 +4,7 @@ Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
 ## Abstract
 
-This BRC defines the **application basket profile** for [BRC-161](./0161.md) BSV-21 fungible **value** outputs under [BRC-46](../wallet/0046.md) / [BRC-100](../wallet/0100.md). It reserves the basket name `bsv21`, specifies eligibility, documents the tag vocabulary and [BRC-37](../outpoints/0037.md) `customInstructions` schema used for display and remittance, and describes normative hold / list / transfer / import flows.
+This BRC defines the **application basket profile** for [BRC-161](./0161.md) BSV-21 fungible **value** outputs under [BRC-46](../wallet/0046.md) / [BRC-100](../wallet/0100.md). It reserves the basket name `bsv21`, specifies eligibility, documents the **tag** vocabulary for filtering, [BRC-37](../outpoints/0037.md) `customInstructions` for **derivation** (and case-preserving display), and describes normative hold / list / transfer / import flows.
 
 It does **not** redefine BSV-21 token economics (deploy, auth, mint, transfer, burn). Those live in [BRC-161](./0161.md) (JSON) and [BRC-162](./0162.md) (binary).
 
@@ -16,8 +16,8 @@ It does **not** redefine BSV-21 token economics (deploy, auth, mint, transfer, b
 
 1. Hold the same token UTXOs in a common basket (separate from spendable BSV and from `1sat` collectables).
 2. List and aggregate balances by token id for apps and UI.
-3. Transfer value outputs while preserving `id` / `amt` / display claims for the receiver.
-4. Import historical tips via `internalizeAction` with interoperable remittance.
+3. Transfer value outputs while preserving filter tags and unlock metadata the receiver needs.
+4. Import historical tips via `internalizeAction` with interoperable basket insertion.
 
 This profile records that convention so independent wallets can interoperate without trusting a single vendor. It is the fungible counterpart to [BRC-147](./0147.md) for collectables.
 
@@ -48,10 +48,9 @@ This profile’s normative remittance examples use the JSON carrier ([BRC-161](.
 ### Outpoint and token id encoding
 
 * BRC-100 wire `outpoint` fields use **dot** form: `txid.vout`.
-* BSV-21 **token ids** use **underscore** form only: `txid_vout` ([BRC-161](./0161.md)).
-* Inside this profile’s `customInstructions`, the BSV-21 token field `id` MUST use underscore form.
-* The output tag for token id is `bsv21:<tokenId>` (see Tags). After the `bsv21:` prefix, writers MUST use underscore form for the token id. Readers MUST still accept and normalize either outpoint form before comparison.
-* Tip outpoints in other tags: writers SHOULD use underscore form when the value is an outpoint; readers MUST normalize either form.
+* BSV-21 **token ids** use **underscore** form only: `txid_vout` ([BRC-161](./0161.md)). That form is the value after the `bsv21:` tag prefix and in on-chain fields — not a `customInstructions` requirement.
+* After the `bsv21:` tag prefix, writers MUST use underscore form for the token id. Readers MUST still accept and normalize either outpoint form before comparison.
+* Other outpoint-shaped tag values (e.g. `icon:`): writers SHOULD use underscore form; readers MUST normalize either form.
 
 ### Tags vs customInstructions
 
@@ -59,81 +58,86 @@ Both tags and `customInstructions` travel with the output under [BRC-46](../wall
 
 | | **Tags** | **`customInstructions`** |
 |--|----------|---------------------------|
-| Role | Query / filter keys (`listOutputs` + `tags` / `tagQueryMode`) | Remittance object: token fields, display, optional spend metadata |
+| Role | **Searchable / filterable** keys (`listOutputs` + `tags` / `tagQueryMode`) | How *this* wallet unlocks the tip (derivation), plus case-preserving display that tags cannot hold |
 | Case | Reference validation **trims and lowercases** each tag before store/match ([BRC-100](../wallet/0100.md)) | JSON string values **preserve case** |
-| Size | Each tag ≤ **300 UTF-8 bytes** (`OutputTagStringUnder300Bytes`) | `internalizeAction` basket insertion caps the string at **1000 UTF-8 bytes**. `createAction` outputs are not capped the same way in current SDK validation, but writers SHOULD still keep CI lean so import/re-file paths succeed |
-| Authority | Non-authoritative claims / local metadata | Same for display; inscription / local history admit value |
+| Size | Each tag ≤ **300 UTF-8 bytes** | `internalizeAction` basket insertion caps the string at **1000 UTF-8 bytes**; keep CI lean |
+| Authority | Non-authoritative filter claims | Derivation fields describe this wallet’s unlock; display fields are claims |
+
+**Token economics on the tip** (`id`, `amt`, `op`, deploy metadata such as `dec` / on-chain `icon`) live in the **locking script** ([BRC-161](./0161.md) / [BRC-162](./0162.md)). Wallets and indexers parse the script when admission or display needs those fields. This profile MUST NOT require a second full copy of those fields in `customInstructions`.
 
 **Writers SHOULD:**
 
-* Put **filterable** facts in tags: bare `bsv21`, `bsv21:<tokenId>`, `amt:<…>`, and when useful `op:<…>`.
-* Put **case-preserving display** (`sym`) and load-bearing token fields (`id`, `amt`, `op`, `dec`, `icon`) in `customInstructions`.
-* Prefer a short CI object on `internalizeAction` (well under 1000 bytes). Do not embed large proofs, BEEF, or media **bytes** in CI for this profile — carry icon media in accompanying BEEF (see Icon media).
+* Put **filterable** facts in tags: `bsv21:<tokenId>`, `amt:<…>`, and when useful `dec:…`, `icon:…`, `bsv21:deploy` / `bsv21:auth`, `issuer:…`.
+* Put **derivation** in `customInstructions` when this wallet created the lock: `protocolID`, `keyID`, `counterparty` (and similar spend metadata only as needed to unlock).
+* Put **case-preserving** display symbol in `customInstructions.sym` when known (tags alone lose case).
 
 **Writers SHOULD NOT:**
 
-* Rely on a `sym:` tag as the primary display symbol (lowercasing destroys intended case; use CI `sym`).
-* Use tag prefix `id:` for the BSV-21 token id (see Tags).
+* Duplicate script-parseable token fields (`p`, `op`, token `id`, `amt`, `dec`, `icon`) into CI as a normative remittance blob.
+* Use a bare `bsv21` tag (no suffix) — basket membership already scopes the tip; use `bsv21:<tokenId>` for filtering by token.
+* Use tag prefix `id:` for the BSV-21 token id (see Tags / [BRC-164](../wallet/0164.md)).
 * Stuff oversized blobs into CI and expect `internalizeAction` to accept them.
 
-Readers resolving a display symbol SHOULD prefer `customInstructions.sym` when present, and MAY fall back to a `sym:` tag.
+Readers resolving a display symbol SHOULD prefer `customInstructions.sym` when present, and MAY fall back to a `sym:` tag or overlay metadata.
 
 ### Tags
 
-Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hints. They are **non-authoritative for balances**. Because the reference client lowercases tags, writers MUST treat tag equality as **case-insensitive** and SHOULD write tags in a lowercase-safe alphabet (hex outpoints, decimal `amt`, ASCII ops).
+Tags are optional BRC-46 / BRC-100 output tags used for **filtering**. They are **non-authoritative for balances** (script / local history admit value). Because the reference client lowercases tags, writers MUST treat tag equality as **case-insensitive** and SHOULD write tags in a lowercase-safe alphabet (hex outpoints, decimal `amt`, ASCII ops).
 
 | Tag | Requirement | Meaning |
 |-----|-------------|---------|
-| `bsv21` | SHOULD on conforming transfers and imports | Marks the output as a BSV-21 value tip under this profile (no suffix). |
-| `bsv21:<tokenId>` | SHOULD when known | Token id (`txid_vout` of deploy). Distinct from the bare `bsv21` marker. |
+| `bsv21:<tokenId>` | SHOULD when known | Token id (`txid_vout` of deploy). Primary filter key for “which token.” |
 | `amt:<string>` | SHOULD when known | Token amount in this output (decimal string, integer units). |
-| `op:<string>` | MAY | Last known op (`transfer`, `mint`, `deploy+mint`, …). |
-| `sym:<string>` | MAY (legacy / filter only) | Lowercased symbol hint. New writers SHOULD put display symbol in `customInstructions.sym` instead. |
-| `issuer:<pubkeyHex>` | SHOULD when issuer is known | Compressed issuer identity pubkey (hex). Filter mirror only — verify Sigma on-chain. |
+| `dec:<string>` | MAY | Deploy decimals `0`–`18` (filter / UI hint; also on-chain at deploy). |
+| `icon:<outpoint>` | MAY | Deploy icon outpoint (underscore form preferred). Pointer only — see **Icon media**. |
+| `sym:<string>` | MAY | Lowercased symbol filter only. Display case belongs in CI `sym`. |
+| `bsv21:deploy` | MAY | Marks a deploy output under this profile. |
+| `bsv21:auth` | MAY | Marks an authority UTXO filed in this basket (if the wallet tracks auth here). |
+| `issuer:<pubkeyHex>` | MAY when issuer is known | Compressed issuer identity pubkey (hex). Filter mirror — verify Sigma on-chain. |
 | `id:<string>` | MAY | Wallet-local per-output list key per [BRC-164](../wallet/0164.md). **Not** the BSV-21 token id. |
 
-Conforming writers MUST NOT use `id:<…>` for the BSV-21 token id. Ordinary `id:<key>` tags are defined by **[BRC-164](../wallet/0164.md)** (stable per-row handles for `listOutputs`). This profile MUST NOT treat `id:` as token id, issuer, or global asset identity. Receivers MUST ignore a counterparty-supplied `id:` and stamp their own if they adopt BRC-164. Token id in inscription / `customInstructions` JSON remains the BRC-161 field name `id`.
+There is **no** bare `bsv21` marker tag. Basket name `bsv21` already scopes the row; adding a redundant tag does not improve queries.
+
+Conforming writers MUST NOT use `id:<…>` for the BSV-21 token id. Ordinary `id:<key>` tags are defined by **[BRC-164](../wallet/0164.md)**. This profile MUST NOT treat `id:` as token id, issuer, or global asset identity. Receivers MUST ignore a counterparty-supplied `id:` and stamp their own if they adopt BRC-164.
 
 Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md)).
 
 ### Custom instructions ([BRC-37](../outpoints/0037.md))
 
-When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON object serialized as a string**. Conforming writers SHOULD emit a **compact** object (plain BSV-21 value tips):
+When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON object serialized as a string**.
+
+**Primary job — derivation (when this wallet can unlock the tip):**
 
 ```json
 {
-  "p": "bsv-20",
-  "op": "transfer",
-  "id": "<txid_vout>",
-  "amt": "<uint64 decimal string>",
-  "sym": "<optional>",
-  "icon": "<optional txid_vout>",
-  "dec": "<optional 0-18 string>"
+  "protocolID": [0, "onesat"],
+  "keyID": "<wallet-defined>",
+  "counterparty": "self",
+  "sym": "<optional case-preserving ticker>"
 }
 ```
 
 | Field | Type | Requirement | Meaning |
 |-------|------|-------------|---------|
-| `p` | string | SHOULD | `bsv-20` (legacy protocol id per [BRC-161](./0161.md)). |
-| `op` | string | SHOULD | Value op for this output (`transfer`, `mint`, or `deploy+mint`). |
-| `id` | string | SHOULD | Token id, underscore form. |
-| `amt` | string | SHOULD | Amount in this UTXO (integer units as decimal string). |
-| `sym` | string | SHOULD when known | Display symbol (case-preserving; not unique). Preferred over a `sym:` tag. |
-| `icon` | string | MAY | Deploy icon outpoint (`txid_vout`). Pointer only — see **Icon media**. |
-| `dec` | string | MAY | Deploy decimals `0`–`18` as a decimal string. |
-| `issuer` | string | SHOULD when known | Compressed issuer identity pubkey hex (33-byte). Remittance **mirror** of on-chain attestation — not the proof. |
+| `protocolID` | array | SHOULD when wallet-derived | BRC-43 protocol used to derive the locking key. |
+| `keyID` | string | SHOULD when wallet-derived | BRC-43 key id for this output. |
+| `counterparty` | string | SHOULD when wallet-derived | BRC-43 counterparty (`self`, identity key, …). |
+| `sym` | string | SHOULD when known | Display symbol (**case-preserving**). Preferred over a `sym:` tag for UI. |
+| `issuer` | string | MAY when known | Compressed issuer pubkey hex — remittance mirror only; not proof. |
 
-Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)), subject to the reference client’s size limits above.
+Do **not** require CI copies of script fields (`p`, `op`, token `id`, `amt`, `dec`, `icon`). Parse those from the locking script / local history when needed. Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)), subject to the reference client’s size limits.
+
+When the tip is locked with a **literal** script or external address and this wallet has no derivation triple, CI MAY be omitted or hold only `sym` / other non-derivation claims. Do not invent a `keyID` that was never used to lock the output.
 
 ### Icon media (P2P — no content indexer)
 
-BRC-161 `icon` is an **outpoint** of a prior image inscription (B-protocol / `ord` envelope), not a URL.
+BRC-161 `icon` is an **outpoint** of a prior image inscription (B-protocol / `ord` envelope), not a URL. The outpoint is known from the **deploy script** (and MAY be mirrored as tag `icon:<outpoint>` for filters).
 
 * **Writers MUST NOT** require receivers to fetch icon bytes from an HTTP content API (Gorilla, 1Sat content host, or similar) in order to display the ticker.
 * **Writers SHOULD** include the icon inscription transaction in the **BEEF** that accompanies transfer / import (`inputBEEF`, AtomicBEEF subject parents, or equivalent known-tx set) whenever they know that transaction (minting wallet, prior holder with stored BEEF).
 * **Receivers MUST** prefer decoding icon bytes from local BEEF / locking script (`ord` envelope field 0 + content-type) and MAY cache them keyed by the icon outpoint.
-* **`customInstructions` MUST NOT** embed raw image bytes or large base64 (CI stays under the 1000-byte `internalizeAction` cap). The outpoint in CI remains the stable pointer; media travels in BEEF.
-* When no icon outpoint is present, or icon bytes cannot be recovered locally, wallets MAY show a deterministic hash tile (identicon) from `id` / `sym` — that is a UI fallback, not on-chain metadata.
+* **`customInstructions` MUST NOT** embed raw image bytes or large base64 (CI stays under the 1000-byte `internalizeAction` cap). Media travels in BEEF; the stable pointer is the on-chain / tag outpoint.
+* When no icon outpoint is present, or icon bytes cannot be recovered locally, wallets MAY show a deterministic hash tile (identicon) from token id / `sym` — that is a UI fallback, not on-chain metadata.
 * Content HTTP APIs remain an optional **recovery** aid for wallets that lost local BEEF; they are not part of the normative remittance contract.
 
 ### Issuer attestation
@@ -141,18 +145,18 @@ BRC-161 `icon` is an **outpoint** of a prior image inscription (B-protocol / `or
 `sym` is not unique. Meaningful tokens bind a **deploy** to an **issuer identity**.
 
 * **Proof (normative when claimed):** the deploy transaction SHOULD carry a [Sigma](https://docs.sigmaidentity.com/) signature over the value tip, signed with the issuer’s identity key (prefer **BRC-77** so the pubkey is recoverable; **BSM** is acceptable when the remittance carries the matching compressed pubkey). This matches `js-1sat-ord` `deployBsv21Token({ signer: { idKey } })`.
-* **Remittance mirror:** writers SHOULD set `customInstructions.issuer` to that compressed pubkey hex and MAY set tag `issuer:<pubkey>` (lowercase-safe) for `listOutputs` filters.
+* **Optional mirrors:** writers MAY set tag `issuer:<pubkey>` (lowercase-safe) for `listOutputs` filters and/or `customInstructions.issuer` as a display mirror.
 * **CI/tags are not proof.** Receivers SHOULD verify Sigma on the tip when present. **Unsigned deploys remain fully valid** value tips under this profile — issuer attestation is optional. When an issuer is shown, wallets SHOULD distinguish a Sigma-matched claim from a remittance-only claim; when no issuer is known, omit issuer UI rather than framing the tip as defective.
-* Do **not** use tag `id:` for issuer or for the BSV-21 token id ([BRC-164](../wallet/0164.md)). Token id remains `bsv21:<tokenId>` / CI field `id`.
+* Do **not** use tag `id:` for issuer or for the BSV-21 token id ([BRC-164](../wallet/0164.md)). Token id remains tag `bsv21:<tokenId>` and the on-chain token id field.
 * Display SHOULD key by `(issuer, tokenId)` with `sym` as a nickname only.
 
 #### Claims vs admission
 
-* Tags and `customInstructions` fields are **claims** for display and remittance convenience.
-* Token **admission** for a tip the wallet holds is local: valid inscription / remittance fields plus any history the wallet verifies for that tip. Global supply audits and indexers are optional.
-* A wallet MUST NOT treat `amt` / `id` as proven solely because they appear in remittance from an untrusted sender.
+* Tags and non-derivation CI fields are **claims** for filter / display convenience.
+* Token **admission** for a tip the wallet holds is local: valid script / history the wallet verifies for that tip. Global supply audits and indexers are optional.
+* A wallet MUST NOT treat `amt` / token id as proven solely because they appear in tags from an untrusted sender — prefer script parse and local history.
 * Issuers (especially authority-mint tokens) are trusted for mint policy under this profile.
-* Issuer pubkey in remittance is a claim until Sigma (or equivalent on-chain attestation) verifies.
+* Issuer pubkey in tags/CI is a claim until Sigma (or equivalent on-chain attestation) verifies.
 
 ### Non-plain locks (out of scope for this profile’s send path)
 
@@ -174,20 +178,20 @@ Applications list held tips with BRC-100 `listOutputs`:
 }
 ```
 
-UI SHOULD aggregate by `id` (sum `amt`) for balances. Wallets MAY require basket permission per BRC-46 / BRC-100 before returning outputs.
+UI SHOULD aggregate by token id (from tag `bsv21:<tokenId>` and/or script parse) and sum `amt:` (or script amounts) for balances. Wallets MAY require basket permission per BRC-46 / BRC-100 before returning outputs.
 
 ### Transfer (send)
 
 A conforming transfer of held `bsv21` value SHOULD use BRC-100 `createAction` with:
 
-1. One or more **inputs** spending value tips (`satoshis === 1`) whose claimed `id` matches the token being sent.
-2. One or more **outputs** with `satoshis: 1`, `basket: "bsv21"`, tags per this profile, and `customInstructions` as above with `op: "transfer"`, the same `id`, and the output `amt`.
-3. Output amounts MUST NOT exceed input amounts for that `id` under [BRC-161](./0161.md) conservation (excess burns). Change SHOULD return to the sender as another `bsv21` output when needed.
+1. One or more **inputs** spending value tips (`satoshis === 1`) whose token id matches the token being sent (script and/or tags).
+2. One or more **outputs** with `satoshis: 1`, `basket: "bsv21"`, tags per this profile (`bsv21:<tokenId>`, `amt:…`, …), and `customInstructions` for **derivation** when this wallet locks the output (plus `sym` when known).
+3. Output amounts MUST NOT exceed input amounts for that token id under [BRC-161](./0161.md) conservation (excess burns). Change SHOULD return to the sender as another `bsv21` output when needed.
 4. Prefer supplying `inputBEEF` / BEEF for spent tips when available so the receiver can validate the spend graph ([BRC-62](../transactions/0062.md), [BRC-95](../transactions/0095.md)).
-5. When `customInstructions.icon` (or deploy `icon`) is set, SHOULD merge the **icon inscription transaction** into that BEEF so the receiver can decode ticker media offline (see Icon media).
-6. Action `labels` MAY include `bsv21`; labels are non-normative for balances.
+5. When an icon outpoint is known for the token, SHOULD merge the **icon inscription transaction** into that BEEF so the receiver can decode ticker media offline (see Icon media).
+6. Action `labels` MAY include `bsv21`; labels are non-normative for balances. Held spends MAY use [BRC-164](../wallet/0164.md) list keys in labels when a permission module is present; that is out of scope for this profile’s remittance rules.
 
-Senders that rebuild `customInstructions` MUST preserve `id` / `amt` / display fields they still know (including `icon` when known), and MUST NOT invent a different `id` for the same physical tip.
+Self-kept change MUST carry tags for the new `amt` and MUST record derivation CI when the wallet derived the lock. Senders MUST NOT invent a different token id for the same economic tip.
 
 ### Import / receive (`internalizeAction`)
 
@@ -203,14 +207,14 @@ To place an existing value tip into basket `bsv21`, use BRC-100 `internalizeActi
     "protocol": "basket insertion",
     "insertionRemittance": {
       "basket": "bsv21",
-      "tags": ["bsv21", "bsv21:<txid_vout>", "amt:<amt>"],
-      "customInstructions": "{\"p\":\"bsv-20\",\"op\":\"transfer\",\"id\":\"<txid_vout>\",\"amt\":\"<amt>\",\"sym\":\"DEMO\"}"
+      "tags": ["bsv21:<txid_vout>", "amt:<amt>"],
+      "customInstructions": "{\"sym\":\"DEMO\"}"
     }
   }]
 }
 ```
 
-Import CI MUST stay within the reference client’s **1000-byte** `customInstructions` cap.
+Import CI is optional and MUST stay within the reference client’s **1000-byte** cap. Prefer tags for filter keys; parse token id / amount from the tip script when verifying admission. Derivation fields apply only if this wallet will unlock the tip with a known triple.
 
 ### Payment separation (wallet policy guidance)
 
@@ -231,7 +235,7 @@ Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0
 ## Security considerations
 
 * **Indexer trust** — Display MUST NOT depend on HTTP content indexers for `icon` when BEEF was supplied. Indexers are optional recovery only (see Icon media).
-* **Remittance spoofing** — `id` / `amt` / `sym` in CI are forgeable. Receivers SHOULD verify tip history for outs they accept; do not treat remittance alone as admission.
+* **Tag spoofing** — `bsv21:` / `amt:` / `sym` claims are forgeable. Receivers SHOULD verify tip script / history for outs they accept; do not treat tags alone as admission.
 * **Trusted issuer** — This profile does not require wallets to prove a global supply cap. Over-mint by an authority issuer is an issuer/policy risk accepted by holders of that token.
 * **Symbol collision** — `sym` is not unique; always key balances by token id.
 * **Basket pollution** — Non-value or multi-sat outs in `bsv21` confuse list UIs; re-check `satoshis` and inscription rules.

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -1,0 +1,183 @@
+# BRC-163: BSV-21 Basket Profile for BRC-46 / BRC-100
+
+Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
+
+## Abstract
+
+This BRC defines the **application basket profile** for [BRC-161](./0161.md) BSV-21 fungible **value** outputs under [BRC-46](../wallet/0046.md) / [BRC-100](../wallet/0100.md). It reserves the basket name `bsv21`, specifies eligibility, documents the tag vocabulary and [BRC-37](../outpoints/0037.md) `customInstructions` schema used for display and remittance, and describes normative hold / list / transfer / import flows.
+
+It does **not** redefine BSV-21 token economics (deploy, auth, mint, transfer, burn). Those live in [BRC-161](./0161.md) (JSON) and [BRC-162](./0162.md) (binary). Offline amount-conservation proofs are out of scope here.
+
+## Motivation
+
+[BRC-161](./0161.md) / [BRC-162](./0162.md) define how BSV-21 appears on outputs. Without a shared basket name and remittance contract, wallets cannot reliably:
+
+1. Hold the same token UTXOs in a common basket (separate from spendable BSV and from `1sat` collectables).
+2. List and aggregate balances by token id for apps and UI.
+3. Transfer value outputs while preserving `id` / `amt` / display claims for the receiver.
+4. Import historical tips via `internalizeAction` with interoperable remittance.
+
+This profile records that convention so independent wallets can interoperate without trusting a single vendor. It is the fungible counterpart to [BRC-147](./0147.md) for collectables.
+
+## Specification
+
+### Basket identifier
+
+* The basket name is the UTF-8 string `bsv21`.
+* Per [BRC-46](../wallet/0046.md), implementations normalize basket identifiers by trimming whitespace and lowercasing. After normalization, conforming use of this profile MUST use exactly `bsv21`.
+* This identifier does **not** use the [BRC-99](../wallet/0099.md) reserved `p ` prefix. It is a standard application basket under BRC-46 permissioning.
+
+### Eligibility
+
+An output SHOULD be placed in basket `bsv21` only when **all** of the following hold:
+
+1. `satoshis === 1` (JSON carrier is a 1-sat inscription output per [BRC-161](./0161.md) / [BRC-160](./0160.md)).
+2. The output is a BSV-21 **value** output under [BRC-161](./0161.md): balance-bearing `deploy+mint`, `mint`, or `transfer` (not authority-only `deploy+auth` / `auth`, and not `burn`).
+3. The sender or importer reasonably believes the inscription (or prior remittance) names a valid token `id` and `amt` for that output.
+
+Wallets MUST NOT place ordinary payment change, `1sat` collectables, or authority-only outputs into `bsv21` merely to attach token-looking tags. Authority UTXOs MAY be tracked in a future companion basket; they are out of scope for this profile’s list/send surface.
+
+Outputs that fail eligibility MAY still appear if a buggy sender used the basket; receivers SHOULD re-check inscription / remittance fields and MUST NOT present them as spendable token value solely because of basket membership.
+
+### Binary encoding ([BRC-162](./0162.md))
+
+This profile’s normative remittance examples use the JSON carrier ([BRC-161](./0161.md)). Wallets that hold [BRC-162](./0162.md) binary value outputs MAY use the same basket name `bsv21` and the same tag / `customInstructions` field map (token id underscore string, decimal `amt` string). Encoding detection is local; the basket contract is shared.
+
+### Outpoint and token id encoding
+
+* BRC-100 wire `outpoint` fields use **dot** form: `txid.vout`.
+* BSV-21 **token ids** use **underscore** form only: `txid_vout` ([BRC-161](./0161.md)).
+* Inside this profile’s `customInstructions`, `id` MUST use underscore form. Tags MAY use either form after the `id:` prefix; readers MUST normalize before comparison.
+* Tip outpoints in tags MAY use either form; readers MUST normalize.
+
+### Tags
+
+Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hints. They are **non-authoritative for balances**.
+
+| Tag | Requirement | Meaning |
+|-----|-------------|---------|
+| `bsv21` | SHOULD on conforming transfers and imports | Marks the output as a BSV-21 value tip under this profile. |
+| `id:<tokenId>` | SHOULD when known | Token id (`txid_vout` of deploy). |
+| `amt:<string>` | SHOULD when known | Token amount in this output (decimal string, integer units). |
+| `sym:<string>` | MAY | Display symbol from deploy (not unique). |
+| `op:<string>` | MAY | Last known op (`transfer`, `mint`, …). |
+
+Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md)).
+
+### Custom instructions ([BRC-37](../outpoints/0037.md))
+
+When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON object serialized as a string**. Conforming writers SHOULD emit:
+
+```json
+{
+  "p": "bsv-20",
+  "op": "transfer",
+  "id": "<txid_vout>",
+  "amt": "<uint64 decimal string>",
+  "sym": "<optional>",
+  "icon": "<optional txid_vout>",
+  "dec": "<optional 0-18 string>"
+}
+```
+
+| Field | Type | Requirement | Meaning |
+|-------|------|-------------|---------|
+| `p` | string | SHOULD | `bsv-20` (legacy protocol id per [BRC-161](./0161.md)). |
+| `op` | string | SHOULD | Value op for this output (`transfer`, `mint`, or `deploy+mint`). |
+| `id` | string | SHOULD | Token id, underscore form. |
+| `amt` | string | SHOULD | Amount in this UTXO (integer units as decimal string). |
+| `sym` | string | MAY | Display symbol (inherited from deploy; not unique). |
+| `icon` | string | MAY | Deploy icon outpoint (`txid_vout`). |
+| `dec` | string | MAY | Deploy decimals `0`–`18` as a decimal string. |
+
+Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)).
+
+#### Claims vs admission
+
+* Tags and `customInstructions` fields are **claims** for display and remittance convenience.
+* Token **admission** (valid supply / authority / conservation) is defined by [BRC-161](./0161.md) / [BRC-162](./0162.md) and the wallet’s indexer or verification policy — not by basket membership alone.
+* A wallet MUST NOT treat `amt` / `id` as proven solely because they appear in remittance.
+
+### Hold and list
+
+Applications list held tips with BRC-100 `listOutputs`:
+
+```json
+{
+  "basket": "bsv21",
+  "includeTags": true,
+  "includeCustomInstructions": true
+}
+```
+
+UI SHOULD aggregate by `id` (sum `amt`) for balances. Wallets MAY require basket permission per BRC-46 / BRC-100 before returning outputs.
+
+### Transfer (send)
+
+A conforming transfer of held `bsv21` value SHOULD use BRC-100 `createAction` with:
+
+1. One or more **inputs** spending value tips (`satoshis === 1`) whose claimed `id` matches the token being sent.
+2. One or more **outputs** with `satoshis: 1`, `basket: "bsv21"`, tags per this profile, and `customInstructions` as above with `op: "transfer"`, the same `id`, and the output `amt`.
+3. Output amounts MUST NOT exceed input amounts for that `id` under [BRC-161](./0161.md) conservation (excess burns). Change SHOULD return to the sender as another `bsv21` output when needed.
+4. Prefer supplying `inputBEEF` / BEEF for spent tips when available so the receiver can validate the spend graph ([BRC-62](../transactions/0062.md), [BRC-95](../transactions/0095.md)).
+5. Action `labels` MAY include `bsv21`; labels are non-normative for balances.
+
+Senders that rebuild `customInstructions` MUST preserve `id` / `amt` / display fields they still know, and MUST NOT invent a different `id` for the same physical tip.
+
+### Import / receive (`internalizeAction`)
+
+To place an existing value tip into basket `bsv21`, use BRC-100 `internalizeAction` with protocol `basket insertion`:
+
+```json
+{
+  "tx": "<AtomicBEEF or BEEF bytes for the tip transaction>",
+  "description": "Import BSV-21 token",
+  "labels": ["bsv21"],
+  "outputs": [{
+    "outputIndex": 0,
+    "protocol": "basket insertion",
+    "insertionRemittance": {
+      "basket": "bsv21",
+      "tags": ["bsv21", "id:<txid_vout>", "amt:<amt>"],
+      "customInstructions": "{\"p\":\"bsv-20\",\"op\":\"transfer\",\"id\":\"<txid_vout>\",\"amt\":\"<amt>\"}"
+    }
+  }]
+}
+```
+
+### Payment separation (wallet policy guidance)
+
+Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0029.md) / default-basket payment. Conforming wallets SHOULD:
+
+* Require distinct user authorization (or a dedicated token/basket grant) before `createAction` / `relinquishOutput` that spends `bsv21` outputs.
+* Not treat a general “pay” or auto-pay grant as authorization to spend `bsv21` tips.
+* Not fund ordinary payment outputs from `bsv21` basket UTXOs.
+* Not mix `bsv21` value into basket `1sat` ([BRC-147](./0147.md)) or count it toward BSV balance views.
+
+### Compatibility
+
+* Wallets that do not implement this profile MUST still store and forward unknown baskets’ `customInstructions` and tags unchanged ([BRC-37](../outpoints/0037.md)).
+* Basket `1sat` remains collectables only ([BRC-147](./0147.md)); BSV-21 value MUST NOT be filed there.
+* Deprecated tick-based BSV-20 inventory is out of scope.
+
+## Security considerations
+
+* **Remittance spoofing** — `id` / `amt` / `sym` in CI are forgeable without an indexer or offline proof. Do not treat remittance as admission.
+* **Symbol collision** — `sym` is not unique; always key balances by token id.
+* **Basket pollution** — Non-value or multi-sat outs in `bsv21` confuse list UIs; re-check `satoshis` and inscription rules.
+* **Over-transfer burn** — Building outputs whose `amt` sum exceeds inputs burns value ([BRC-161](./0161.md)).
+
+## Implementations
+
+* **HandCash Desktop** (reference, in progress): basket `bsv21` list / import under Collect (not Pay); JSON carrier aligned with [BRC-161](./0161.md).  
+  Source: `src/wallet/bsv21.ts`, `src/wallet/fungibles.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).
+
+## References
+
+1. [BRC-161](./0161.md) — BSV-21 Fungible Tokens (JSON / Legacy)
+2. [BRC-162](./0162.md) — BSV-21 Fungible Tokens (Binary)
+3. [BRC-147](./0147.md) — 1Sat Ordinals Basket Profile
+4. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions
+5. [BRC-46](../wallet/0046.md) — Output Baskets
+6. [BRC-100](../wallet/0100.md) — Wallet-to-Application Interface
+7. [BRC-159](./0159.md) / [BRC-160](./0160.md) — 1Sat carrier (not FT admission)

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -78,8 +78,8 @@ Tags are optional BRC-46 / BRC-100 output tags used for **exact-match filtering*
 | Tag | Requirement | Meaning |
 |-----|-------------|---------|
 | `bsv21:<tokenId>` | SHOULD | Token id (`txid_vout` of deploy). Primary filter: “UTXOs of this token.” |
-| `bsv21:deploy` | MAY | Deploy output under this profile. |
-| `bsv21:auth` | MAY | Authority UTXO filed in this basket (if tracked here). |
+| `bsv21:deploy` | SHOULD when applicable | Deploy output under this profile. |
+| `bsv21:auth` | SHOULD when applicable | Authority UTXO filed in this basket (if tracked here). |
 | `op:<string>` | MAY | Last known op filter (`transfer`, `mint`, `deploy+mint`, …). |
 | `issuer:<pubkeyHex>` | MAY when issuer is known | Issuer pubkey hex for filters. Verify Sigma on-chain for proof. |
 | `id:<string>` | MAY | Wallet-local per-output list key per [BRC-164](../wallet/0164.md). Token id is CI `id` / tag `bsv21:<tokenId>`. |

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -80,7 +80,7 @@ Tags are optional BRC-46 / BRC-100 output tags used for **exact-match filtering*
 | `bsv21:<tokenId>` | SHOULD | Token id (`txid_vout` of deploy). Primary filter: “UTXOs of this token.” |
 | `bsv21:deploy` | SHOULD when applicable | Deploy output under this profile. |
 | `bsv21:auth` | SHOULD when applicable | Authority UTXO filed in this basket (if tracked here). |
-| `op:<string>` | MAY | Last known op filter (`transfer`, `mint`, `deploy+mint`, …). |
+| `op:<string>` | MAY | Op for this output (`transfer`, `mint`, `deploy+mint`, …). |
 | `issuer:<pubkeyHex>` | MAY when issuer is known | Issuer pubkey hex for filters. Verify Sigma on-chain for proof. |
 | `id:<string>` | SHOULD when adopting [BRC-164](../wallet/0164.md) | Per-output list key (wallet-local). Not the BSV-21 token id. |
 | `amt:<string>` | MAY | Legacy / compat amount filter. Prefer CI `amt` for reads; exact tag match is rarely useful for balances. |

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -54,29 +54,20 @@ This profile’s normative remittance examples use the JSON carrier ([BRC-161](.
 
 ### Tags vs customInstructions
 
-Both tags and `customInstructions` travel with the output under [BRC-46](../wallet/0046.md) / [BRC-37](../outpoints/0037.md). They serve different jobs. Profiles MUST NOT recommend shapes that fail in the **reference BRC-100 client** (`@bsv/sdk` wallet validation / wallet-toolbox storage):
+Both tags and `customInstructions` travel with the output under [BRC-46](../wallet/0046.md) / [BRC-37](../outpoints/0037.md). They serve different jobs. Writers SHOULD stay within **reference BRC-100 client** limits (`@bsv/sdk` / wallet-toolbox): tags ≤ **300** UTF-8 bytes each; `customInstructions` on `internalizeAction` basket insertion ≤ **1000** UTF-8 bytes.
 
 | | **Tags** | **`customInstructions`** |
 |--|----------|---------------------------|
-| Role | **Searchable / filterable** keys (`listOutputs` + `tags` / `tagQueryMode`) | How *this* wallet unlocks the tip (derivation), plus case-preserving display that tags cannot hold |
-| Case | Reference validation **trims and lowercases** each tag before store/match ([BRC-100](../wallet/0100.md)) | JSON string values **preserve case** |
-| Size | Each tag ≤ **300 UTF-8 bytes** | `internalizeAction` basket insertion caps the string at **1000 UTF-8 bytes**; keep CI lean |
-| Authority | Non-authoritative filter claims | Derivation fields describe this wallet’s unlock; display fields are claims |
+| Role | **Searchable / filterable** keys (`listOutputs` + `tags` / `tagQueryMode`) | How *this* wallet unlocks the tip (**derivation**), plus case-preserving display |
+| Case | Reference validation **trims and lowercases** each tag ([BRC-100](../wallet/0100.md)) | JSON string values **preserve case** |
+| Typical content | Token id, amount, decimals, icon outpoint, deploy/auth markers, issuer filter, [BRC-164](../wallet/0164.md) `id:` | `protocolID` / `keyID` / `counterparty`; `sym` when known |
 
-**Token economics on the tip** (`id`, `amt`, `op`, deploy metadata such as `dec` / on-chain `icon`) live in the **locking script** ([BRC-161](./0161.md) / [BRC-162](./0162.md)). Wallets and indexers parse the script when admission or display needs those fields. This profile MUST NOT require a second full copy of those fields in `customInstructions`.
+On-chain token fields remain defined by [BRC-161](./0161.md) / [BRC-162](./0162.md). Tags are the wallet’s filter index for those facts; CI is not a second inscription document.
 
-**Writers SHOULD:**
+**Placement:**
 
-* Put **filterable** facts in tags: `bsv21:<tokenId>`, `amt:<…>`, and when useful `dec:…`, `icon:…`, `bsv21:deploy` / `bsv21:auth`, `issuer:…`.
-* Put **derivation** in `customInstructions` when this wallet created the lock: `protocolID`, `keyID`, `counterparty` (and similar spend metadata only as needed to unlock).
-* Put **case-preserving** display symbol in `customInstructions.sym` when known (tags alone lose case).
-
-**Writers SHOULD NOT:**
-
-* Duplicate script-parseable token fields (`p`, `op`, token `id`, `amt`, `dec`, `icon`) into CI as a normative remittance blob.
-* Use a bare `bsv21` tag (no suffix) — basket membership already scopes the tip; use `bsv21:<tokenId>` for filtering by token.
-* Use tag prefix `id:` for the BSV-21 token id (see Tags / [BRC-164](../wallet/0164.md)).
-* Stuff oversized blobs into CI and expect `internalizeAction` to accept them.
+* **Tags** — filterable facts: `bsv21:<tokenId>`, `amt:<…>`, and when useful `dec:…`, `icon:…`, `bsv21:deploy` / `bsv21:auth`, `issuer:…`, plus `id:<key>` per [BRC-164](../wallet/0164.md).
+* **`customInstructions`** — derivation when this wallet created the lock (`protocolID`, `keyID`, `counterparty`, …) and **case-preserving** `sym` when known.
 
 Readers resolving a display symbol SHOULD prefer `customInstructions.sym` when present, and MAY fall back to a `sym:` tag or overlay metadata.
 
@@ -88,25 +79,21 @@ Tags are optional BRC-46 / BRC-100 output tags used for **filtering**. They are 
 |-----|-------------|---------|
 | `bsv21:<tokenId>` | SHOULD when known | Token id (`txid_vout` of deploy). Primary filter key for “which token.” |
 | `amt:<string>` | SHOULD when known | Token amount in this output (decimal string, integer units). |
-| `dec:<string>` | MAY | Deploy decimals `0`–`18` (filter / UI hint; also on-chain at deploy). |
+| `dec:<string>` | MAY | Deploy decimals `0`–`18` (filter / UI hint). |
 | `icon:<outpoint>` | MAY | Deploy icon outpoint (underscore form preferred). Pointer only — see **Icon media**. |
-| `sym:<string>` | MAY | Lowercased symbol filter only. Display case belongs in CI `sym`. |
+| `sym:<string>` | MAY | Lowercased symbol filter. Prefer CI `sym` for display case. |
 | `bsv21:deploy` | MAY | Marks a deploy output under this profile. |
 | `bsv21:auth` | MAY | Marks an authority UTXO filed in this basket (if the wallet tracks auth here). |
 | `issuer:<pubkeyHex>` | MAY when issuer is known | Compressed issuer identity pubkey (hex). Filter mirror — verify Sigma on-chain. |
-| `id:<string>` | MAY | Wallet-local per-output list key per [BRC-164](../wallet/0164.md). **Not** the BSV-21 token id. |
+| `id:<string>` | MAY | Wallet-local per-output list key per [BRC-164](../wallet/0164.md). Token id uses `bsv21:<tokenId>` above. |
 
-There is **no** bare `bsv21` marker tag. Basket name `bsv21` already scopes the row; adding a redundant tag does not improve queries.
-
-Conforming writers MUST NOT use `id:<…>` for the BSV-21 token id. Ordinary `id:<key>` tags are defined by **[BRC-164](../wallet/0164.md)**. This profile MUST NOT treat `id:` as token id, issuer, or global asset identity. Receivers MUST ignore a counterparty-supplied `id:` and stamp their own if they adopt BRC-164.
-
-Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md)).
+Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md)). Receivers that adopt BRC-164 stamp their own `id:` on import.
 
 ### Custom instructions ([BRC-37](../outpoints/0037.md))
 
 When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON object serialized as a string**.
 
-**Primary job — derivation (when this wallet can unlock the tip):**
+Conforming writers SHOULD emit derivation fields when this wallet locked the tip, and `sym` when known:
 
 ```json
 {
@@ -120,25 +107,24 @@ When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON obj
 | Field | Type | Requirement | Meaning |
 |-------|------|-------------|---------|
 | `protocolID` | array | SHOULD when wallet-derived | BRC-43 protocol used to derive the locking key. |
-| `keyID` | string | SHOULD when wallet-derived | BRC-43 key id for this output. |
+| `keyID` | string | SHOULD when wallet-derived | BRC-43 key id for this output (only when that key was used to lock). |
 | `counterparty` | string | SHOULD when wallet-derived | BRC-43 counterparty (`self`, identity key, …). |
-| `sym` | string | SHOULD when known | Display symbol (**case-preserving**). Preferred over a `sym:` tag for UI. |
-| `issuer` | string | MAY when known | Compressed issuer pubkey hex — remittance mirror only; not proof. |
+| `sym` | string | SHOULD when known | Display symbol (**case-preserving**). |
+| `issuer` | string | MAY when known | Compressed issuer pubkey hex — display mirror; not proof. |
 
-Do **not** require CI copies of script fields (`p`, `op`, token `id`, `amt`, `dec`, `icon`). Parse those from the locking script / local history when needed. Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)), subject to the reference client’s size limits.
+Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)), subject to the reference client’s size limits.
 
-When the tip is locked with a **literal** script or external address and this wallet has no derivation triple, CI MAY be omitted or hold only `sym` / other non-derivation claims. Do not invent a `keyID` that was never used to lock the output.
+When the tip is locked with a **literal** script or external address and this wallet has no derivation triple, CI MAY be omitted or hold only `sym` (and similar display claims).
 
 ### Icon media (P2P — no content indexer)
 
 BRC-161 `icon` is an **outpoint** of a prior image inscription (B-protocol / `ord` envelope), not a URL. The outpoint is known from the **deploy script** (and MAY be mirrored as tag `icon:<outpoint>` for filters).
 
-* **Writers MUST NOT** require receivers to fetch icon bytes from an HTTP content API (Gorilla, 1Sat content host, or similar) in order to display the ticker.
 * **Writers SHOULD** include the icon inscription transaction in the **BEEF** that accompanies transfer / import (`inputBEEF`, AtomicBEEF subject parents, or equivalent known-tx set) whenever they know that transaction (minting wallet, prior holder with stored BEEF).
-* **Receivers MUST** prefer decoding icon bytes from local BEEF / locking script (`ord` envelope field 0 + content-type) and MAY cache them keyed by the icon outpoint.
-* **`customInstructions` MUST NOT** embed raw image bytes or large base64 (CI stays under the 1000-byte `internalizeAction` cap). Media travels in BEEF; the stable pointer is the on-chain / tag outpoint.
-* When no icon outpoint is present, or icon bytes cannot be recovered locally, wallets MAY show a deterministic hash tile (identicon) from token id / `sym` — that is a UI fallback, not on-chain metadata.
-* Content HTTP APIs remain an optional **recovery** aid for wallets that lost local BEEF; they are not part of the normative remittance contract.
+* **Receivers SHOULD** prefer decoding icon bytes from local BEEF / locking script (`ord` envelope field 0 + content-type) and MAY cache them keyed by the icon outpoint.
+* The stable pointer is the on-chain / tag outpoint; media bytes travel in BEEF (keep CI under the 1000-byte `internalizeAction` cap).
+* When no icon outpoint is present, or icon bytes cannot be recovered locally, wallets MAY show a deterministic hash tile (identicon) from token id / `sym` — a UI fallback, not on-chain metadata.
+* Content HTTP APIs remain an optional **recovery** aid when local BEEF is missing.
 
 ### Issuer attestation
 

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -6,7 +6,9 @@ Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
 This BRC defines the **application basket profile** for [BRC-161](./0161.md) BSV-21 fungible **value** outputs under [BRC-46](../wallet/0046.md) / [BRC-100](../wallet/0100.md). It reserves the basket name `bsv21`, specifies eligibility, documents the tag vocabulary and [BRC-37](../outpoints/0037.md) `customInstructions` schema used for display and remittance, and describes normative hold / list / transfer / import flows.
 
-It does **not** redefine BSV-21 token economics (deploy, auth, mint, transfer, burn). Those live in [BRC-161](./0161.md) (JSON) and [BRC-162](./0162.md) (binary). Offline amount-conservation proofs are out of scope here.
+It does **not** redefine BSV-21 token economics (deploy, auth, mint, transfer, burn). Those live in [BRC-161](./0161.md) (JSON) and [BRC-162](./0162.md) (binary).
+
+**Trust model:** holders verify *their* tips (local history / remittance / BEEF for the outs they hold). Issuers are trusted for mint policy. Global supply-cap / world-conservation proofs are **not** required by this profile.
 
 ## Motivation
 
@@ -95,8 +97,9 @@ Additional JSON keys are permitted and MUST be ignored by readers that do not un
 #### Claims vs admission
 
 * Tags and `customInstructions` fields are **claims** for display and remittance convenience.
-* Token **admission** (valid supply / authority / conservation) is defined by [BRC-161](./0161.md) / [BRC-162](./0162.md) and the wallet’s indexer or verification policy — not by basket membership alone.
-* A wallet MUST NOT treat `amt` / `id` as proven solely because they appear in remittance.
+* Token **admission** for a tip the wallet holds is local: valid inscription / remittance fields plus any history the wallet verifies for that tip. Global supply audits and indexers are optional.
+* A wallet MUST NOT treat `amt` / `id` as proven solely because they appear in remittance from an untrusted sender.
+* Issuers (especially authority-mint tokens) are trusted for mint policy under this profile.
 
 ### Hold and list
 
@@ -162,10 +165,11 @@ Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0
 
 ## Security considerations
 
-* **Remittance spoofing** — `id` / `amt` / `sym` in CI are forgeable without an indexer or offline proof. Do not treat remittance as admission.
+* **Remittance spoofing** — `id` / `amt` / `sym` in CI are forgeable. Receivers SHOULD verify tip history for outs they accept; do not treat remittance alone as admission.
+* **Trusted issuer** — This profile does not require wallets to prove a global supply cap. Over-mint by an authority issuer is an issuer/policy risk accepted by holders of that token.
 * **Symbol collision** — `sym` is not unique; always key balances by token id.
 * **Basket pollution** — Non-value or multi-sat outs in `bsv21` confuse list UIs; re-check `satoshis` and inscription rules.
-* **Over-transfer burn** — Building outputs whose `amt` sum exceeds inputs burns value ([BRC-161](./0161.md)).
+* **Over-transfer burn** — Building outputs whose `amt` sum exceeds *spent inputs* burns value ([BRC-161](./0161.md)). Local send paths SHOULD conserve the sender's inputs.
 
 ## Implementations
 

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -53,26 +53,51 @@ This profile’s normative remittance examples use the JSON carrier ([BRC-161](.
 * The output tag for token id is `bsv21:<tokenId>` (see Tags). After the `bsv21:` prefix, tags MAY use either outpoint form; readers MUST normalize before comparison.
 * Tip outpoints in other tags MAY use either form; readers MUST normalize.
 
+### Tags vs customInstructions
+
+Both tags and `customInstructions` travel with the output under [BRC-46](../wallet/0046.md) / [BRC-37](../outpoints/0037.md). They serve different jobs. Profiles MUST NOT recommend shapes that fail in the **reference BRC-100 client** (`@bsv/sdk` wallet validation / wallet-toolbox storage):
+
+| | **Tags** | **`customInstructions`** |
+|--|----------|---------------------------|
+| Role | Query / filter keys (`listOutputs` + `tags` / `tagQueryMode`) | Remittance object: token fields, display, optional spend metadata |
+| Case | Reference validation **trims and lowercases** each tag before store/match ([BRC-100](../wallet/0100.md)) | JSON string values **preserve case** |
+| Size | Each tag ≤ **300 UTF-8 bytes** (`OutputTagStringUnder300Bytes`) | `internalizeAction` basket insertion caps the string at **1000 UTF-8 bytes**. `createAction` outputs are not capped the same way in current SDK validation, but writers SHOULD still keep CI lean so import/re-file paths succeed |
+| Authority | Non-authoritative claims / local metadata | Same for display; inscription / local history admit value |
+
+**Writers SHOULD:**
+
+* Put **filterable** facts in tags: bare `bsv21`, `bsv21:<tokenId>`, `amt:<…>`, and when useful `op:<…>`.
+* Put **case-preserving display** (`sym`) and load-bearing token fields (`id`, `amt`, `op`, `dec`, `icon`) in `customInstructions`.
+* Prefer a short CI object on `internalizeAction` (well under 1000 bytes). Do not embed large proofs, BEEF, or media in CI for this profile.
+
+**Writers SHOULD NOT:**
+
+* Rely on a `sym:` tag as the primary display symbol (lowercasing destroys intended case; use CI `sym`).
+* Use tag prefix `id:` for the BSV-21 token id (see Tags).
+* Stuff oversized blobs into CI and expect `internalizeAction` to accept them.
+
+Readers resolving a display symbol SHOULD prefer `customInstructions.sym` when present, and MAY fall back to a `sym:` tag.
+
 ### Tags
 
-Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hints. They are **non-authoritative for balances**.
+Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hints. They are **non-authoritative for balances**. Because the reference client lowercases tags, writers MUST treat tag equality as **case-insensitive** and SHOULD write tags in a lowercase-safe alphabet (hex outpoints, decimal `amt`, ASCII ops).
 
 | Tag | Requirement | Meaning |
 |-----|-------------|---------|
 | `bsv21` | SHOULD on conforming transfers and imports | Marks the output as a BSV-21 value tip under this profile (no suffix). |
 | `bsv21:<tokenId>` | SHOULD when known | Token id (`txid_vout` of deploy). Distinct from the bare `bsv21` marker. |
 | `amt:<string>` | SHOULD when known | Token amount in this output (decimal string, integer units). |
-| `sym:<string>` | MAY | Display symbol from deploy (not unique). |
-| `op:<string>` | MAY | Last known op (`transfer`, `mint`, …). |
-| `cosign:<pubkeyHex>` | SHOULD when the tip is cosigner-gated | Compressed cosigner pubkey (33-byte hex). |
+| `op:<string>` | MAY | Last known op (`transfer`, `mint`, `deploy+mint`, …). |
+| `sym:<string>` | MAY (legacy / filter only) | Lowercased symbol hint. New writers SHOULD put display symbol in `customInstructions.sym` instead. |
+| `id:<string>` | MAY | Wallet-local per-output list key (see below). **Not** the BSV-21 token id. |
 
-Conforming writers MUST NOT use `id:<…>` for the BSV-21 token id. The tag prefix `id:` is reserved for a per-output identity key (wallet / basket stack lookup of a specific output) and MUST NOT be overloaded here. Token id in inscription / `customInstructions` JSON remains the BRC-161 field name `id`.
+Conforming writers MUST NOT use `id:<…>` for the BSV-21 token id. The tag prefix `id:` is reserved for a **per-output** identity / list key across the wallet stack (so a specific output can be found without scanning every basket row). Generation is wallet-defined; it is not global asset identity. Token id in inscription / `customInstructions` JSON remains the BRC-161 field name `id`.
 
 Unknown tags MUST be preserved when transporting the output ([BRC-37](../outpoints/0037.md)).
 
 ### Custom instructions ([BRC-37](../outpoints/0037.md))
 
-When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON object serialized as a string**. Conforming writers SHOULD emit:
+When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON object serialized as a string**. Conforming writers SHOULD emit a **compact** object (plain BSV-21 value tips):
 
 ```json
 {
@@ -82,12 +107,7 @@ When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON obj
   "amt": "<uint64 decimal string>",
   "sym": "<optional>",
   "icon": "<optional txid_vout>",
-  "dec": "<optional 0-18 string>",
-  "cosign": {
-    "pubkey": "<33-byte compressed pubkey hex>",
-    "endpoint": "<optional https host or base URL>",
-    "feeAddress": "<optional>"
-  }
+  "dec": "<optional 0-18 string>"
 }
 ```
 
@@ -97,60 +117,11 @@ When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON obj
 | `op` | string | SHOULD | Value op for this output (`transfer`, `mint`, or `deploy+mint`). |
 | `id` | string | SHOULD | Token id, underscore form. |
 | `amt` | string | SHOULD | Amount in this UTXO (integer units as decimal string). |
-| `sym` | string | MAY | Display symbol (inherited from deploy; not unique). |
+| `sym` | string | SHOULD when known | Display symbol (case-preserving; not unique). Preferred over a `sym:` tag. |
 | `icon` | string | MAY | Deploy icon outpoint (`txid_vout`). |
 | `dec` | string | MAY | Deploy decimals `0`–`18` as a decimal string. |
-| `cosign` | object | MAY | Optional cosigner gate (see below). Omit for plain P2PKH value tips. |
 
-Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)).
-
-### Optional cosigner gate
-
-Some BSV-21 value tips (e.g. regulated stables such as MNEE) require a **service cosigner** in addition to the owner key. Cosigning is **optional** in this profile: plain owner-only tips remain valid. When present, cosign MUST be an explicit spend path — never a silent fallthrough to bare P2PKH `createAction`.
-
-#### On-chain template (informative)
-
-After the [BRC-160](./0160.md) inscription envelope, a common cosigned lock is:
-
-1. Owner P2PKH branch ending in `OP_CHECKSIGVERIFY` (not `OP_CHECKSIG`).
-2. Push of a 33-byte compressed **cosigner pubkey**.
-3. `OP_CHECKSIG`.
-
-Hex suffix shape (after the inscription prefix):
-
-`76a914` ‖ `<20-byte pkhash>` ‖ `88ad21` ‖ `<33-byte pubkey>` ‖ `ac`
-
-Other templates MAY exist; wallets detect cosign by script inspection and/or remittance.
-
-#### Remittance
-
-When a tip is cosigner-gated, conforming writers SHOULD:
-
-* Set `customInstructions.cosign.pubkey` to the cosigner compressed pubkey hex.
-* Set tag `cosign:<pubkeyHex>`.
-* MAY set `cosign.endpoint` (HTTPS base for the issuer’s transfer API) and `cosign.feeAddress` when known.
-
-Receivers that do not implement cosign MUST still store and forward these fields, and MUST NOT spend the tip as if it were plain P2PKH.
-
-#### Spend paths (tagged)
-
-| Path | When | Behavior |
-|------|------|----------|
-| `plain` | Tip lock is owner-only (or remittance has no cosign and script is plain) | Normal BRC-100 spend of the value tip; conserve `amt` for `id`. |
-| `cosigned` | Tip requires cosigner (script and/or remittance) **and** wallet has a cosigner client for that pubkey/endpoint | Build transfer outs with the same cosign template; owner signs with a sighash the cosigner can complete (commonly `SIGHASH_ALL\|ANYONECANPAY\|FORKID`); submit partial tx to the cosigner; broadcast only the cosigner-finalized transaction. |
-| `refuse` | Tip is cosigned but no cosigner client is available, or the lock is unknown | Fail closed. Do not attempt plain unlock. Surface a named reason (e.g. `cosigner_required`). |
-
-Wallets MUST NOT catch a cosigner / script failure and retry as `plain`.
-
-#### Cosigner API (informative)
-
-Issuers MAY expose an HTTP transfer API. A widely deployed shape (MNEE) is:
-
-* `POST /v2/transfer` with `{ "rawtx": "<base64 partial tx>", "callback_url"?: "..." }` → ticket id
-* `GET /v2/ticket?ticketID=...` → status / final hex
-* `GET /v1/config` → `approver` pubkey, fee address, token id, fee policy
-
-This profile does not mandate that API; it only requires the remittance fields and fail-closed path split when a tip is cosigned.
+Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)), subject to the reference client’s size limits above.
 
 #### Claims vs admission
 
@@ -158,6 +129,14 @@ This profile does not mandate that API; it only requires the remittance fields a
 * Token **admission** for a tip the wallet holds is local: valid inscription / remittance fields plus any history the wallet verifies for that tip. Global supply audits and indexers are optional.
 * A wallet MUST NOT treat `amt` / `id` as proven solely because they appear in remittance from an untrusted sender.
 * Issuers (especially authority-mint tokens) are trusted for mint policy under this profile.
+
+### Non-plain locks (out of scope for this profile’s send path)
+
+This profile’s normative hold / list / transfer path is **plain** owner-controlled BSV-21 value tips (inscription + P2PKH-style owner lock), matching common 1Sat / `js-1sat-ord` BSV-21 tooling.
+
+**Cosigner-gated instruments** (e.g. MNEE) use issuer-specific APIs and a different signing flow. They are **not** intermixed with plain BSV-21 in the 1Sat SDK and are **not** standardized by this basket profile. Wallets that encounter a non-plain lock on a tip filed under `bsv21` MUST **fail closed** (named refuse such as `cosigner_required` / `unknown_lock`) and MUST NOT fall through to bare P2PKH `createAction`.
+
+A separate instrument / cosigner profile MAY document those routes later. Remittance MUST NOT invent a generic “any cosigner” send path that pretends MNEE-style flows are ordinary BSV-21 transfers.
 
 ### Hold and list
 
@@ -200,11 +179,13 @@ To place an existing value tip into basket `bsv21`, use BRC-100 `internalizeActi
     "insertionRemittance": {
       "basket": "bsv21",
       "tags": ["bsv21", "bsv21:<txid_vout>", "amt:<amt>"],
-      "customInstructions": "{\"p\":\"bsv-20\",\"op\":\"transfer\",\"id\":\"<txid_vout>\",\"amt\":\"<amt>\"}"
+      "customInstructions": "{\"p\":\"bsv-20\",\"op\":\"transfer\",\"id\":\"<txid_vout>\",\"amt\":\"<amt>\",\"sym\":\"DEMO\"}"
     }
   }]
 }
 ```
+
+Import CI MUST stay within the reference client’s **1000-byte** `customInstructions` cap.
 
 ### Payment separation (wallet policy guidance)
 
@@ -228,13 +209,14 @@ Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0
 * **Symbol collision** — `sym` is not unique; always key balances by token id.
 * **Basket pollution** — Non-value or multi-sat outs in `bsv21` confuse list UIs; re-check `satoshis` and inscription rules.
 * **Over-transfer burn** — Building outputs whose `amt` sum exceeds *spent inputs* burns value ([BRC-161](./0161.md)). Local send paths SHOULD conserve the sender's inputs.
-* **Cosigner bypass** — Spending a cosigned tip with a plain P2PKH unlock fails on-chain and MUST be refused in the wallet. Do not fall through from `cosigned` to `plain`.
+* **Non-plain lock bypass** — Unlocking a cosigner-gated tip with a plain P2PKH path fails on-chain and MUST be refused in the wallet. Do not treat MNEE-class instruments as ordinary `bsv21` sends.
+* **CI / tag limits** — Oversized `customInstructions` on `internalizeAction` is rejected by the reference SDK (1000-byte cap). Case-sensitive data in tags alone is lost to lowercasing.
 
 ## Implementations
 
-* **HandCash Desktop** (reference, in progress): basket `bsv21` list / import under Collect (not Pay); optional cosign detect + remittance; cosigned send refuses until a cosigner client is configured.  
+* **HandCash Desktop** (reference, in progress): basket `bsv21` list / import under Collect (not Pay); plain BSV-21 tips; non-plain locks refuse rather than fall through.  
   Source: `src/wallet/bsv21.ts`, `src/wallet/bsv21TipKind.ts`, `src/wallet/fungibles.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).
-* **HandCash Cloud**: MNEE cosigner instrument path (`mneeCosignerService`, `mneeFactory`) — production cosigned send for the MNEE token as a Pay currency.
+* **HandCash Cloud**: MNEE remains a **separate** Pay / cosigner instrument path (`mneeCosignerService`, `mneeFactory`) — not the plain BRC-163 send surface.
 
 ## References
 

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -68,7 +68,7 @@ Both tags and `customInstructions` travel with the output under [BRC-46](../wall
 
 * Put **filterable** facts in tags: bare `bsv21`, `bsv21:<tokenId>`, `amt:<…>`, and when useful `op:<…>`.
 * Put **case-preserving display** (`sym`) and load-bearing token fields (`id`, `amt`, `op`, `dec`, `icon`) in `customInstructions`.
-* Prefer a short CI object on `internalizeAction` (well under 1000 bytes). Do not embed large proofs, BEEF, or media in CI for this profile.
+* Prefer a short CI object on `internalizeAction` (well under 1000 bytes). Do not embed large proofs, BEEF, or media **bytes** in CI for this profile — carry icon media in accompanying BEEF (see Icon media).
 
 **Writers SHOULD NOT:**
 
@@ -119,11 +119,22 @@ When present for basket `bsv21`, `customInstructions` MUST be a **UTF-8 JSON obj
 | `id` | string | SHOULD | Token id, underscore form. |
 | `amt` | string | SHOULD | Amount in this UTXO (integer units as decimal string). |
 | `sym` | string | SHOULD when known | Display symbol (case-preserving; not unique). Preferred over a `sym:` tag. |
-| `icon` | string | MAY | Deploy icon outpoint (`txid_vout`). |
+| `icon` | string | MAY | Deploy icon outpoint (`txid_vout`). Pointer only — see **Icon media**. |
 | `dec` | string | MAY | Deploy decimals `0`–`18` as a decimal string. |
 | `issuer` | string | SHOULD when known | Compressed issuer identity pubkey hex (33-byte). Remittance **mirror** of on-chain attestation — not the proof. |
 
 Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)), subject to the reference client’s size limits above.
+
+### Icon media (P2P — no content indexer)
+
+BRC-161 `icon` is an **outpoint** of a prior image inscription (B-protocol / `ord` envelope), not a URL.
+
+* **Writers MUST NOT** require receivers to fetch icon bytes from an HTTP content API (Gorilla, 1Sat content host, or similar) in order to display the ticker.
+* **Writers SHOULD** include the icon inscription transaction in the **BEEF** that accompanies transfer / import (`inputBEEF`, AtomicBEEF subject parents, or equivalent known-tx set) whenever they know that transaction (minting wallet, prior holder with stored BEEF).
+* **Receivers MUST** prefer decoding icon bytes from local BEEF / locking script (`ord` envelope field 0 + content-type) and MAY cache them keyed by the icon outpoint.
+* **`customInstructions` MUST NOT** embed raw image bytes or large base64 (CI stays under the 1000-byte `internalizeAction` cap). The outpoint in CI remains the stable pointer; media travels in BEEF.
+* When no icon outpoint is present, or icon bytes cannot be recovered locally, wallets MAY show a deterministic hash tile (identicon) from `id` / `sym` — that is a UI fallback, not on-chain metadata.
+* Content HTTP APIs remain an optional **recovery** aid for wallets that lost local BEEF; they are not part of the normative remittance contract.
 
 ### Issuer attestation
 
@@ -173,9 +184,10 @@ A conforming transfer of held `bsv21` value SHOULD use BRC-100 `createAction` wi
 2. One or more **outputs** with `satoshis: 1`, `basket: "bsv21"`, tags per this profile, and `customInstructions` as above with `op: "transfer"`, the same `id`, and the output `amt`.
 3. Output amounts MUST NOT exceed input amounts for that `id` under [BRC-161](./0161.md) conservation (excess burns). Change SHOULD return to the sender as another `bsv21` output when needed.
 4. Prefer supplying `inputBEEF` / BEEF for spent tips when available so the receiver can validate the spend graph ([BRC-62](../transactions/0062.md), [BRC-95](../transactions/0095.md)).
-5. Action `labels` MAY include `bsv21`; labels are non-normative for balances.
+5. When `customInstructions.icon` (or deploy `icon`) is set, SHOULD merge the **icon inscription transaction** into that BEEF so the receiver can decode ticker media offline (see Icon media).
+6. Action `labels` MAY include `bsv21`; labels are non-normative for balances.
 
-Senders that rebuild `customInstructions` MUST preserve `id` / `amt` / display fields they still know, and MUST NOT invent a different `id` for the same physical tip.
+Senders that rebuild `customInstructions` MUST preserve `id` / `amt` / display fields they still know (including `icon` when known), and MUST NOT invent a different `id` for the same physical tip.
 
 ### Import / receive (`internalizeAction`)
 
@@ -217,6 +229,7 @@ Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0
 
 ## Security considerations
 
+* **Indexer trust** — Display MUST NOT depend on HTTP content indexers for `icon` when BEEF was supplied. Indexers are optional recovery only (see Icon media).
 * **Remittance spoofing** — `id` / `amt` / `sym` in CI are forgeable. Receivers SHOULD verify tip history for outs they accept; do not treat remittance alone as admission.
 * **Trusted issuer** — This profile does not require wallets to prove a global supply cap. Over-mint by an authority issuer is an issuer/policy risk accepted by holders of that token.
 * **Symbol collision** — `sym` is not unique; always key balances by token id.
@@ -227,8 +240,8 @@ Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0
 
 ## Implementations
 
-* **HandCash Desktop** (reference, in progress): basket `bsv21` list / import under Collect (not Pay); plain BSV-21 tips; non-plain locks refuse rather than fall through.  
-  Source: `src/wallet/bsv21.ts`, `src/wallet/bsv21TipKind.ts`, `src/wallet/fungibles.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).
+* **HandCash Desktop** (reference, in progress): basket `bsv21` list / import under Collect (not Pay); plain BSV-21 tips; non-plain locks refuse rather than fall through; ticker icons from local BEEF / mint cache (not HTTP content APIs).  
+  Source: `src/wallet/bsv21.ts`, `src/wallet/fungibles.ts`, `src/wallet/tokenIconCache.ts` in [HandCash/HANDCASH-DESKTOP](https://github.com/HandCash/HANDCASH-DESKTOP).
 * **HandCash Cloud**: MNEE remains a **separate** Pay / cosigner instrument path (`mneeCosignerService`, `mneeFactory`) — not the plain BRC-163 send surface.
 
 ## References

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -77,8 +77,8 @@ Tags are optional BRC-46 / BRC-100 output tags used for **filtering**. They are 
 
 | Tag | Requirement | Meaning |
 |-----|-------------|---------|
-| `bsv21:<tokenId>` | SHOULD when known | Token id (`txid_vout` of deploy). Primary filter key for “which token.” |
-| `amt:<string>` | SHOULD when known | Token amount in this output (decimal string, integer units). |
+| `bsv21:<tokenId>` | SHOULD | Token id (`txid_vout` of deploy) from the tip. Primary filter key for “which token.” |
+| `amt:<string>` | SHOULD | Token amount in this output (decimal string, integer units) from the tip. |
 | `dec:<string>` | MAY | Deploy decimals `0`–`18` (filter / UI hint). |
 | `icon:<outpoint>` | MAY | Deploy icon outpoint (underscore form preferred). Pointer only — see **Icon media**. |
 | `sym:<string>` | MAY | Lowercased symbol filter. Prefer CI `sym` for display case. |


### PR DESCRIPTION
## Summary
- Adds **BRC-163**: application basket profile for BSV-21 fungible **value** under BRC-46 / BRC-100 (`bsv21`).
- Mirrors [BRC-147](./tokens/0147.md) for collectables: tags, `customInstructions`, list / send / `internalizeAction`, payment separation.
- Depends on [#213](https://github.com/bsv-blockchain/BRCs/pull/213) (BRC-161 / BRC-162). This PR does **not** redefine token economics — only wallet basket / remittance interop.
- Index rows in `README.md` / `SUMMARY.md` (placed after 160 until 161/162 land on master).

## Motivation
#213 correctly leaves baskets out of scope. Without a shared basket name and remittance contract, wallets cannot hold / list / transfer / import the same tips interoperably. HandCash is already using `bsv21` under Collect → Tokens (not Pay / not `1sat`).

## Test plan
- [ ] Review against #213 field names (`id` underscore, `amt` string, `p`/`op`)
- [ ] Confirm basket id `bsv21` and eligibility (`satoshis === 1`, value ops only)
- [ ] Confirm payment-separation guidance matches wallet policy intent
- [ ] Merge after or with #213 so `./0161.md` / `./0162.md` links resolve


Made with [Cursor](https://cursor.com)