### PR TITLE
BRC-169: certificate custody, self-handle discovery, and reverse resolution

### DIFF
--- a/peer-to-peer/0169.md
+++ b/peer-to-peer/0169.md
@@ -195,7 +195,7 @@ A handle can be released and reassigned to a different person. Address book entr
 
 #### 4.5 Certificate type identifiers
 
-A [BRC-52](./0052.md) `CertificateTypeID` is an opaque 32-byte value, and no BRC defines an authority that allocates one. Rather than wait for an allocation that has no allocator, this document **derives** its two type values from a name, so that any implementation reproduces them from this section alone:
+A [BRC-52](./0052.md) `CertificateTypeID` is an opaque 32-byte value, and no BRC defines an authority that allocates one. Rather than wait for an allocation that has no allocator, this document **derives** its type values from a name, so that any implementation reproduces them from this section alone:
 
 ```
 type = base64( SHA-256( ASCII derivation string ) )
@@ -205,15 +205,28 @@ type = base64( SHA-256( ASCII derivation string ) )
 | --- | --- | --- |
 | Handle certificate (section 4.1) | `metanet-handles handle certificate v1` | `XgCFdUfxEcI+3xtDjsIuSAjMl5EwzCUjsQc45ds1lC8=` |
 | Delegation certificate (section 9.1) | `metanet-handles delegation certificate v1` | `30kchAJIGfLxzCNloCJNLI3AtkgA8UbkxlXU2Cj4PpA=` |
+| Primary designation (section 5.9) | `metanet-handles primary designation v1` | `myjPvkwiyYPEpN5LrLLePQFYA7R6ES8TqTFGOAYg/V0=` |
 
-1. Both values are normative. An implementation MUST use them, and MUST NOT substitute a locally chosen constant.
+1. All three values are normative. An implementation MUST use them, and MUST NOT substitute a locally chosen constant.
 2. The derivation strings carry no BRC number. Nothing else in this document carries one in a wire name either — the manifest key is `metanet.handles`, the alias protocol field is `ecosystem-alias` — so that a later revision does not leave the deployed vocabulary naming a superseded document.
 3. The `v1` suffix versions the type rather than the document. A future revision that changes the field names or meanings of either certificate MUST mint a new type by changing the derivation string, so that certificates issued under the two revisions remain distinguishable and a verifier is never required to guess which set of field semantics applies. This is what BRC-52 means when it says certificates of the same type are expected to use the same field names and meanings.
-4. The handle-certificate value above is the one used throughout Appendix A, and is therefore covered by the worked signature in A.3.
+4. The handle-certificate value is the one used throughout Appendix A and is covered by the worked signature in A.3. The primary-designation value is covered by A.9, which also demonstrates that BRC-52's signing parameters apply unchanged when `subject` and `certifier` are the same key.
 
 **Publishing type metadata is an open consideration.** Deployed overlay infrastructure includes a certificate-type directory, reachable as the topic `tm_certmap` and the lookup service `ls_certmap` and wrapped by a registry client in several BSV SDKs, through which an operator publishes a type identifier together with a human-readable name, an icon, a description, and per-field descriptors. It is not specified by any BRC, it does not allocate or reserve a type, and its records are attributable to the operator that published them rather than to any authority over the type. Whether this document should recommend publishing there, and if so what an operator should publish and how a client should weigh a record it finds, is left open for review. Nothing in this section depends on it: the type values above are fixed by their derivation.
 
-#### 4.6 Historical note
+#### 4.6 Custody of the certificate
+
+Section 4.1 requires a verifier to check the certificate and ends by noting that certificates are exchanged and selectively revealed over [BRC-103](./0103.md) and [BRC-104](./0104.md). Both presuppose that the holder still has it. This section says where it lives, because a specification that defines an attestation and not its custody gets implementations in which the attestation exists for the length of one HTTP response.
+
+1. A client that claims or receives a handle certificate MUST store it through [BRC-100](../wallet/0100.md) `acquireCertificate`, so that `listCertificates` returns it and `proveCertificate` can reveal its fields.
+2. **A client MUST NOT store a derived summary in place of the certificate.** A record of the handle and the identity key, written by the wallet into its own storage, is not an attestation. It is the wallet's own claim about itself: unsigned, unverifiable by anybody else, unaffected when the revocation outpoint of section 4.2 is spent, and indistinguishable from a handle the wallet never held. Keeping the fields and discarding the signature keeps the part that is easy to fabricate and throws away the part that is not.
+3. When a handle is released or reassigned per section 4.3, the holder MUST `relinquishCertificate` for the retired binding. A wallet that keeps a revoked certificate in storage will return it from `listCertificates`, and a client that trusts the surface without performing the revocation check of section 4.2 will present a binding that no longer holds.
+4. **A wallet MUST NOT expose handle information through a vendor-specific method in place of the certificate surface**, and MUST NOT restrict that surface by an origin allowlist. Certificate access is already permissioned: [BRC-116](../wallet/0116.md) section 4.4 governs which application may read which certificate fields, with the user deciding. An origin allowlist replaces that decision with the vendor's, cannot be reasoned about by an application that is not on it, and produces no diagnosable failure for one that is not.
+5. An allowlist that contains a development origin is worse than one that contains none, because an integration then passes locally and fails on deployment. A wallet that must restrict access during development SHOULD do so by a mechanism the user can see and change, not by a list the application cannot read.
+
+Rule 2 is the one worth stating at length, because it is the failure that actually occurs and it looks like a reasonable optimisation from inside the wallet. The wallet knows the handle; it needs the handle for its own display; storing a small record is cheaper than storing a certificate. What is lost is not convenience but the entire evidentiary chain: the ecosystem host's signature over the binding, the revocation outpoint that retires it, and the ability of any third party to check either. An application then has no way to learn the handle except to ask the user, and no way to believe the answer except to trust them.
+
+#### 4.7 Historical note
 
 The Authrite-era certificate documents ([BRC-31](./0031.md), [BRC-53](../wallet/0053.md), [BRC-56](../wallet/0056.md)) are cited for historical context only. Per BRC-52's own status notes they are not normative for BRC-100 certificate behavior, and this document does not depend on them.
 
@@ -239,6 +252,7 @@ A host MUST additionally publish a `metanet.handles` object alongside `metanet.t
       "version": "1.0",
       "resolve": "https://lkup.net/.well-known/metanet-handles/resolve",
       "search": "https://lkup.net/.well-known/metanet-handles/search",
