### PR TITLE
docs(tokens): draft BRC-165 P1Sat collectable permission scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ BRC | Standard
 159  | [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 160  | [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
 164  | [Output Identity Tags for BRC-100 Wallets](./wallet/0164.md)
+165  | [P1Sat Collectable Permission Scheme for BRC-100](./tokens/0165.md)
 168  | [Verifiable Time Allocation](./apps/0168.md)
 169  | [Universal Handle Addressing and Resolution for the Metanet](./peer-to-peer/0169.md)
 210  | [Derived Collectibles](./apps/0210.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -118,9 +118,9 @@
 * [Proof-of-Indexing Hash-to-Mint Tokens](./tokens/0117.md)
 * [1Sat Ordinals Basket Profile for BRC-46 / BRC-100](./tokens/0147.md)
 * [1Sat Provenance Remittance for Basket `1sat`](./tokens/0150.md)
-* [P1Sat Collectable Permission Scheme for BRC-100](./tokens/0165.md)
 * [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 * [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
+* [P1Sat Collectable Permission Scheme for BRC-100](./tokens/0165.md)
 * [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)
 
 ## Overlays

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -118,6 +118,7 @@
 * [Proof-of-Indexing Hash-to-Mint Tokens](./tokens/0117.md)
 * [1Sat Ordinals Basket Profile for BRC-46 / BRC-100](./tokens/0147.md)
 * [1Sat Provenance Remittance for Basket `1sat`](./tokens/0150.md)
+* [P1Sat Collectable Permission Scheme for BRC-100](./tokens/0165.md)
 * [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 * [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
 * [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)

--- a/tokens/0165.md
+++ b/tokens/0165.md
@@ -1,0 +1,162 @@
+# BRC-165: P1Sat Collectable Permission Scheme for BRC-100
+
+Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
+
+## Abstract
+
+This BRC defines the **P1Sat** basket permission scheme for [BRC-100](../wallet/0100.md) wallets: scheme id **`1sat`** under [BRC-99](../wallet/0099.md). Apps request scoped access to collectables with basket ids of the form `p 1sat <scope>`. Conforming wallets **normalize** those requests onto the published storage basket **`1sat`** ([BRC-147](./0147.md)) and apply `<scope>` only to permission prompts and `listOutputs` filtering.
+
+This document does **not** redefine 1Sat chain theory, inscriptions, collections, or provenance proofs. It does **not** replace [BRC-147](./0147.md) or retarget [BRC-150](./0150.md).
+
+## Motivation
+
+Plain [BRC-46](../wallet/0046.md) baskets only support coarse grant/deny. Collectables need finer app access — one collection, one issuer, one origin — without inventing a storage basket per collection and without forcing inventory to live under a `p …` name.
+
+[BRC-99](../wallet/0099.md) reserves `p <scheme> …` for that richer path. A prior draft series ([BRCs PR #200](https://github.com/bsv-blockchain/BRCs/pull/200), draft BRC-302 / BRC-303) proposed scheme id `1sat` with storage baskets such as `p 1sat ordinals`. That collapses **permissions** and **storage** into one string, would supersede BRC-147, and would retarget BRC-150 off basket `1sat`.
+
+HandCash wallets already file and remit against storage `1sat`. This BRC keeps scheme id `1sat` and the `p 1sat` protocol name from that work, and separates layers:
+
+| Layer | Law |
+|-------|-----|
+| Storage basket | `1sat` ([BRC-147](./0147.md)) |
+| Permissions | `p 1sat <scope>` |
+| Provenance | [BRC-150](./0150.md) on storage `1sat` |
+
+## Source material and relationship to prior drafts
+
+This specification is **derived from** [bsv-blockchain/BRCs#200](https://github.com/bsv-blockchain/BRCs/pull/200) (*Add BRC-300–307: the 1Sat Ordinals series*; David Case / b-open-io; closed without merge), especially draft **BRC-302** (P1Sat scheme) and draft **BRC-303** (collectables under P1Sat).
+
+**Kept from that series (for this document):**
+
+* Scheme id `1sat`
+* BRC-98 protocol name `p 1sat`
+* Motivation for scheme-mediated item access instead of a blank basket dump
+* Treating display tags as claims (authenticity remains [BRC-150](./0150.md))
+
+**Changed relative to draft 302 / 303:**
+
+1. **Storage stays `1sat`.** Do not use `p 1sat ordinals` (or any `p …` string) as the collectable storage basket. Do not mark [BRC-147](./0147.md) superseded for new work solely because this scheme exists.
+2. **`<scope>` is a filter**, not an asset-class storage suffix (`ordinals`, `bsv21`, …).
+3. **[BRC-150](./0150.md)** remains scoped to basket `1sat`.
+4. **`id:` tags** ([BRC-164](../wallet/0164.md)) are optional for interop. They MUST NOT be required to recognize, prove, internalize, or list tips. Mandatory `id:<actionId>_<outputIndex>` and mandatory `p 1sat input` / `p 1sat action-id` labels from draft 302 are out of scope here.
+
+Chain / encoding drafts from PR #200 (core, envelopes, collections, BSV-21, Sigma) may proceed independently; this BRC does not depend on their placeholder numbers.
+
+## Basket Namespace
+
+Per [BRC-123](../wallet/0123.md) §3.2:
+
+1. **Scheme ID:** `1sat`
+2. **Category:** Category 1 — Asset Permission Scheme
+3. **Basket name format:** `p 1sat <scope>` where `<scope>` is defined in [Scopes](#scopes)
+4. **Wallet capability:** Must implement storage basket `1sat` per [BRC-147](./0147.md); must normalize `p 1sat …` onto that basket for list/internalize/spend gating; must present a scoped permission prompt (or honor a prior grant) before returning or spending matching outputs
+5. **Permission semantics:** See [Permissions](#permissions)
+
+Also claim BRC-98 protocol name `p 1sat` for key derivation / signing when an application uses this scheme’s protocol path. Security level follows ordinary [BRC-43](../key-derivation/0043.md) rules; this document does not fix a level.
+
+## Specification
+
+### Scheme identifier
+
+* **Scheme id:** `1sat` (no spaces; matches [BRC-123](../wallet/0123.md) id rules)
+* **BRC-98 protocol name:** `p 1sat`
+* **BRC-99 basket form:** `p 1sat <scope>`
+
+Wallets that do not implement this scheme MUST reject operations under these identifiers per [BRC-99](../wallet/0099.md).
+
+### Storage vs permissions
+
+1. Conforming wallets MUST file collectables in storage basket **`1sat`** ([BRC-147](./0147.md)).
+2. Apps MAY request access with plain `1sat` or `p 1sat <scope>`.
+3. When the basket argument is `p 1sat <scope>`, the wallet MUST:
+   * treat the request as scheme `1sat`;
+   * **normalize** the storage target to basket `1sat`;
+   * apply `<scope>` to the permission grant and to which outputs are returned or spendable under that grant.
+4. Wallets MUST NOT treat `p 1sat ordinals`, `p 1sat bsv21`, or other `p 1sat <class>` spellings as storage basket names for collectables under this BRC.
+
+Fungible BSV-21 inventory is out of scope (separate storage profile). This scheme does not define `p 1sat bsv21` as a storage basket.
+
+### Scopes
+
+`<scope>` is a single scope token after `p 1sat ` (trimmed). Defined tokens:
+
+| Scope token | Meaning | Match (informative) |
+|-------------|---------|---------------------|
+| `*` or empty / bare `p 1sat` | All collectables the grant covers | Entire storage basket `1sat` (subject to grant) |
+| `collection:<id>` or `collectionId:<id>` | One collection | `collection:` / `collectionId:` tags or remittance `collectionId` |
+| `creator:<id>`, `app:<id>`, or `author:<id>` | One issuer | `app:` / `creator:` / `author:` tags or remittance `app` / `creator` |
+| `origin:<outpoint>` | One item | `origin:` tag or remittance `origin` |
+
+Notes:
+
+* `<outpoint>` SHOULD use `txid.vout` or `txid_vout`; wallets MUST accept both after normalize when matching.
+* Unknown scope tokens SHOULD be treated as “all” for prompting so the user still sees a clear request, or rejected with a clear error — wallet policy. HandCash treats unknown tokens as “all”.
+* Apps MAY also narrow with ordinary `tags` / `tagQueryMode` on storage basket `1sat`; scoped `p 1sat …` is the preferred permission-shaped form.
+
+#### Open issue — BRC-100 basket charset
+
+[BRC-100](../wallet/0100.md) requires basket names to use only lowercase letters, numbers, and spaces. Live HandCash scope tokens use `:` and `*` (tag-style), which are outside that charset. This draft documents the **shipped wire form** for feedback.
+
+Charset-compliant alternatives for a later revision (not required of current HandCash clients):
+
+* `p 1sat all` instead of `p 1sat *`
+* `p 1sat collection <id>` (space-separated) instead of `p 1sat collection:<id>`
+* similarly for `creator` / `app` / `author` / `origin`
+
+Reviewers: prefer keeping tag-style scopes (and relaxing or clarifying charset for the `<rest>` of `p <scheme> …` only), or migrating the wire form to spaces-only?
+
+### Permissions
+
+A conforming wallet that implements this scheme:
+
+1. **List / view** — `listOutputs` with `p 1sat <scope>` (or plain `1sat`) requires user grant (or a prior grant) for that scope. After grant, return only outputs in storage `1sat` that match the scope (and any additional tag filters).
+2. **Receive / internalize** — inserting into storage `1sat` is scheme-gated when the caller uses this scheme; plain basket insertion into `1sat` follows ordinary BRC-46 / wallet policy.
+3. **Spend / relinquish** — spending or relinquishing outputs from storage `1sat` MUST NOT be covered by ordinary payment / auto-pay grants. The wallet MUST require item-capable permission (this scheme or an equivalent explicit item grant).
+4. **Unsupported schemes** — `p <other> …` MUST be rejected per BRC-99 (e.g. clear unsupported-scheme error).
+
+Prompt text SHOULD describe the scope in user terms (e.g. issuer id, collection, single item, or all collectables).
+
+### Tags and `id:`
+
+Display and filter tags on storage outputs follow [BRC-147](./0147.md). They remain **claims**.
+
+[BRC-164](../wallet/0164.md) `id:<key>` MAY be stamped as a held-row list key. Under this scheme:
+
+* `id:` MUST NOT be required to list, internalize, prove, or spend a tip.
+* Spend targeting by outpoint and/or `origin:` remains valid.
+
+### Custom instructions
+
+Spend and display fields for outputs in `1sat` follow [BRC-147](./0147.md) / [BRC-150](./0150.md). When `protocolID` is used for P1Sat-managed derivation, writers SHOULD use `[<level>, "p 1sat"]`. This document does not require every collectable tip to use that protocol.
+
+### Out of scope
+
+* Origin / sat-ordering / transfer consensus rules
+* Inscription envelope bytes
+* Collection membership proofs (MAP / Sigma / parent)
+* BSV-21 fungible storage and permissions
+* Marketplace lock templates
+* Mandatory action-label vocabulary from draft BRC-302
+
+## Security considerations
+
+* **Scope spoofing** — Matching on tags / remittance is only as trustworthy as the holding wallet’s own stamps and verification policy. Do not treat `origin:` or `collection:` as proof without [BRC-150](./0150.md) (and collection rules elsewhere).
+* **Over-broad unknown scopes** — Treating unknown tokens as “all” favors UX; wallets that prefer fail-closed SHOULD reject unknown scopes instead.
+* **Scheme bypass** — Filing collectables only in a non-`1sat` basket loses this scheme’s routing; apps must not invent parallel storage names for the same tips.
+* **Charset** — Until the open issue is resolved, gateways that strictly enforce BRC-100 basket charset may reject live `p 1sat collection:…` forms.
+
+## Implementations
+
+* HandCash Desktop / Mobile — normalize `p 1sat <scope>` → storage `1sat`; scoped prompts and `listOutputs` filters (`itemAccess` / BRC-100 handler)
+* App guide (informative): HandCash `p1sat-listoutputs-guide` (foxplorer / Pixel Foxes patterns)
+
+## References
+
+1. [BRC-99: P Baskets](../wallet/0099.md)
+2. [BRC-98: P Protocols](../wallet/0098.md)
+3. [BRC-100: Wallet Interface](../wallet/0100.md)
+4. [BRC-123: Basket Permission Scheme Registry](../wallet/0123.md)
+5. [BRC-147: 1Sat Ordinals Basket Profile](./0147.md)
+6. [BRC-150: 1Sat Provenance Remittance](./0150.md)
+7. [BRC-164: Output Identity Tags](../wallet/0164.md)
+8. [bsv-blockchain/BRCs#200](https://github.com/bsv-blockchain/BRCs/pull/200) — source material (draft 302 / 303)

--- a/tokens/0165.md
+++ b/tokens/0165.md
@@ -78,43 +78,59 @@ Fungible BSV-21 inventory is out of scope (separate storage profile). This schem
 
 ### Scopes
 
-`<scope>` is a single scope token after `p 1sat ` (trimmed). Defined tokens:
+`<scope>` is a single scope token after `p 1sat ` (trimmed). **Normative wire form** (HandCash reference):
 
-| Scope token | Meaning | Match (informative) |
-|-------------|---------|---------------------|
+| Scope token | Meaning | Match |
+|-------------|---------|-------|
 | `*` or empty / bare `p 1sat` | All collectables the grant covers | Entire storage basket `1sat` (subject to grant) |
-| `collection:<id>` or `collectionId:<id>` | One collection | `collection:` / `collectionId:` tags or remittance `collectionId` |
-| `creator:<id>`, `app:<id>`, or `author:<id>` | One issuer | `app:` / `creator:` / `author:` tags or remittance `app` / `creator` |
-| `origin:<outpoint>` | One item | `origin:` tag or remittance `origin` |
+| `collection:<id>` or `collectionId:<id>` | One collection | `collection:` / `collectionId:` tags **or** remittance `collectionId` |
+| `creator:<id>`, `app:<id>`, or `author:<id>` | One issuer | `app:` / `creator:` / `author:` tags **or** remittance `app` / `creator` |
+| `origin:<outpoint>` | One item | `origin:` tag **or** remittance `origin` |
 
 Notes:
 
 * `<outpoint>` SHOULD use `txid.vout` or `txid_vout`; wallets MUST accept both after normalize when matching.
-* Unknown scope tokens SHOULD be treated as “all” for prompting so the user still sees a clear request, or rejected with a clear error — wallet policy. HandCash treats unknown tokens as “all”.
-* Apps MAY also narrow with ordinary `tags` / `tagQueryMode` on storage basket `1sat`; scoped `p 1sat …` is the preferred permission-shaped form.
+* Unknown scope tokens SHOULD be treated as “all” for prompting so the user still sees a clear request (HandCash does this), or rejected with a clear error — wallet policy MUST be documented.
+* Apps MAY also pass ordinary `tags` / `tagQueryMode` together with `p 1sat <scope>`. Conforming wallets MUST **merge** basket-scope filters with tag filters (union of constraints on the same axis; empty axis means unconstrained on that axis).
+* When normalizing `listOutputs`, wallets SHOULD rewrite `basket` to `1sat` and MAY inject the scope as equivalent `tags` entries (e.g. `collection:<id>`) so downstream storage queries stay ordinary BRC-46 tag filters.
 
-#### Open issue — BRC-100 basket charset
+#### BRC-100 basket charset (feedback ask)
 
-[BRC-100](../wallet/0100.md) requires basket names to use only lowercase letters, numbers, and spaces. Live HandCash scope tokens use `:` and `*` (tag-style), which are outside that charset. This draft documents the **shipped wire form** for feedback.
+[BRC-100](../wallet/0100.md) requires basket names to use only lowercase letters, numbers, and spaces. This scheme’s normative `<scope>` uses `:` and `*` (tag-style), matching HandCash and overlapping tag vocabulary.
 
-Charset-compliant alternatives for a later revision (not required of current HandCash clients):
-
-* `p 1sat all` instead of `p 1sat *`
-* `p 1sat collection <id>` (space-separated) instead of `p 1sat collection:<id>`
-* similarly for `creator` / `app` / `author` / `origin`
-
-Reviewers: prefer keeping tag-style scopes (and relaxing or clarifying charset for the `<rest>` of `p <scheme> …` only), or migrating the wire form to spaces-only?
+**Request for reviewers:** allow those characters in the `<rest>` of `p <scheme> …` basket ids (scheme id itself stays `[a-z][a-z0-9]*`), **or** accept an explicit exception for registered schemes that document tag-style rests. Space-separated alternatives (`p 1sat collection <id>`, `p 1sat all`) MAY be added later as aliases; they MUST NOT be required for HandCash interop in this draft.
 
 ### Permissions
 
-A conforming wallet that implements this scheme:
+Item access is **not** covered by ordinary payment / auto-pay grants. Conforming wallets MUST model at least three capabilities (names informative; storage local):
 
-1. **List / view** — `listOutputs` with `p 1sat <scope>` (or plain `1sat`) requires user grant (or a prior grant) for that scope. After grant, return only outputs in storage `1sat` that match the scope (and any additional tag filters).
-2. **Receive / internalize** — inserting into storage `1sat` is scheme-gated when the caller uses this scheme; plain basket insertion into `1sat` follows ordinary BRC-46 / wallet policy.
-3. **Spend / relinquish** — spending or relinquishing outputs from storage `1sat` MUST NOT be covered by ordinary payment / auto-pay grants. The wallet MUST require item-capable permission (this scheme or an equivalent explicit item grant).
-4. **Unsupported schemes** — `p <other> …` MUST be rejected per BRC-99 (e.g. clear unsupported-scheme error).
+| Capability | Covers | HandCash reference |
+|------------|--------|--------------------|
+| **View** | `listOutputs` on storage `1sat` / `p 1sat …` | `view`: `none` \| `all` \| `filtered` (+ `collections` / `creators` / `origins`) |
+| **Send** | `createAction` / `signAction` / `relinquishOutput` that spend or move item tips | `canSend` |
+| **Receive** | `internalizeAction` basket insertion into `1sat` | `canReceive` |
 
-Prompt text SHOULD describe the scope in user terms (e.g. issuer id, collection, single item, or all collectables).
+Normative behavior:
+
+1. **List / view** — `listOutputs` with `p 1sat <scope>` or plain `1sat` requires a view grant covering that request (or a user prompt that creates one). After allow, the wallet MUST return only outputs the grant permits (see [Matching outputs](#matching-outputs)). Denial SHOULD use a distinct error (HandCash: `ITEM_VIEW_DENIED`).
+2. **Receive / internalize** — basket insertion into `1sat` requires receive permission (prompt or prior `canReceive`). It MUST NOT be satisfied by payment grants alone.
+3. **Spend / relinquish** — spending or relinquishing outputs from `1sat` MUST NOT be covered by ordinary payment / auto-pay. The wallet MUST require send permission (prompt or prior `canSend`). Detecting “this action is an item spend” is wallet policy (labels, `origin:` tags, `satoshis === 1` + item basket, etc.); once classified as item spend, payment auto-approve MUST NOT apply.
+4. **Unsupported schemes** — `p <other> …` MUST be rejected per BRC-99. HandCash uses HTTP 400 with code `UNSUPPORTED_P_BASKET`.
+5. **Grant widening** — a successful scoped view prompt MAY widen a filtered grant (add collections/creators/origins) or upgrade to `all` when the request asked for all. Send and receive grants are independent of view.
+
+Prompt text SHOULD describe the scope in user terms (issuer, collection, single item, or all collectables) and SHOULD state that Pay does not cover inventory.
+
+### Matching outputs
+
+When view is filtered, an output matches only if it satisfies **every** non-empty filter axis on the grant:
+
+* **Collection axis** — if the grant lists collections, the output’s collection id (tag or remittance) MUST be one of them.
+* **Creator axis** — if the grant lists creators, the output’s issuer id (tag `app:` / `creator:` / `author:` or remittance `app` / `creator`) MUST be one of them.
+* **Origin axis** — if the grant lists origins, the output’s origin MUST be one of them.
+
+If tags omit a field the grant filters on, wallets SHOULD fall back to parsing [BRC-37](../outpoints/0037.md) `customInstructions` JSON for `collectionId`, `app`, `creator`, and `origin` (HandCash does this so pre-tag tips remain listable under issuer scope).
+
+A grant with `view = all` returns all storage `1sat` outputs (subject to the caller’s tag query). A grant with `view = none` returns none / denies the list.
 
 ### Tags and `id:`
 

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -17,4 +17,5 @@ BRC | Standard
 150  | [1Sat Provenance Remittance for Basket `1sat`](./0150.md)
 159  | [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./0159.md)
 160  | [1Sat Ordinals — Inscription Envelopes](./0160.md)
+165  | [P1Sat Collectable Permission Scheme for BRC-100](./0165.md)
 226  | [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./0226.md)

--- a/wallet/0123.md
+++ b/wallet/0123.md
@@ -102,8 +102,11 @@ A scheme ID is considered registered when its defining BRC is merged into the BR
 | Scheme ID | Category | Defining BRC | Purpose | Example basket |
 |---|---|---|---|---|
 | `app` | *(Reserved)* | *(Future BRC)* | Application-scoped basket isolation | *(TBD)* |
+| `1sat` | 1 (Asset) | [BRC-165](../tokens/0165.md) | Scoped collectable view/spend grants; normalize to storage basket `1sat` | `p 1sat collection:<id>` |
 
 The `app` scheme ID is reserved to allow a future specification to define application-scoped baskets where the originator's identity is encoded in the basket name. This supplements (rather than replaces) [BRC-116](./0116.md)<sup>1</sup> originator-based access control, which operates at the permission layer rather than the naming layer.
+
+The `1sat` scheme ID is defined by [BRC-165](../tokens/0165.md). Storage remains plain basket `1sat` ([BRC-147](../tokens/0147.md)); `p 1sat <scope>` is permissions and list filtering only.
 
 ### 5. Validation Guidance
 


### PR DESCRIPTION
## Summary
- Draft **BRC-165**: P1Sat collectable permission scheme (BRC-99 scheme id `1sat`).
- **Storage** stays basket `1sat` ([BRC-147](./tokens/0147.md)); **`p 1sat <scope>`** is permissions + `listOutputs` filtering only.
- Registers `1sat` in [BRC-123](./wallet/0123.md).
- Explicitly derived from closed [PR #200](https://github.com/bsv-blockchain/BRCs/pull/200) drafts 302/303, with a documented storage/permissions split (does **not** adopt `p 1sat ordinals` as storage, does **not** supersede 147 or retarget 150).

## Seeking feedback on
- [ ] Layering: storage `1sat` vs permissions `p 1sat <scope>` (vs PR #200’s `p 1sat ordinals` storage model)
- [ ] Scope grammar (`collection:` / `creator:` / `origin:` / `*`) vs BRC-100 basket charset (`[a-z0-9 ]`) — open issue called out in the draft; space-separated alternatives listed
- [ ] Optional vs required `id:` (align with BRC-164; reject draft 302 MUST)
- [ ] Numbering (`165`) and registry row shape in BRC-123

## Test plan
- [ ] Spec read-through by wallet / 1sat-sdk folks
- [ ] Confirm no collision with open BSV-21 drafts (#213 / #217)
- [ ] Decide charset follow-up before marking ready for review

Draft PR for feedback — not ready to merge.

Made with [Cursor](https://cursor.com)