### PR TITLE
BRC-164: Output identity tags (id:) for BRC-100 wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ BRC | Standard
 158  | [Outpoint BEEF](./transactions/0158.md)
 159  | [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 160  | [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
+164  | [Output Identity Tags for BRC-100 Wallets](./wallet/0164.md)
 168  | [Verifiable Time Allocation](./apps/0168.md)
 169  | [Universal Handle Addressing and Resolution for the Metanet](./peer-to-peer/0169.md)
 210  | [Derived Collectibles](./apps/0210.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -48,6 +48,7 @@
 * [Wallet Permissions and Counterparty Trust](./wallet/0116.md)
 * [Basket Permission Scheme Registry and Governance](./wallet/0123.md)
 * [Action Reference Labels for BRC-100 Wallets](./wallet/0153.md)
+* [Output Identity Tags for BRC-100 Wallets](./wallet/0164.md)
 * [Pluggable Backup Services for BRC-140 Share Vaults](./wallet/0154.md)
 * [Pull-Based Receive Discovery](./wallet/0155.md)
 * [Wallet Permission Prompt Liveness Contract](./wallet/0219.md)

--- a/wallet/0164.md
+++ b/wallet/0164.md
@@ -32,29 +32,27 @@ Tags beginning with `brc164:` are reserved for this output list-key role.
 
 ### Meaning
 
-- `brc164:<key>` identifies a **wallet output row** for list and spend targeting.
-- It is **not** a global asset id, token id, origin, outpoint, or proof of ownership.
-- Uniqueness: when the wallet authors the tag, `<key>` SHOULD be unique among that wallet’s held outputs (or among outputs in the same basket — wallet-defined, but must be documented by the implementation if narrower than wallet-wide).
-- Stability: for a given held row, the wallet-authored `brc164:` value SHOULD remain stable for the life of that row (including unproven / unmined outputs if they are listable).
+- `brc164:<key>` identifies a **wallet output row** for list and spend targeting inside the holding wallet.
+- It is **not** a global asset id, token id, origin, outpoint, remittance field, or proof of ownership.
+- `<key>` is wallet-defined encoding of the wallet’s internal id (encoding is opaque to apps; only that wallet must round-trip it).
+- Uniqueness: `<key>` SHOULD be unique among that wallet’s held outputs (or a documented narrower scope such as per basket).
+- Stability: for a given held row, `brc164:` SHOULD remain stable for the life of that row (including unproven / unmined outputs if they are listable).
 
 ### Wallet behavior
 
+`brc164:` is the **holding wallet’s** internal output identifier, exposed as a tag for `listOutputs` queries. It is not remittance and not copied from counterparties.
+
 Conforming wallets SHOULD:
 
-1. Ensure each listable basket output can be found via a `brc164:` tag — either by persisting one at create/import time, or by exposing an internal storage id in this form on `listOutputs` when `includeTags` is true.
-2. Accept `listOutputs` queries that include a full `brc164:<key>` tag (with ordinary `tags` / `tagQueryMode` behavior) so callers can select that row.
-3. Preserve unknown `brc164:` tags when transporting outputs under [BRC-37](../outpoints/0037.md) when the wallet does not overwrite them with its own key.
-
-Wallets MAY overwrite or replace application-stamped `brc164:` values with their own canonical key when assuming custody of a row.
+1. Author `brc164:<key>` from their own storage (e.g. numeric output primary key as decimal digits) for each listable basket output — at insert and/or when returning tags on `listOutputs` with `includeTags` true.
+2. Accept `listOutputs` queries that include a full `brc164:<key>` tag (ordinary `tags` / `tagQueryMode`) so callers can select that row.
+3. **Ignore** any `brc164:` value supplied externally (createAction/import remittance, another wallet’s tags, app-forged tags). Do not persist a foreign `brc164:` as the row key; replace with the wallet’s own key when custody is taken.
 
 ### Application behavior
 
-Applications MAY:
+Applications MAY read `brc164:<key>` from `listOutputs` results and use it in later tag filters or app state.
 
-- Read `brc164:<key>` from `listOutputs` results and use it in later `listOutputs` tag filters or app state.
-- Stamp their own `brc164:<key>` on outputs they create, if the wallet does not yet assign one.
-
-Applications SHOULD NOT treat `brc164:` as token id, origin, or any on-chain identifier. Basket profiles that need those notions use their own tag vocabulary (e.g. `bsv21:<tokenId>`, `origin:…`).
+Applications SHOULD NOT rely on stamping `brc164:` themselves — the wallet ignores external `brc164:` tags. Applications SHOULD NOT treat `brc164:` as token id, origin, or any on-chain identifier. Basket profiles that need those notions use their own tag vocabulary (e.g. `bsv21:<tokenId>`, `origin:…`).
 
 ### Relationship to bare `id:` tags
 
@@ -69,7 +67,7 @@ This BRC does **not** reserve or redefine `id:`. Profiles and apps that historic
 ## Security considerations
 
 - **Not authentication** — Knowing `brc164:<key>` only helps address a row inside a wallet that already authorized `listOutputs` / spend for that basket.
-- **Forgery** — Tags are claims unless the wallet authors or replaces them. Do not treat a counterparty-supplied `brc164:` as a capability.
+- **Forgery** — External `brc164:` tags are ignored. Only the holding wallet’s key is authoritative inside that wallet.
 - **Case folding** — Assume tags are lowercased in storage; do not put case-sensitive secrets in `<key>`.
 
 ## Implementations

--- a/wallet/0164.md
+++ b/wallet/0164.md
@@ -1,0 +1,85 @@
+# BRC-164: Output Identity Tags for BRC-100 Wallets
+
+David Case (david.case@shruggr.cloud)
+
+## Abstract
+
+This specification defines a backwards-compatible convention for [BRC-100](./0100.md) wallets: a reserved output **tag** prefix `brc164:` that carries a **wallet-local** list key for a held output. Applications use it with `listOutputs` to select a specific row. It does not change the BRC-100 request or response shape.
+
+## Motivation
+
+Basket profiles and applications often need a stable handle for one wallet output — reload after restart, target a spend, correlate UI to storage — without scanning every row.
+
+Ad-hoc tag names collide. In particular, the bare prefix `id:` is overloaded (token id, app id, origin-like claims). A single reserved prefix, owned by this BRC, gives wallets and apps one interoperable list key without claiming general-purpose `id:`.
+
+Wallets already assign internal identifiers to stored outputs. Surfacing that value (or an equivalent stable key) as a normal, **queryable** tag makes `listOutputs` the lookup API.
+
+## Specification
+
+### Reserved tag form
+
+This specification reserves tags of the form:
+
+```
+brc164:<key>
+```
+
+- The prefix is exactly `brc164:` (lowercase, ASCII).
+- `<key>` is a non-empty string chosen by the wallet (or stamped by an application). It MUST NOT contain spaces.
+- Because reference BRC-100 clients commonly **trim and lowercase** tags before store and match, writers SHOULD use a case-insensitive alphabet for `<key>` (e.g. lowercase hex), and readers MUST treat tag equality as case-insensitive.
+
+Tags beginning with `brc164:` are reserved for this output list-key role.
+
+### Meaning
+
+- `brc164:<key>` identifies a **wallet output row** for list and spend targeting.
+- It is **not** a global asset id, token id, origin, outpoint, or proof of ownership.
+- Uniqueness: when the wallet authors the tag, `<key>` SHOULD be unique among that wallet’s held outputs (or among outputs in the same basket — wallet-defined, but must be documented by the implementation if narrower than wallet-wide).
+- Stability: for a given held row, the wallet-authored `brc164:` value SHOULD remain stable for the life of that row (including unproven / unmined outputs if they are listable).
+
+### Wallet behavior
+
+Conforming wallets SHOULD:
+
+1. Ensure each listable basket output can be found via a `brc164:` tag — either by persisting one at create/import time, or by exposing an internal storage id in this form on `listOutputs` when `includeTags` is true.
+2. Accept `listOutputs` queries that include a full `brc164:<key>` tag (with ordinary `tags` / `tagQueryMode` behavior) so callers can select that row.
+3. Preserve unknown `brc164:` tags when transporting outputs under [BRC-37](../outpoints/0037.md) when the wallet does not overwrite them with its own key.
+
+Wallets MAY overwrite or replace application-stamped `brc164:` values with their own canonical key when assuming custody of a row.
+
+### Application behavior
+
+Applications MAY:
+
+- Read `brc164:<key>` from `listOutputs` results and use it in later `listOutputs` tag filters or app state.
+- Stamp their own `brc164:<key>` on outputs they create, if the wallet does not yet assign one.
+
+Applications SHOULD NOT treat `brc164:` as token id, origin, or any on-chain identifier. Basket profiles that need those notions use their own tag vocabulary (e.g. `bsv21:<tokenId>`, `origin:…`).
+
+### Relationship to bare `id:` tags
+
+This BRC does **not** reserve or redefine `id:`. Profiles and apps that historically used `id:` for a per-output list key SHOULD migrate to `brc164:`. Readers MAY accept legacy `id:` list keys during a transition; new writers SHOULD emit `brc164:`.
+
+### Out of scope
+
+- Changing BRC-100 method schemas or WalletWire encodings
+- Basket names, token economics, or provenance proofs
+- Requiring a particular key generation algorithm (UUID, counter, storage PK encoding, …)
+
+## Security considerations
+
+- **Not authentication** — Knowing `brc164:<key>` only helps address a row inside a wallet that already authorized `listOutputs` / spend for that basket.
+- **Forgery** — Tags are claims unless the wallet authors or replaces them. Do not treat a counterparty-supplied `brc164:` as a capability.
+- **Case folding** — Assume tags are lowercased in storage; do not put case-sensitive secrets in `<key>`.
+
+## Implementations
+
+* Target: BRC-100 reference wallet storage (`bsv-blockchain` ts-sdk / wallet-toolbox) and [b-open-io/1sat-sdk](https://github.com/b-open-io/1sat-sdk) tracked outputs (migrating from `id:` list keys).
+
+## References
+
+1. [BRC-100](./0100.md) — Unified Open BSV Wallet-to-Application Interface
+2. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions Extension for Bitcoin Outpoints
+3. [BRC-46](./0046.md) — Wallet Transaction Output Tracking (Output Baskets)
+4. [BRC-153](./0153.md) — Action Reference Labels for BRC-100 Wallets
+5. [BRC-147](../tokens/0147.md) — 1Sat Ordinals Basket Profile

--- a/wallet/0164.md
+++ b/wallet/0164.md
@@ -10,9 +10,7 @@ This specification defines a backwards-compatible convention for [BRC-100](./010
 
 Basket profiles and applications often need a stable handle for one wallet output — reload after restart, target a spend, correlate UI to storage — without scanning every row.
 
-Ad-hoc tag names collide. In particular, the bare prefix `id:` is overloaded (token id, app id, origin-like claims). A single reserved prefix, owned by this BRC, gives wallets and apps one interoperable list key without claiming general-purpose `id:`.
-
-Wallets already assign internal identifiers to stored outputs. Surfacing that value (or an equivalent stable key) as a normal, **queryable** tag makes `listOutputs` the lookup API.
+Wallets already assign internal identifiers to stored outputs. Surfacing that value as a normal, **queryable** tag under a reserved prefix makes `listOutputs` the lookup API, without new BRC-100 fields.
 
 ## Specification
 
@@ -58,7 +56,7 @@ Applications SHOULD NOT rely on stamping `brc164:` themselves — the wallet ign
 
 - Changing BRC-100 method schemas or WalletWire encodings
 - Basket names, token economics, or provenance proofs
-- Other tag prefixes (including bare `id:`) — this BRC only defines `brc164:`
+- Any tag prefix other than `brc164:`
 - Requiring a particular key generation algorithm (UUID, counter, storage PK encoding, …)
 
 ## Security considerations

--- a/wallet/0164.md
+++ b/wallet/0164.md
@@ -54,14 +54,11 @@ Applications MAY read `brc164:<key>` from `listOutputs` results and use it in la
 
 Applications SHOULD NOT rely on stamping `brc164:` themselves — the wallet ignores external `brc164:` tags. Applications SHOULD NOT treat `brc164:` as token id, origin, or any on-chain identifier. Basket profiles that need those notions use their own tag vocabulary (e.g. `bsv21:<tokenId>`, `origin:…`).
 
-### Relationship to bare `id:` tags
-
-This BRC does **not** reserve or redefine `id:`. Profiles and apps that historically used `id:` for a per-output list key SHOULD migrate to `brc164:`. Readers MAY accept legacy `id:` list keys during a transition; new writers SHOULD emit `brc164:`.
-
 ### Out of scope
 
 - Changing BRC-100 method schemas or WalletWire encodings
 - Basket names, token economics, or provenance proofs
+- Other tag prefixes (including bare `id:`) — this BRC only defines `brc164:`
 - Requiring a particular key generation algorithm (UUID, counter, storage PK encoding, …)
 
 ## Security considerations
@@ -72,7 +69,7 @@ This BRC does **not** reserve or redefine `id:`. Profiles and apps that historic
 
 ## Implementations
 
-* Target: BRC-100 reference wallet storage (`bsv-blockchain` ts-sdk / wallet-toolbox) and [b-open-io/1sat-sdk](https://github.com/b-open-io/1sat-sdk) tracked outputs (migrating from `id:` list keys).
+* Target: BRC-100 reference wallet storage (`bsv-blockchain` ts-sdk / wallet-toolbox) and [b-open-io/1sat-sdk](https://github.com/b-open-io/1sat-sdk).
 
 ## References
 

--- a/wallet/0164.md
+++ b/wallet/0164.md
@@ -4,70 +4,63 @@ David Case (david.case@shruggr.cloud)
 
 ## Abstract
 
-This specification defines a backwards-compatible convention for [BRC-100](./0100.md) wallets: a reserved output **tag** prefix `brc164:` that carries a **wallet-local** list key for a held output. Applications use it with `listOutputs` to select a specific row. It does not change the BRC-100 request or response shape.
+This specification defines a **tag convention** for [BRC-100](./0100.md): an output tag prefix `id:` that carries a stable list key for a held output. Callers use it with ordinary `listOutputs` tag filters. It does not change the BRC-100 request or response shape, and it does not require special wallet storage behavior beyond normal tags.
 
 ## Motivation
 
 Basket profiles and applications often need a stable handle for one wallet output — reload after restart, target a spend, correlate UI to storage — without scanning every row.
 
-Wallets already assign internal identifiers to stored outputs. Surfacing that value as a normal, **queryable** tag under a reserved prefix makes `listOutputs` the lookup API, without new BRC-100 fields.
+Stamping that handle as a normal, **queryable** tag under a short prefix makes `listOutputs` the lookup API, without new BRC-100 fields or pseudo-tag peel paths.
 
 ## Specification
 
-### Reserved tag form
+### Tag form
 
-This specification reserves tags of the form:
+This specification uses tags of the form:
 
 ```
-brc164:<key>
+id:<key>
 ```
 
-- The prefix is exactly `brc164:` (lowercase, ASCII).
-- `<key>` is a non-empty string chosen by the wallet (or stamped by an application). It MUST NOT contain spaces.
-- Because reference BRC-100 clients commonly **trim and lowercase** tags before store and match, writers SHOULD use a case-insensitive alphabet for `<key>` (e.g. lowercase hex), and readers MUST treat tag equality as case-insensitive.
+- The prefix is exactly `id:` (lowercase, ASCII).
+- `<key>` is a non-empty string chosen by the writer that stamps the tag (wallet or tool).
+- Because reference BRC-100 clients commonly **trim and lowercase** tags before store and match, writers SHOULD use a case-insensitive alphabet for `<key>` (e.g. lowercase hex or decimal digits), and readers MUST treat tag equality as case-insensitive.
 
-Tags beginning with `brc164:` are reserved for this output list-key role.
+Tags beginning with `id:` are used for this output list-key role.
 
 ### Meaning
 
-- `brc164:<key>` identifies a **wallet output row** for list and spend targeting inside the holding wallet.
+- `id:<key>` identifies a **held output row** for list and spend targeting inside that wallet storage.
 - It is **not** a global asset id, token id, origin, outpoint, remittance field, or proof of ownership.
-- `<key>` is wallet-defined encoding of the wallet’s internal id (encoding is opaque to apps; only that wallet must round-trip it).
+- Encoding of `<key>` is defined by the writer (e.g. decimal storage primary key, UUID). Only that writer must round-trip it.
 - Uniqueness: `<key>` SHOULD be unique among that wallet’s held outputs (or a documented narrower scope such as per basket).
-- Stability: for a given held row, `brc164:` SHOULD remain stable for the life of that row (including unproven / unmined outputs if they are listable).
+- Stability: for a given held row, `id:` SHOULD remain stable for the life of that row (including unproven / unmined outputs if they are listable).
 
-### Wallet behavior
+### Behavior
 
-`brc164:` is the **holding wallet’s** internal output identifier, exposed as a tag for `listOutputs` queries. It is not remittance and not copied from counterparties.
+`id:` is an ordinary BRC-100 output tag. No special `listOutputs` semantics, peel, inject, or foreign-tag overwrite is required of generic wallet storage.
 
-Conforming wallets SHOULD:
+Conforming **tools and wallets that adopt this profile** SHOULD:
 
-1. Author `brc164:<key>` from their own storage (e.g. numeric output primary key as decimal digits) for each listable basket output — at insert and/or when returning tags on `listOutputs` with `includeTags` true.
-2. Accept `listOutputs` queries that include a full `brc164:<key>` tag (ordinary `tags` / `tagQueryMode`) so callers can select that row.
-3. **Ignore** any `brc164:` value supplied externally (createAction/import remittance, another wallet’s tags, app-forged tags). Do not persist a foreign `brc164:` as the row key; replace with the wallet’s own key when custody is taken.
+1. Stamp `id:<key>` on the output when the row is created or first taken into custody (same path as any other tag).
+2. Query with a full `id:<key>` tag via ordinary `tags` / `tagQueryMode`.
+3. Treat `id:` as their own list key vocabulary — not as token id, origin, or on-chain identity. Basket profiles that need those notions use their own tags (e.g. `bsv21:<tokenId>`, `origin:…`).
 
-### Application behavior
-
-Applications MAY read `brc164:<key>` from `listOutputs` results and use it in later tag filters or app state.
-
-Applications SHOULD NOT rely on stamping `brc164:` themselves — the wallet ignores external `brc164:` tags. Applications SHOULD NOT treat `brc164:` as token id, origin, or any on-chain identifier. Basket profiles that need those notions use their own tag vocabulary (e.g. `bsv21:<tokenId>`, `origin:…`).
+Applications MAY read `id:<key>` from `listOutputs` (with `includeTags`) and reuse it in later filters or app state.
 
 ### Out of scope
 
 - Changing BRC-100 method schemas or WalletWire encodings
 - Basket names, token economics, or provenance proofs
-- Any tag prefix other than `brc164:`
 - Requiring a particular key generation algorithm (UUID, counter, storage PK encoding, …)
+- Mandating peel/inject or other non-tag storage paths in reference wallets
 
 ## Security considerations
 
-- **Not authentication** — Knowing `brc164:<key>` only helps address a row inside a wallet that already authorized `listOutputs` / spend for that basket.
-- **Forgery** — External `brc164:` tags are ignored. Only the holding wallet’s key is authoritative inside that wallet.
+- **Not authentication** — Knowing `id:<key>` only helps address a row inside a wallet that already authorized `listOutputs` / spend for that basket.
+- **Authority** — The tag is only as trustworthy as the storage that stamped it. Counterparty remittance is not a substitute for the holding wallet’s (or tool’s) own stamp.
 - **Case folding** — Assume tags are lowercased in storage; do not put case-sensitive secrets in `<key>`.
-
-## Implementations
-
-* Target: BRC-100 reference wallet storage (`bsv-blockchain` ts-sdk / wallet-toolbox) and [b-open-io/1sat-sdk](https://github.com/b-open-io/1sat-sdk).
+- **Ambiguity** — `id:` is short and may appear in other informal tag sets. Writers that need a stricter namespace MAY document a longer key form; this BRC does not reserve exclusivity of the two-letter prefix beyond the list-key meaning above for adopters.
 
 ## References
 

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -36,6 +36,7 @@ BRC | Standard
 116  | [Wallet Permissions and Counterparty Trust](./0116.md)
 123  | [Basket Permission Scheme Registry and Governance](./0123.md)
 153  | [Action Reference Labels for BRC-100 Wallets](./0153.md)
+164  | [Output Identity Tags for BRC-100 Wallets](./0164.md)
 154  | [Pluggable Backup Services for BRC-140 Share Vaults](./0154.md)
 155  | [Pull-Based Receive Discovery](./0155.md)
 219  | [Wallet Permission Prompt Liveness Contract](./0219.md)


### PR DESCRIPTION
## Summary

Adds **BRC-164**: ordinary output tag convention `id:<key>` as a stable, queryable list key for held BRC-100 outputs.

- No BRC-100 schema changes
- No special wallet peel/inject/strip — stamp and query like any other tag
- Conforming tools/wallets that adopt the profile SHOULD stamp `id:<key>` on create/custody
- Not a global asset, token, origin, or on-chain id (those stay in basket-profile tags)

## Test plan
- [ ] Spec review (prefix, meaning, ordinary-tag behavior)
- [ ] Follow-up: 1sat-sdk (and any tools) stamp/query `id:` per this BRC