+      "reverse": "https://lkup.net/.well-known/metanet-handles/reverse",
       "messagebox": "https://messagebox.lkup.net",
       "aliases": ["lkup"],
       "commands": []
@@ -252,6 +266,7 @@ A host MUST additionally publish a `metanet.handles` object alongside `metanet.t
 | `version` | MUST | The BRC-169 version implemented. `"1.0"` for this document. |
 | `resolve` | SHOULD | Absolute HTTPS URL of the resolution endpoint. When absent, clients MUST use `https://<domain>/.well-known/metanet-handles/resolve`. |
 | `search` | MAY | Absolute HTTPS URL of the search endpoint (section 5.6). When absent, search is not offered and clients MUST NOT probe the well-known path. |
+| `reverse` | MAY | Absolute HTTPS URL of the reverse-resolution endpoint (section 5.10). When absent, reverse resolution is not offered and clients MUST NOT probe for it. |
 | `messagebox` | SHOULD | Default messagebox URL for handles in this ecosystem. Per-handle values in the resolution response override it. |
 | `aliases` | MAY | Aliases this domain claims, used for the bidirectional check of section 5.5. |
 | `commands` | MAY | Ecosystem-custom command descriptors. The contents are specified by [BRC-218](../apps/0218.md); hosts not implementing BRC-218 MUST publish an empty array or omit the field. |
@@ -403,6 +418,93 @@ Given a recipient string, a conforming client MUST:
 5. Verify the certificate per section 4.1, including the revocation check of section 4.2 at the freshness required by the pending action.
 6. Apply the key-change check of section 4.4.
 7. Only then treat the identity key as the key for that handle, and the messagebox as the delivery target.
