### PR TITLE
Fix legacy repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The standards in this repository are vendor-neutral. Current BSV Association ref
 - `@bsv/sdk` for TypeScript SDK primitives, transactions, identities, overlays, storage, and the BRC-100 `WalletClient` interface.
 - `@bsv/wallet-toolbox` for BRC-100 wallet storage, services, signing, monitoring, and wallet implementation tooling.
 - BSV Desktop and BSV Browser as BSV Association reference wallet/browser applications for the BRC-100 interface.
-- Overlay service implementations in `bsv-blockchain/overlay-services`, `bsv-blockchain/overlay-express`, and related overlay example repositories.
+- Overlay service implementations in [`bsv-blockchain/ts-stack`](https://github.com/bsv-blockchain/ts-stack/tree/main/packages/overlays), including the `overlay` and `overlay-express` packages, and related overlay example repositories.
 
 Vendor distributions can implement the same standards with their own branding and hosted service defaults. Examples include Babbage's Metanet Desktop / Metanet Explorer as well as the Hudos Browser built by Matt Archbold.
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Contribute
 
-* [Discuss on Github](https://github.com/bitcoin-sv/BRCs/discussions/new/choose)
+* [Discuss on Github](https://github.com/bsv-blockchain/BRCs/discussions/new/choose)
 
 ## Example
 

--- a/apps/0224.md
+++ b/apps/0224.md
@@ -89,7 +89,7 @@ BMF exists to make that structure expressible and playable:
 
 ## References
 
-- <a name="footnote-1">1</a>: Merkle Proof Token (MPT) protocol — BRC-113, https://github.com/bitcoin-sv/BRCs
+- <a name="footnote-1">1</a>: Merkle Proof Token (MPT) protocol — BRC-113, https://github.com/bsv-blockchain/BRCs
 - <a name="footnote-2">2</a>: Block Media Format reference implementation and examples, https://github.com/sun-dive/block-media-format
 
 > The References section should contain any footnotes used throughout the document.

--- a/apps/0227.md
+++ b/apps/0227.md
@@ -92,4 +92,4 @@ A claim link MUST carry the voucher **WIF** and enough context to identify the a
 ## References
 
 - <a name="footnote-1">1</a>: Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX) — BRC-146 (the covenant-token asset a voucher claims; its permissionless replicate branch is the acquisition transaction funded by the voucher).
-- <a name="footnote-2">2</a>: Pay to Public Key Hash — BRC-16, https://github.com/bitcoin-sv/BRCs (the voucher output and funding-input template).
+- <a name="footnote-2">2</a>: Pay to Public Key Hash — BRC-16, https://github.com/bsv-blockchain/BRCs (the voucher output and funding-input template).

--- a/gitbooks.yaml
+++ b/gitbooks.yaml
@@ -18,12 +18,12 @@ plugins:
 languages:
   - en
 github:
-  repository: https://github.com/bitcoin-sv/BRCs
+  repository: https://github.com/bsv-blockchain/BRCs
 theme:
   navigationDepth: 2
   style: website
 links:
   sharing:
-    github: https://github.com/bitcoin-sv/BRCs
+    github: https://github.com/bsv-blockchain/BRCs
     twitter: https://twitter.com/BitcoinAssn
     linkedin: https://www.linkedin.com/company/bitcoinassociation

--- a/key-derivation/0042.md
+++ b/key-derivation/0042.md
@@ -64,7 +64,7 @@ This specification provides a method for key derivation that enables two parties
 
 ## Implementations
 
-This specification has been implemented into both the BSV [TypeScript](https://github.com/bitcoin-sv/ts-sdk) and [Go](https://github.com/bitcoin-sv/go-sdk) libraries.
+This specification has been implemented in both the BSV [TypeScript SDK](https://github.com/bsv-blockchain/ts-stack/tree/main/packages/sdk) and [Go SDK](https://github.com/bsv-blockchain/go-sdk).
 
 ## Test Vectors
 

--- a/key-derivation/0043.md
+++ b/key-derivation/0043.md
@@ -89,4 +89,4 @@ To illustrate how the system is intended to function, we provide several example
 
 ## Implementation
 
-The system is implemented into the [Babbage SDK](https://github.com/p2ppsr/babbage-sdk), which employs protocol IDs, key IDs and security levels when facilitating the functionality of the encryption and digital signature creation components.
+The system is implemented by [`WalletClient`](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/wallet/WalletClient.ts) in the maintained `@bsv/sdk` package, which uses protocol IDs, key IDs, and security levels for encryption, signature, and key-derivation operations.

--- a/key-derivation/0094.md
+++ b/key-derivation/0094.md
@@ -101,7 +101,7 @@ The verifier can then use this proof to confirm the validity of the shared secre
 
 ## Implementation
 
-See [`Schnorr.ts`](https://github.com/bitcoin-sv/ts-sdk/blob/fb5de11bf837f84f2ffc708979d2f78484f3df10/src/primitives/Schnorr.ts).
+See [`Schnorr.ts`](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/primitives/Schnorr.ts) in the maintained `@bsv/sdk` package.
 
 ### Integration with BRC-69 and BRC-72
 

--- a/key-derivation/0140.md
+++ b/key-derivation/0140.md
@@ -160,4 +160,4 @@ Relevant methods:
 - <a name="footnote-1">1</a>: Shamir, A. (1979). "How to share a secret." *Communications of the ACM*, 22(11), 612–613.
 - <a name="footnote-2">2</a>: [BRC-42: BSV Key Derivation Scheme (BKDS)](./0042.md)
 - <a name="footnote-3">3</a>: [SEC 2: Recommended Elliptic Curve Domain Parameters (secp256k1)](https://www.secg.org/sec2-v2.pdf)
-- <a name="footnote-4">4</a>: BSV Blockchain TypeScript SDK — `PrivateKey` primitive: https://github.com/bsv-blockchain/ts-sdk
+- <a name="footnote-4">4</a>: BSV Blockchain TypeScript SDK — `PrivateKey` primitive: https://github.com/bsv-blockchain/ts-stack/tree/main/packages/sdk

--- a/outpoints/0038.md
+++ b/outpoints/0038.md
@@ -611,4 +611,4 @@ The storage-global `monitor_events` table is intentionally excluded because it i
 - [BRC-40: User Wallet Data Synchronization](./0040.md)
 - [BRC-100: Unified, Vendor-Neutral, Unchanging, and Open BSV Blockchain Standard Wallet-to-Application Interface](../wallet/0100.md)
 - [RFC 8785: JSON Canonicalization Scheme (JCS)](https://www.rfc-editor.org/rfc/rfc8785)
-- [Wallet Toolbox Repository](https://github.com/bsv-blockchain/wallet-toolbox)
+- [Wallet Toolbox package in `ts-stack`](https://github.com/bsv-blockchain/ts-stack/tree/main/packages/wallet/wallet-toolbox)

--- a/overlays/0026.md
+++ b/overlays/0026.md
@@ -21,7 +21,7 @@ Specification
 
 ### Status Note
 
-The content-addressing idea remains current, and `bsv-blockchain/ts-sdk` includes `StorageUtils`, `StorageDownloader`, and `StorageUploader` helpers for UHRP-style storage. Some details below are historical:
+The content-addressing idea remains current, and the [`@bsv/sdk` package in `bsv-blockchain/ts-stack`](https://github.com/bsv-blockchain/ts-stack/tree/main/packages/sdk) includes `StorageUtils`, `StorageDownloader`, and `StorageUploader` helpers for UHRP-style storage. Some details below are historical:
 
 - Current SDK UHRP URLs encode the SHA-256 file hash with Base58Check prefix `ce00`; callers may use the bare string or a `uhrp:` / `uhrp://` prefix.
 - Current SDK download resolution queries BRC-24 service `ls_uhrp` with `{ "uhrpUrl": "..." }` and expects an `output-list` response.
@@ -46,6 +46,6 @@ Upon creation and submission of an advertisement to a [BRC-22](./0022.md) overla
 Implementation
 --------------
 
-Tools such as [NanoSeek](https://github.com/p2ppsr/nanoseek) (for downloading) and [NanoStore-Publisher](https://github.com/p2ppsr/nanostore-publisher) (for uploading to a NanoStore provider) have been created by the Babbage team. To implement the serialization format, the [`uhrp-url` tool](https://github.com/p2ppsr/uhrp-url) can be used.
+The deprecated NanoSeek, NanoStore-Publisher, and `uhrp-url` tools have been superseded by [`StorageDownloader`](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/storage/StorageDownloader.ts), [`StorageUploader`](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/storage/StorageUploader.ts), and [`StorageUtils`](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/storage/StorageUtils.ts), respectively, in the maintained `@bsv/sdk` package.
 
 Questions about this initial draft specification should be directed to the author.

--- a/overlays/0035.md
+++ b/overlays/0035.md
@@ -493,4 +493,4 @@ Implementations **SHOULD** be tested against at least the following scenarios:
 - [BRC-99: P Baskets: Allowing Future Wallet Basket and Digital Asset Permission Schemes](../wallet/0099.md)
 - [BRC-100: Unified, Vendor-Neutral, Unchanging, and Open BSV Blockchain Standard Wallet-to-Application Interface](../wallet/0100.md)
 - [BRC-116: Wallet Permissions and Counterparty Trust](../wallet/0116.md)
-- [`bsv-blockchain/ts-sdk`](https://github.com/bsv-blockchain/ts-sdk)
+- [`@bsv/sdk` in `bsv-blockchain/ts-stack`](https://github.com/bsv-blockchain/ts-stack/tree/main/packages/sdk)

--- a/payments/0041.md
+++ b/payments/0041.md
@@ -46,4 +46,4 @@ To implement PacketPay, API providers and consumers must follow these steps:
 
 By following the above implementation steps, API providers and consumers can ensure secure and efficient micropayments using the PacketPay system. This will enable a new revenue model for APIs, allowing for greater flexibility and scalability in the ever-growing world of web services.
 
-The PacketPay [client](https://github.com/p2ppsr/packetpay-js) and [express middleware](https://github.com/p2ppsr/packetpay-express) have been implemented in JavaScript by the Babbage Team.
+The deprecated PacketPay packages have been superseded by [`AuthFetch`](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/auth/clients/AuthFetch.ts) for authenticated client requests and the maintained [`payment-express-middleware`](https://github.com/bsv-blockchain/ts-stack/tree/main/packages/middleware/payment-express-middleware) package for Express servers. New integrations should use the current BRC-105, BRC-118, or BRC-121 profile described in the status note above.

--- a/payments/0105.md
+++ b/payments/0105.md
@@ -238,8 +238,8 @@ If payment is successful, the server responds with a normal (e.g., `200 OK`) plu
 
 ## 10. References
 
-- [BRC-103](https://github.com/bitcoin-sv/BRCs/blob/master/peer-to-peer/0103.md): *Peer-to-Peer Mutual Authentication and Certificate Exchange Protocol*  
-- [BRC-104](https://github.com/bitcoin-sv/BRCs/blob/master/peer-to-peer/0104.md): *HTTP Transport for BRC-103*  
+- [BRC-103](https://github.com/bsv-blockchain/BRCs/blob/master/peer-to-peer/0103.md): *Peer-to-Peer Mutual Authentication and Certificate Exchange Protocol*
+- [BRC-104](https://github.com/bsv-blockchain/BRCs/blob/master/peer-to-peer/0104.md): *HTTP Transport for BRC-103*
 - [BRC-29](./0029.md): *Derivation-based Payment Protocol*  
 - [RFC 9110 Section 15.5.3: 402 Payment Required](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.3)
 - [402 Payment Required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402)

--- a/payments/0121.md
+++ b/payments/0121.md
@@ -112,7 +112,7 @@ A client MAY cache the set of URLs for which payment has been accepted and skip 
 
 ## Implementations
 
-1. **`@bsv/402-pay` (npm package)** -- A production npm package providing both server middleware and client fetch wrapper. Install with `npm install @bsv/402-pay`. Source: [github.com/bsv-blockchain/402-pay](https://github.com/bsv-blockchain/402-pay).
+1. **`@bsv/402-pay` (npm package)** -- A production npm package providing both server middleware and client fetch wrapper. Install with `npm install @bsv/402-pay`. Source: [`packages/middleware/402-pay` in `bsv-blockchain/ts-stack`](https://github.com/bsv-blockchain/ts-stack/tree/main/packages/middleware/402-pay).
 
    ```ts
    // Server (Express)

--- a/peer-to-peer/0031.md
+++ b/peer-to-peer/0031.md
@@ -14,7 +14,7 @@ Identity on the internet relies heavily on trusted third parties to authenticate
 
 ### Status Note
 
-BRC-31 is the Authrite-era predecessor to the current mutual-authentication specifications. Current `bsv-blockchain/ts-sdk` peer authentication behavior is specified by [BRC-103](./0103.md), with HTTP transport specified by [BRC-104](./0104.md). BRC-103 preserves the same broad message family (`initialRequest`, `initialResponse`, `certificateRequest`, `certificateResponse`, and `general`) but binds certificate semantics to current [BRC-52](./0052.md) certificate formats and BRC-100 wallet methods.
+BRC-31 is the Authrite-era predecessor to the current mutual-authentication specifications. Current [`@bsv/sdk` peer authentication behavior](https://github.com/bsv-blockchain/ts-stack/tree/main/packages/sdk/src/auth) is specified by [BRC-103](./0103.md), with HTTP transport specified by [BRC-104](./0104.md). BRC-103 preserves the same broad message family (`initialRequest`, `initialResponse`, `certificateRequest`, `certificateResponse`, and `general`) but binds certificate semantics to current [BRC-52](./0052.md) certificate formats and BRC-100 wallet methods.
 
 New integrations should reference BRC-103/BRC-104. The Authrite package references and BRC-53/BRC-56 dependencies below are retained only for historical context.
 
@@ -405,7 +405,7 @@ For Bob to trigger the process, he must return an error and ask Alice to send a 
 
 ## Implementations
 
-The Authrite protocol has been implemented in JavaScript through the following two NPM packages:
+The deprecated Authrite packages have been superseded by these maintained `ts-stack` implementations:
 
-- **[Authrite-JS](https://github.com/p2ppsr/authrite-js)** implements the client-side functionality
-- **[Authrite-Express](https://github.com/p2ppsr/authrite-express)** implements the server-side functionality, for use on Express servers
+- [`AuthFetch`](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/auth/clients/AuthFetch.ts) implements the client-side functionality in `@bsv/sdk`.
+- [`auth-express-middleware`](https://github.com/bsv-blockchain/ts-stack/tree/main/packages/middleware/auth-express-middleware) implements the server-side functionality for Express servers.

--- a/peer-to-peer/0085.md
+++ b/peer-to-peer/0085.md
@@ -28,7 +28,7 @@ Roughly speaking you create a shared secret between you and the counterparty usi
 
 ## Implementations
 
-[SPV Wallet](https://github.com/bitcoin-sv/spv-wallet)
+[SPV Wallet](https://github.com/bsv-blockchain/spv-wallet)
 
 ## Flow
 

--- a/peer-to-peer/0138.md
+++ b/peer-to-peer/0138.md
@@ -133,9 +133,9 @@ A reference implementation in TypeScript, [`@bsv/auth`](https://www.npmjs.com/pa
 ## References
 
 1. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels — https://www.rfc-editor.org/rfc/rfc2119
-2. BRC-42: BSV Key Derivation Scheme (BKDS) — https://github.com/bitcoin-sv/BRCs/blob/master/key-derivation/0042.md
-3. BRC-43: Security Levels, Protocol IDs, Key IDs and Counterparties — https://github.com/bitcoin-sv/BRCs/blob/master/key-derivation/0043.md
-4. BRC-100: Wallet-to-Application Interface — https://github.com/bitcoin-sv/BRCs/blob/master/wallet/0100.md
-5. BRC-103: Peer-to-Peer Mutual Authentication and Certificate Exchange Protocol — https://github.com/bitcoin-sv/BRCs/blob/master/peer-to-peer/0103.md
-6. BRC-31: Authrite Mutual Authentication — https://github.com/bitcoin-sv/BRCs/blob/master/peer-to-peer/0031.md
+2. BRC-42: BSV Key Derivation Scheme (BKDS) — https://github.com/bsv-blockchain/BRCs/blob/master/key-derivation/0042.md
+3. BRC-43: Security Levels, Protocol IDs, Key IDs and Counterparties — https://github.com/bsv-blockchain/BRCs/blob/master/key-derivation/0043.md
+4. BRC-100: Wallet-to-Application Interface — https://github.com/bsv-blockchain/BRCs/blob/master/wallet/0100.md
+5. BRC-103: Peer-to-Peer Mutual Authentication and Certificate Exchange Protocol — https://github.com/bsv-blockchain/BRCs/blob/master/peer-to-peer/0103.md
+6. BRC-31: Authrite Mutual Authentication — https://github.com/bsv-blockchain/BRCs/blob/master/peer-to-peer/0031.md
 7. `@bsv/sdk`: TypeScript SDK — the `createNonce` / `verifyNonce` primitives and the BRC-103 `Peer` reference implementation — https://www.npmjs.com/package/@bsv/sdk

--- a/scripts/0048.md
+++ b/scripts/0048.md
@@ -24,7 +24,7 @@ The following is an example output script for a token as defined by this standar
 
 ## Implementations
 
-This script template has been implemented within the [PushDrop JavaScript library](https://github.com/p2ppsr/pushdrop).
+This script template is implemented by the [`PushDrop` template](https://github.com/bsv-blockchain/ts-stack/blob/main/packages/sdk/src/script/templates/PushDrop.ts) in the maintained `@bsv/sdk` package.
 
 ## How it Works
 

--- a/tokens/0117.md
+++ b/tokens/0117.md
@@ -10,7 +10,7 @@ This BRC defines a mechanism for minting BSV-21 tokens via Proof-of-Work where t
 
 ### The Overlay Network Bootstrap Problem
 
-BSV overlay networks ([BRC-22](https://github.com/bitcoin-sv/BRCs)) require nodes to index and serve specialized transaction data. Currently, overlay operation depends on centralized service providers (GorillaPool, WhatsOnChain) or volunteer node operators with no economic incentive. This creates single points of failure and limits decentralization.
+BSV overlay networks ([BRC-22](https://github.com/bsv-blockchain/BRCs)) require nodes to index and serve specialized transaction data. Currently, overlay operation depends on centralized service providers (GorillaPool, WhatsOnChain) or volunteer node operators with no economic incentive. This creates single points of failure and limits decentralization.
 
 The fundamental question for any overlay network is: **who runs the nodes, and why?**
 
@@ -511,7 +511,7 @@ This specification contains six open questions requiring community input before 
 | 6 | Difficulty adjustment mechanism | 5.3 | **Open** | A: Fixed, B: Stateful on-chain, C: Off-chain + migration |
 | 7 | Contract script size feasibility | 9.5 | **Resolved** | 23.91 KB compiled — within BSV limits, ~$0.01/mint |
 
-Feedback may be submitted as issues on the [BRC repository](https://github.com/bitcoin-sv/BRCs) or discussed in the BSV developer community channels.
+Feedback may be submitted as issues on the [BRC repository](https://github.com/bsv-blockchain/BRCs) or discussed in the BSV developer community channels.
 
 ## Implementations
 
@@ -523,15 +523,15 @@ Feedback may be submitted as issues on the [BRC repository](https://github.com/b
 
 1. <a id="footnote-1"></a> BSV-21 Token Standard. [docs.1satordinals.com/fungible-tokens/bsv-21](https://docs.1satordinals.com/fungible-tokens/bsv-21)
 2. <a id="footnote-2"></a> POW-20 Protocol. [protocol.pow20.io](https://protocol.pow20.io/)
-3. <a id="footnote-3"></a> BRC-104: HTTP Transport for Mutual Authentication. [github.com/bitcoin-sv/BRCs](https://github.com/bitcoin-sv/BRCs)
-4. <a id="footnote-4"></a> BRC-105: HTTP Service Monetization Framework. [github.com/bitcoin-sv/BRCs](https://github.com/bitcoin-sv/BRCs)
-5. <a id="footnote-5"></a> BRC-22: Overlay Network Topics. [github.com/bitcoin-sv/BRCs](https://github.com/bitcoin-sv/BRCs)
+3. <a id="footnote-3"></a> BRC-104: HTTP Transport for Mutual Authentication. [github.com/bsv-blockchain/BRCs](https://github.com/bsv-blockchain/BRCs)
+4. <a id="footnote-4"></a> BRC-105: HTTP Service Monetization Framework. [github.com/bsv-blockchain/BRCs](https://github.com/bsv-blockchain/BRCs)
+5. <a id="footnote-5"></a> BRC-22: Overlay Network Topics. [github.com/bsv-blockchain/BRCs](https://github.com/bsv-blockchain/BRCs)
 6. <a id="footnote-6"></a> sCrypt BSV20V2 Base Class. [github.com/sCrypt-Inc/scrypt-ord](https://github.com/sCrypt-Inc/scrypt-ord)
 7. <a id="footnote-7"></a> Lock-to-Mint Pattern (msinkec). [gist.github.com/msinkec/6389a7943ed054fa5c74ba8f79bf730e](https://gist.github.com/msinkec/6389a7943ed054fa5c74ba8f79bf730e)
 8. <a id="footnote-8"></a> POW20 Miner (Rust). [github.com/yours-org/pow20-miner](https://github.com/yours-org/pow20-miner)
 9. <a id="footnote-9"></a> BSV-21 Overlay. [github.com/b-open-io/bsv21-overlay](https://github.com/b-open-io/bsv21-overlay)
-10. <a id="footnote-10"></a> BRC-62: Background Evaluation Extended Format (BEEF). [github.com/bitcoin-sv/BRCs](https://github.com/bitcoin-sv/BRCs)
-11. <a id="footnote-11"></a> BRC-100: Wallet-to-Application Interaction Substrate. [github.com/bitcoin-sv/BRCs](https://github.com/bitcoin-sv/BRCs)
-12. <a id="footnote-12"></a> BRC-103: Peer-to-Peer Mutual Authentication. [github.com/bitcoin-sv/BRCs](https://github.com/bitcoin-sv/BRCs)
-13. <a id="footnote-13"></a> BRC-24: Overlay Lookup Services. [github.com/bitcoin-sv/BRCs](https://github.com/bitcoin-sv/BRCs)
+10. <a id="footnote-10"></a> BRC-62: Background Evaluation Extended Format (BEEF). [github.com/bsv-blockchain/BRCs](https://github.com/bsv-blockchain/BRCs)
+11. <a id="footnote-11"></a> BRC-100: Wallet-to-Application Interaction Substrate. [github.com/bsv-blockchain/BRCs](https://github.com/bsv-blockchain/BRCs)
+12. <a id="footnote-12"></a> BRC-103: Peer-to-Peer Mutual Authentication. [github.com/bsv-blockchain/BRCs](https://github.com/bsv-blockchain/BRCs)
+13. <a id="footnote-13"></a> BRC-24: Overlay Lookup Services. [github.com/bsv-blockchain/BRCs](https://github.com/bsv-blockchain/BRCs)
 14. <a id="footnote-14"></a> x402: Stateless Settlement-Gated HTTP Protocol. Rui Da Silva / Merkle Works, 2026. [github.com/ruidasilva/merkleworks-x402-spec](https://github.com/ruidasilva/merkleworks-x402-spec)

--- a/tokens/0226.md
+++ b/tokens/0226.md
@@ -110,9 +110,9 @@ A wallet claiming support for this class:
 
 ## References
 
-- <a name="footnote-1">1</a>: Merkle Proof Token (MPT) protocol — BRC-113, https://github.com/bitcoin-sv/BRCs (identity binds to genesis; self-verification without a lineage walk).
-- <a name="footnote-2">2</a>: BSV Unified Merkle Path (BUMP) — BRC-74, https://github.com/bitcoin-sv/BRCs (single-proof SPV to a block header).
-- <a name="footnote-3">3</a>: BEEF — BRC-62, https://github.com/bitcoin-sv/BRCs (ancestor-carrying format; explicitly NOT required by this class).
+- <a name="footnote-1">1</a>: Merkle Proof Token (MPT) protocol — BRC-113, https://github.com/bsv-blockchain/BRCs (identity binds to genesis; self-verification without a lineage walk).
+- <a name="footnote-2">2</a>: BSV Unified Merkle Path (BUMP) — BRC-74, https://github.com/bsv-blockchain/BRCs (single-proof SPV to a block header).
+- <a name="footnote-3">3</a>: BEEF — BRC-62, https://github.com/bsv-blockchain/BRCs (ancestor-carrying format; explicitly NOT required by this class).
 - <a name="footnote-4">4</a>: Block Media Format (BMF) — BRC-145 (composable on-chain audio/video; the multi-payee profile enforces payment to the creators of the components a BMF composition reuses).
-- <a name="footnote-5">5</a>: Push TX — BRC-21, https://github.com/bitcoin-sv/BRCs (transaction introspection by pushing and verifying the sighash preimage).
-- <a name="footnote-6">6</a>: Pay to Push Drop — BRC-48, https://github.com/bitcoin-sv/BRCs (data fields pushed then dropped ahead of a spendable locking script).
+- <a name="footnote-5">5</a>: Push TX — BRC-21, https://github.com/bsv-blockchain/BRCs (transaction introspection by pushing and verifying the sighash preimage).
+- <a name="footnote-6">6</a>: Pay to Push Drop — BRC-48, https://github.com/bsv-blockchain/BRCs (data fields pushed then dropped ahead of a spendable locking script).

--- a/transactions/0067.md
+++ b/transactions/0067.md
@@ -41,10 +41,9 @@ If all inputs come from Transactions which are mined in a block, then the associ
 
 In a long chain of transactions conducted while not connected to the internet, each new transaction is appended to the end of the SPV data such that all prior transaction ancestry is propagated to all counterparties, until they are broadcasted. So we would expect large SPV data payloads only when many transactions happen offline, which in today's age will be extremely rare.
 
-![all inputs lead to a block](https://github.com/bitcoin-sv/BRCs/assets/8416253/0977b132-7a7b-4f22-8ee1-5819ce42590f)
+![all inputs lead to a block](https://github.com/bsv-blockchain/BRCs/assets/8416253/0977b132-7a7b-4f22-8ee1-5819ce42590f)
 
 
 ### Locktime and Sequence
 
 The nLocktime default is 00000000, and nSequence default is FFFFFFFF. If these values are not default then there is a naunced condition to the transaction which is explained [here](https://wiki.bitcoinsv.io/index.php/NLocktime_and_nSequence).
-

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -389,6 +389,6 @@ function combinePaths(one, two) {
 
 ## Implementations
 
-TypeScript - [ts-sdk](https://github.com/bsv-blockchain/ts-sdk)  
+TypeScript - [`@bsv/sdk` in ts-stack](https://github.com/bsv-blockchain/ts-stack/tree/main/packages/sdk)
 Golang - [go-sdk](https://github.com/bsv-blockchain/go-sdk)  
 Python - [py-sdk](https://github.com/bsv-blockchain/py-sdk)  


### PR DESCRIPTION
## What changed

- Replace deprecated NanoSeek, NanoStore Publisher, UHRP URL, Authrite, PacketPay, PushDrop, and Babbage SDK links with their maintained `bsv-blockchain/ts-stack` package or source locations.
- Update SDK, Wallet Toolbox, 402 Pay, overlay, BRC repository, Go SDK, and SPV Wallet links to their canonical modern locations.
- Point GitBook repository metadata and BRC self-references at `bsv-blockchain/BRCs`.

## Why

Several historical BRC implementation links lead readers through deprecated repositories whose replacement links target the removed `bitcoin-sv/ts-sdk` location. The TypeScript implementation has since moved into the `bsv-blockchain/ts-stack` monorepo.

## Impact

Readers now land directly on maintained implementations instead of deprecated redirect repositories or transferred GitHub locations.

## Validation

- `git diff --check`
- Audited all 66 GitHub URLs in the BRC corpus; every URL returned HTTP 200 after the update.
- Confirmed no remaining BRC links target the replaced deprecated repositories or the moved `bitcoin-sv/BRCs`, `bitcoin-sv/ts-sdk`, `bitcoin-sv/go-sdk`, or `bitcoin-sv/spv-wallet` locations.