+
+#### 5.8 The connected user's own handle
+
+Sections 5.2 through 5.7 run in one direction: a client holds a handle and wants the key behind it. An application with a connected wallet has the opposite problem. It holds the identity key, has proven the user controls it, and wants the handle to show them. Nothing above answers that, and the certificate of section 4.1 is exactly the object that does.
+
+Throughout this section, **proven** means the client has verified a challenge signature against the identity key in the current session, per [BRC-103](./0103.md) or an equivalent handshake. Everything here compares against that key and is worthless without it.
+
+A client MUST attempt these in order, and MUST NOT fall back to a later path while an earlier one has yielded a verified binding. A client MAY continue through the remaining paths to discover further bindings, which an organisation or agent holding several will need.
+
+1. **Ask the wallet.** Call [BRC-100](../wallet/0100.md) `listCertificates` for the handle-certificate type of section 4.5, and verify each result per section 4.1, including that `subject` equals the proven key. This is the correct path, and it works only where the wallet kept the certificate, which section 4.6 requires.
+2. **Ask the identity overlay.** Call `discoverByIdentityKey` for the proven key and verify each certificate returned per section 4.1.
+3. **Ask the user, and check the answer.** Where neither yields anything, a client MAY accept a handle from the user, and then MUST resolve it forward per section 5.7 and MUST compare the `identityKey` in the response against the proven key. It MUST accept the handle only on an exact match.
+
+**Path 3 is verification, not trust, and the distinction is the whole of why it is permitted.** The registry attests the binding, the challenge signature proves the key, and the client checks that the two meet. The user is not being asked to be believed; they are being asked which of the bindings they might own to check, and they can only pass the check for one they actually hold.
+
+1. A client MUST NOT accept a handle supplied by the user without the comparison in path 3. A handle typed into a field and displayed unchecked is not identity, it is a nickname the user chose, and where other users can see it, it is impersonation with an extra step.
+2. A client MUST NOT present an unverified handle in any surface where a verified one would appear, per the display rules of section 2.4.
+3. A client MUST repeat the key-change check of section 4.4 on every subsequent session. A binding verified once is not verified thereafter.
+4. **No path is free of network traffic, and the document should not pretend otherwise.** Verifying per section 4.1 means fetching the manifest at `fields.domain` to check the certifier key, and performing the revocation check of section 4.2 against an overlay or index service at the freshness that section requires. Path 1 therefore makes at least two requests, and the revocation query identifies to whoever answers it which certificate is being checked.
+5. What paths 1 and 2 avoid is telling the ecosystem host that this application is asking about this user. No handle and no key is sent to it, and the verification traffic is the same traffic any resolution already performs. Path 3 additionally discloses the handle to its own host, which already knows it. None of the three discloses the user's key to a party that did not already hold it.
+6. A client SHOULD reuse a cached manifest within the bounds of section 5.4 and a cached revocation result within the bounds of section 4.2, so that repeating section 5.8 across a session does not repeat its traffic.
+
+#### 5.9 Primary designation
+
+A key may hold several bindings: one per ecosystem, or several within one, and section 2.5 contemplates organisations, machines and agents that will hold many. Section 5.8 will therefore often return a set, and an application showing one of them has to decide which.
+
+That decision belongs to the holder, so it is expressed as a **self-issued** [BRC-52](./0052.md) certificate held in the wallet alongside the handle certificates. A worked example, with a real signature and the negative vector, is in Appendix A.9.
+
+| Certificate element | Value |
+| --- | --- |
+| `type` | The primary-designation type identifier of section 4.5 |
+| `subject` | The holder's identity key |
+| `certifier` | The same key. The holder certifies their own preference; nobody else has standing to |
+| `fields.handle` | The normalized handle, without tag and without domain, exactly as in section 4.1 |
+| `fields.domain` | The ecosystem's domain, exactly as in section 4.1 |
+| `revocationOutpoint` | The disabled sentinel, or an outpoint the holder spends to withdraw the designation |
+
+1. A designation is a **preference, not an attestation**. It says which binding the holder wants shown first. It says nothing about whether that binding is valid, and it MUST NOT contribute to any indication that an identity is verified.
+2. A client MUST ignore a designation naming a handle that is not among the bindings it verified in section 5.8. A self-signed statement about a binding the holder does not hold is worth exactly nothing, and honouring it would let a wallet display any handle it liked.
+3. Where a valid designation names a verified binding, a client MAY present that binding alone.
+4. Where none is present, a client **MUST NOT** select one silently, by ordering, by recency, or by any heuristic of its own, and SHOULD present the set and let the user choose. Which name a person goes by is not an inference a client is entitled to make. The prohibition is the requirement; presenting a chooser is how an interactive client satisfies it, and a non-interactive one satisfies it by carrying the set forward or by declining to display a handle at all.
+5. The designation is set in the wallet, by the user. An application MUST NOT write one, and a wallet MUST NOT derive one from application behaviour.
+6. A designation names a binding, not a presentation of one. `fields.handle` MUST carry the handle with any `+tag` stripped, as resolution does per section 5.7 rule 1. A tag selects a delivery context under section 3 and has no bearing on which binding a holder wants shown.
+7. The two field names are those of section 4.1 deliberately: a client holding a certificate of either type reads the binding out of the same two fields, and does not have to know the type before it can parse them.
+8. Because `subject` and `certifier` are the same key, the [BRC-52](./0052.md) signing parameters apply unchanged with the holder as certifier, and the holder is also the only party able to decrypt the field values. A verifier checks the signature against `certifier` exactly as it would for any other certificate.
+
+#### 5.10 Reverse resolution
+
+Reverse resolution answers the third-party question: given an identity key, which handles does it hold? It is OPTIONAL, and a host offering it MUST advertise it in `metanet.handles.reverse`. Clients MUST NOT probe for it otherwise.
+
+```
+GET <reverse>?identityKey=<66-character compressed hex>
+```
+
+```json
+{
+  "metanetHandles": "1.0",
+  "identityKey": "02a1b2c3...",
+  "results": [
+    {
+      "handle": "deggen",
+      "domain": "lkup.net",
+      "certificate": { "...": "the BRC-52 handle certificate of section 4.1" }
+    }
+  ]
+}
+```
+
+1. Every result MUST carry its certificate, and a client MUST verify each per section 4.1 before relying on it. A reverse response is a claim by the host about its own registrations; the certificate is what makes it checkable.
+2. A host MUST return only bindings it issued. There is no federated reverse index and no global one, for the reason section 5.6.4 gives about search.
+3. Hosts MAY require [BRC-104](./0104.md) authentication, apply rate limits, and monetize the endpoint per [BRC-105](../payments/0105.md). Clients MUST handle `429` and `503` per section 5.3.
+4. A client that can answer through section 5.8 path 1 or 2 MUST NOT use reverse resolution for the connected user's own handle. The wallet already holds the answer and asking the host instead discloses a query for no benefit.
+5. `identityKey` MUST be the normalized 66-character compressed form. A host MUST answer a malformed key with the error shape of section 5.3 rather than treating it as a handle.
+
+**Discoverability is on by default, and the holder turns it off.** A handle exists to be addressed, and a binding that cannot be found from either end is a worse address than one that can. So a host MUST treat a binding as reverse-discoverable unless its holder has said otherwise, and the holder says so with a signed directive, in the manner of the forwarding record of section 4.3 and for the same reason: a host MUST NOT be able to fabricate either the hiding or the exposing of a binding it did not author.
+
+| Field | Value |
+| --- | --- |
+| `handle`, `domain` | The binding this directive governs |
+| `discoverable` | `true` or `false` |
+| `created` | ISO-8601 UTC timestamp |
+| `signature` | DER-encoded ECDSA signature by the identity key that is the `subject` of that binding's certificate, over `SHA-256` of the UTF-8 encoding of `handle`, `domain`, `discoverable` as `true` or `false`, and `created`, in that order, each terminated by a single `LF` (`%x0A`) |
+
+6. A host MUST honour the most recent valid directive it holds for a binding, and MUST reject one whose signature does not verify against the current subject key.
+7. A host MUST omit a binding marked `discoverable: false` from every reverse response, and MUST NOT indicate that it withheld one. A response distinguishing "no such key" from "this key asked not to be found" answers the question it was refusing to answer.
+8. **The control is the user's and it lives in their wallet.** A wallet offering handles SHOULD expose the setting per binding, and it is the wallet that signs the directive and delivers it to the host. A host MUST NOT set discoverability on a holder's behalf, and MUST NOT make registration conditional on a particular value.
+9. Withdrawing discoverability does not unpublish anything. A party that resolved the binding while it was discoverable retains what it learned, and section 4.3's forwarding records and the address books of section 10 are unaffected. The directive governs the endpoint, not the past.
 
 ### 6. Payments
 
@@ -631,7 +733,7 @@ Reassigning a role is a revocation followed by a fresh delegation. Organisation 
    2. Where it is unattributed, the **claim itself MUST still be shown**. An anonymous count is a rumour with a number on it; an anonymous reason is something the subject can answer and a reader can weigh.
    3. A client MUST NOT let a negative statement contribute to any indication that an identity is unverified, exactly as rule 6 forbids the positive case. Both are opinions about a person; verification is arithmetic about a key.
    4. Attributed and unattributed statements MUST be visually distinguishable, and a client MUST NOT imply that an unattributed one is attributable on request when it is not.
-8. **Attestations MUST be discoverable, not merely publishable.** Rules 3 to 7 say how a peer statement is made and what it means, and say nothing about how a third party finds the statements made *about* a handle. That is the half a relying party actually needs: a client asking "who has vouched for this identity" has no endpoint to ask. An ecosystem SHOULD answer that question for its own handles, at the resolution endpoint of section 5.7, as a list of attestation outpoints with their certifiers. Until an ecosystem does, any mechanism built on this section — including the access gates of [BRC-190](../apps/0190.md) — can be evaluated only by a party that already holds the attestations, which is to say by nobody who needed to ask.
+8. **Attestations MUST be discoverable, not merely publishable.** Rules 3 to 7 say how a peer statement is made and what it means, and say nothing about how a third party finds the statements made *about* a handle. That is the half a relying party actually needs: a client asking "who has vouched for this identity" has no endpoint to ask. An ecosystem SHOULD answer that question for its own handles, at the resolution endpoint of section 5.7, as a list of attestation outpoints with their certifiers. Until an ecosystem does, any mechanism built on this section — including the access gates of [BRC-146](../apps/0146.md) — can be evaluated only by a party that already holds the attestations, which is to say by nobody who needed to ask.
 9. Because organisations resolve identically to users, the address book doubles as a business directory.
 
 ## Security Considerations
@@ -650,6 +752,12 @@ Reassigning a role is a revocation followed by a fresh delegation. Organisation 
 
 **Alias squatting is a denial of service on the ergonomic layer.** Anyone can publish a signed advertisement claiming any alias. The bidirectional check of section 5.5 prevents binding an alias to a non-consenting domain, and the first-confirmed ordering rule prevents an attacker from permanently disabling an alias by manufacturing a conflict. What remains is a land grab: the first party to advertise a desirable alias holds it. Fully-qualified domains are unaffected, always work, and are what clients fall back to. No value should ever depend on an alias resolving a particular way.
 
+**Reverse resolution attaches a name to a key.** Section 5.10 lets anybody holding an identity key ask which handles it holds, and a key is not a secret: it appears in [BRC-29](../payments/0029.md) remittance, in certificates, and wherever the holder has ever authenticated. Forward resolution has always let somebody who knew a handle learn the key; reverse resolution completes the loop, so a key seen once in a payment becomes a human-readable name. That is what an addressing system is for, and it is also a deanonymisation surface, which is why the directive of section 5.10 exists and why [BRC-228](../payments/0228.md) exists for payers who want neither direction to apply to them. Holders keeping separate handles to keep separate contexts apart SHOULD understand that a shared identity key defeats the separation from the reverse side, and SHOULD use distinct keys rather than distinct handles where the separation matters.
+
+**A wallet that keeps the fields and discards the signature has kept nothing.** Section 4.6 rule 2 exists because the failure looks like a sensible optimisation from inside a wallet, and because its consequences appear somewhere else entirely: an application can then only learn the handle by asking the user, and can only believe the answer by trusting them. The verified claim of section 5.8 path 3 is the repair, and it works precisely because it does not require trusting the user. Where an ecosystem's wallets do not yet satisfy section 4.6, path 3 is the whole of what an application can do, and an application MUST NOT respond by accepting an unchecked handle instead.
+
+**An origin allowlist on the certificate surface is a security decision taken from the user.** [BRC-116](../wallet/0116.md) already governs which application reads which certificate fields, with the user deciding and the decision revocable. A vendor allowlist over the top is neither, and it fails without a diagnosable error for every application not on it. Section 4.6 rules 4 and 5 forbid it, and single out the allowlist that includes a development origin, because that shape passes every local test and fails on deployment, which is the most expensive moment to discover it.
+
 **Toll griefing.** Without the quote mechanism of section 8.3 a recipient could raise a toll after a sender committed to paying it, and retain the payment of a rejected envelope. The binding-quote rule and the delivery invariant close this. Implementations that accept unbroadcast payments but reject the envelope while internalizing anyway are extracting funds for undelivered messages, and violate section 8.3.2. Senders should prefer quoted sends to unquoted ones with any counterparty they do not already trust.
 
 **Tags are sender-controlled.** A tag asserts nothing. See section 3.3.2. Filter rules keyed on tags are a convenience and must not be load-bearing for security.
@@ -666,6 +774,7 @@ Reassigning a role is a revocation followed by a fresh delegation. Organisation 
 
 ## Implementations
 
+- **No deployed wallet is known to satisfy section 4.6 at the time of writing.** A survey of one production implementation found the handle certificate discarded at claim time in favour of a local record of the handle and identity key, leaving `listCertificates` with nothing to return, and the wallet's own accessor for the handle restricted by an origin allowlist. Section 4.6 was written from that finding. Until wallets store the certificate, section 5.8 path 3 is the only path that returns anything, which is why it is specified rather than left to each application to improvise.
 - At the time of writing the authors operate a resolution stack in which an identity overlay resolves a handle to an identity key and a second lookup resolves that key to a messagebox URL. This document restructures that flow around domain-hosted resolution: the domain named in the handle answers directly for the identity key, the attestation, and the messagebox, removing the overlay indirection for the common case. The overlay retains one narrow role, the registry-free alias advertisements of section 5.5.
 - The payment and messaging legs are implementable today with the reference `@bsv/sdk` and `@bsv/wallet-toolbox` stacks. BRC-42 and BRC-43 derivation, BRC-29 envelopes, Atomic BEEF serialization, BRC-33 messagebox relays, BRC-48 PushDrop tokens, overlay topic managers and lookup services, and BRC-100 `internalizeAction` are all shipping components. What this document adds is the addressing grammar, the manifest and endpoint contracts, the attestation rules, and the enforcement invariants that bind them together.
 - The smallest useful conforming implementation is a host that publishes `metanet.handles` with a `resolve` endpoint and issues handle certificates, plus a client that performs section 5.7 and section 6.1. Aliases, search, tolls, and delegation are each independently optional and can be added later without breaking that core.
@@ -695,7 +804,7 @@ Reassigning a role is a revocation followed by a fresh delegation. Organisation 
 - [BRC-104: HTTP Transport for BRC-103 Mutual Authentication](./0104.md)
 - [BRC-105: HTTP Service Monetization Framework](../payments/0105.md)
 - [BRC-125: PeerPay URI Scheme for BRC-29 Payments](../payments/0125.md)
-- [BRC-190: Access Gates for Metanet Rooms](../apps/0190.md)
+- [BRC-146: Access Gates for Metanet Rooms](../apps/0146.md)
 - [BRC-218: Chat-Native Command Grammar for the Metanet](../apps/0218.md)
 - [WhatsOnChain Exchange Rate API](https://docs.whatsonchain.com/exchange-rate)
 - [RFC 1123: Requirements for Internet Hosts](https://www.rfc-editor.org/rfc/rfc1123)
@@ -912,3 +1021,50 @@ The preimage is the four values, each followed by `LF`:
 ```
 
 Critically, this verifies against `0359c5f3...`, the **old** identity key from A.1, and not against the `lkup.net` certifier key. A host cannot forge a redirect for a handle it controls, which is the property section 4.3 requires. A client following this record must also apply section 4.4, since the identity key has changed.
+
+### A.9 A primary designation
+
+Section 5.9, for the case where one key holds several bindings and the holder has said which to show. It is a self-issued certificate: `subject` and `certifier` are both the holder's key from A.1, because nobody else has standing to state a preference on their behalf.
+
+```json
+{
+  "type": "myjPvkwiyYPEpN5LrLLePQFYA7R6ES8TqTFGOAYg/V0=",
+  "serialNumber": "DA8Z3oo7v6EkYt1LPcFUuZgEpNbrrtGaQyzgI60ZO3E=",
+  "subject": "0359c5f3bfe249f6c0ca99d0e9cc1517da51a511f3d04f18e47a5d7ae55f04008c",
+  "certifier": "0359c5f3bfe249f6c0ca99d0e9cc1517da51a511f3d04f18e47a5d7ae55f04008c",
+  "revocationOutpoint": "0000000000000000000000000000000000000000000000000000000000000000.0",
+  "fields": {
+    "domain": "bGt1cC5uZXQ=",
+    "handle": "ZGVnZ2Vu"
+  },
+  "signature": "304402206b208617db1e335d2a1af3fc87250d114e542f46bdf926d8fb0d8d8364433709022056252ff2d9d10b377cefc2e26fa9ce47da840e24031311a21969db8e5be771dc"
+}
+```
+
+`bGt1cC5uZXQ=` decodes to `lkup.net` and `ZGVnZ2Vu` to `deggen`, the same two field names section 4.1 uses, so a client reads the binding out of the same place whichever certificate type it holds.
+
+**Signature preimage.** `CertificateBinary` with `includeSignature = false`:
+
+```
+9b28cfbe4c22c983c4a4de4bacb2de3d015803b47a112f13a93146380620fd5d
+0c0f19de8a3bbfa12462dd4b3dc154b99804a4d6ebaed19a432ce023ad193b71
+0359c5f3bfe249f6c0ca99d0e9cc1517da51a511f3d04f18e47a5d7ae55f0400
+8c0359c5f3bfe249f6c0ca99d0e9cc1517da51a511f3d04f18e47a5d7ae55f04
+008c000000000000000000000000000000000000000000000000000000000000
+0000000206646f6d61696e0c62477431634335755a58513d0668616e646c6508
+5a47566e5a325675
+```
+
+**Signing key.** The invoice number is formed exactly as in A.3, with the designation type in place of the handle-certificate type:
+
+```
+2-certificate signature-myjPvkwiyYPEpN5LrLLePQFYA7R6ES8TqTFGOAYg/V0= DA8Z3oo7v6EkYt1LPcFUuZgEpNbrrtGaQyzgI60ZO3E=
+```
+
+The point of printing this section is that `subject` and `certifier` are the same key and nothing about BRC-52 changes. The holder computes `holderPriv * G`; a verifier computes `1 * holderPub`; both equal the holder's public key, and the derived signing key is:
+
+```
+03c5d4b0f37d3f329b0003eeefe606191e843e38f62c1ce08c0a72f3f49bb94842
+```
+
+**What it does not prove.** Substitute `brandon` for `deggen` in `fields.handle`, leave the signature alone, and verification fails, so a designation cannot be edited after signing. But a designation that verifies still says nothing about whether the binding it names is valid: it is signed by the holder, about the holder's own preference, and a holder can sign a preference for a handle they do not hold. That is why section 5.9 rule 2 requires a client to discard any designation naming a binding it has not independently verified through section 5.8. The signature proves authorship. Section 5.8 proves the binding.


### PR DESCRIPTION
Found while implementing BRC-169 handle support in [Free Radio](https://freeradio.bsvb.net/), a live BRC-169 application, against the HandCash registry and HandCash Desktop.

**One note on vehicle before the substance.** The repository README asks that substantial revisions go into a new extending standard rather than an edit, so as not to disrupt existing implementations. I have proposed this as an edit because section 4.6 is a clarification of something section 4.1 already implies rather than a new requirement, and because splitting three tightly coupled sections across two documents would make both harder to read. If you would rather see the new surface in a separate BRC extending 169, say so and I will restructure it: the content transfers unchanged.

## What is missing

**The document runs one way.** Grammar, resolution, caching and the client algorithm all take a handle and return an identity key. An application with a connected wallet has the opposite problem: it holds the key, has proven the user controls it, and wants the handle to show them. Nothing in the document answers that.

**And it defines a certificate without saying where the holder keeps it.** Section 4.1 requires a verifier to check the certificate, and closes by noting that certificates are exchanged and selectively revealed over BRC-103 and BRC-104. Both presuppose the holder still has it. Nothing said so, and no part of the document mentions `acquireCertificate`, `listCertificates`, `proveCertificate` or `relinquishCertificate`.

That gap has a consequence in production. A surveyed wallet performs forward resolution and claiming correctly, then stores `{handle, display, identityKey, claimedAt}` in its own storage and discards the certificate, so `listCertificates` has nothing to return. That record is not an attestation: it is the wallet's own unsigned claim about itself, it survives the spending of the revocation outpoint, and no third party can check it. Keeping the fields and dropping the signature keeps the part that is easy to fabricate.

The same wallet does expose the handle, through a vendor method restricted by an origin allowlist. The allowlist includes `localhost`, so an integration passes in development and returns 403 on deployment, which is the most expensive moment to find out.

I want to be clear that none of this is a criticism of that implementation. It satisfies every explicit MUST in section 4.1. The specification did not tell it where to put the certificate, so it put it nowhere.

## What this adds

**Section 4.6, custody.** The certificate is stored through BRC-100 `acquireCertificate`, relinquished on release per 4.3, and MUST NOT be replaced by a derived summary. A wallet MUST NOT expose handle data through a vendor method in place of the certificate surface, and MUST NOT gate that surface by origin allowlist: BRC-116 section 4.4 already permissions certificate access with the user deciding and the decision revocable, and an allowlist replaces that with the vendor's judgement while failing undiagnosably for anybody not on it. An allowlist containing a development origin is called out specifically.

**Section 5.8, the connected user's own handle.** Three paths, in order, stopping at the first that yields a verified binding:

1. `listCertificates` for the handle type, verified per 4.1 including `subject` equal to the key proven in session. No network, no disclosure. Works wherever 4.6 is satisfied.
2. `discoverByIdentityKey`.
3. The user supplies a handle; the client forward-resolves it per 5.7 and compares `identityKey` against the proven key, accepting only on exact match.

Path 3 is **verification, not trust**, and that distinction is why it is permitted rather than tolerated: the registry attests the binding, the challenge signature proves the key, and the client checks the two meet. The user is not asked to be believed. A new rule forbids the thing it replaces: a handle typed into a field and displayed unchecked is not identity, and where others can see it, it is impersonation with an extra step. Nothing in the document previously ruled that out.

**Section 5.9, primary designation.** A key may hold several bindings, and section 2.5 already contemplates organisations, machines and agents holding many. Which one to show is the holder's decision, expressed as a self-issued BRC-52 certificate with `subject` and `certifier` both the holder's key. It is a preference and not an attestation, MUST be ignored unless it names a binding the client independently verified, and where none is set the client presents the set and MUST NOT choose silently. A third derived type identifier is added to section 4.5 by the same construction as the existing two.

**Section 5.10, reverse resolution.** An optional endpoint advertised as `metanet.handles.reverse`, returning bindings with their certificates for a given key. **Discoverable by default**, because a handle exists to be addressed and a binding findable from only one end is a worse address. A holder opts out with a directive signed by the subject key, in the manner of the forwarding record of 4.3 and for the same reason: a host must not be able to fabricate either the hiding or the exposing of a binding it did not author. The control sits in the wallet, with the user. A host must not indicate that it withheld a result, since a response distinguishing "no such key" from "this key asked not to be found" answers the question it was refusing to answer.

## Security Considerations

Three paragraphs added: that reverse resolution completes the loop and turns a key seen in a payment into a human-readable name, with BRC-228 named for payers who want neither direction; that a wallet keeping the fields and discarding the signature has kept nothing; and that an origin allowlist over the certificate surface is a security decision taken away from the user.

## Also in this diff

Two stale links, flagged separately so they are not mistaken for part of the feature: BRC-190 was renumbered to BRC-146 on merge and this document still pointed at `../apps/0190.md`, which does not exist. One body reference and one References entry.

## Verification

`verify_appendix.py` still passes in full. No existing normative text was altered, no vector changed, and the three derived type identifiers reproduce from their strings. The new one is `base64(SHA-256("metanet-handles primary designation v1"))` = `myjPvkwiyYPEpN5LrLLePQFYA7R6ES8TqTFGOAYg/V0=`.

Existing implementations are unaffected in the forward direction. Section 4.6 does make a wallet that discards the certificate non-conforming, which is the point of raising it, and section 5.8 path 3 exists precisely so applications have a correct path to ship while wallets catch up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
