### PR TITLE
docs(tokens): draft BRC-165 P1Sat permission scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ BRC | Standard
 159  | [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 160  | [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
 164  | [Output Identity Tags for BRC-100 Wallets](./wallet/0164.md)
+165  | [P1Sat Permission Scheme for Basket `1sat`](./tokens/0165.md)
 168  | [Verifiable Time Allocation](./apps/0168.md)
 169  | [Universal Handle Addressing and Resolution for the Metanet](./peer-to-peer/0169.md)
 210  | [Derived Collectibles](./apps/0210.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -120,6 +120,7 @@
 * [1Sat Provenance Remittance for Basket `1sat`](./tokens/0150.md)
 * [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 * [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
+* [P1Sat Permission Scheme for Basket `1sat`](./tokens/0165.md)
 * [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)
 
 ## Overlays

--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -113,7 +113,7 @@ When present for basket `1sat`, `customInstructions` MUST be a **UTF-8 JSON obje
 | `origin` | string | SHOULD | Claimed origin outpoint (**MUST** underscore form when written). |
 | `content` | string | SHOULD when known for derivatives | Shared **media** outpoint (**MUST** underscore form when written). Used when this tip’s own origin envelope is a reference (e.g. [BRC-160](./0160.md) field 3 parent, or a `text/uri-list` / `ord://` / OrdFS `/content/<outpoint>` body) so receivers can load the one on-chain body without an indexer. |
 | `name` | string | SHOULD when known | Display name (case-preserving). Preferred over a `name:` tag. |
-| `app` | string | MAY | Application / creator id (may mirror an `app:` tag for display). |
+| `app` | string | MAY | Application id (may mirror an `app:` tag for display). Distinct from tag `creator:`. |
 | `provenance` | object | SHOULD on transfer when available | Provenance remittance; v2 in [BRC-150](./0150.md). |
 
 Additional JSON keys are permitted and MUST be ignored by readers that do not understand them. Readers that do not understand `provenance` or `content` MUST still store and forward the entire string unchanged ([BRC-37](../outpoints/0037.md)). Spend-derivation fields a wallet uses only for its own unlock (`protocolID`, `keyID`, `counterparty`, …) MAY appear in the same object; they are not part of this profile’s display / provenance contract and MUST NOT be required of receivers.

--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -67,8 +67,8 @@ Rules:
 
 * **Origin tag** — One tag, two forms:
   * bare `origin` — this output **is** the origin (mint / chain start).
-  * `origin:<outpoint>` — this output is a later tip; `<outpoint>` is the chain origin (`dot` or `underscore` form; readers MUST treat both as the same outpoint per [Outpoint encoding](#outpoint-encoding)).
-  * On self-keep transfer or re-file: if the source has `origin:<outpoint>`, copy that tag unchanged; if the source has bare `origin`, the spent outpoint **is** the origin — write `origin:<spent outpoint>` on the new output.
+  * `origin:<outpoint>` — this output is a later tip; `<outpoint>` is the chain origin in **underscore** form (writers MUST; readers MUST still accept and normalize either form per [Outpoint encoding](#outpoint-encoding)).
+  * On self-keep transfer or re-file: if the source has `origin:<outpoint>`, copy that tag **after normalizing the value to underscore form**; if the source has bare `origin`, the spent outpoint **is** the origin — write `origin:<spent outpoint>` in underscore form on the new output.
   * The origin tag is a wallet **claim**, not proof of chain membership ([BRC-150](./0150.md)).
 * **`type:`** — Describes the origin inscription’s content type, not whatever the current tip’s locking script contains. Self-keep transfers SHOULD copy `type:…` forward with the origin claim rather than re-deriving it from a bare transfer output. Tag matching is exact; there is no prefix or wildcard form.
 * **Wallet-local list keys** — Ordinary `id:<key>` tags (stable per-row handles for `listOutputs`) are defined by **BRC-164**, not by this profile. Conforming `1sat` writers MAY stamp `id:` when they adopt that convention. This profile MUST NOT treat `id:` as origin, media, collection, or global asset identity. Receivers MUST ignore a counterparty-supplied `id:` and stamp their own if they adopt BRC-164.
@@ -110,8 +110,8 @@ When present for basket `1sat`, `customInstructions` MUST be a **UTF-8 JSON obje
 
 | Field | Type | Requirement | Meaning |
 |-------|------|-------------|---------|
-| `origin` | string | SHOULD | Claimed origin outpoint (underscore form preferred). |
-| `content` | string | SHOULD when known for derivatives | Shared **media** outpoint (underscore form preferred). Used when this tip’s own origin envelope is a reference (e.g. [BRC-160](./0160.md) field 3 parent, or a `text/uri-list` / `ord://` / OrdFS `/content/<outpoint>` body) so receivers can load the one on-chain body without an indexer. |
+| `origin` | string | SHOULD | Claimed origin outpoint (**MUST** underscore form when written). |
+| `content` | string | SHOULD when known for derivatives | Shared **media** outpoint (**MUST** underscore form when written). Used when this tip’s own origin envelope is a reference (e.g. [BRC-160](./0160.md) field 3 parent, or a `text/uri-list` / `ord://` / OrdFS `/content/<outpoint>` body) so receivers can load the one on-chain body without an indexer. |
 | `name` | string | SHOULD when known | Display name (case-preserving). Preferred over a `name:` tag. |
 | `app` | string | MAY | Application / creator id (may mirror an `app:` tag for display). |
 | `provenance` | object | SHOULD on transfer when available | Provenance remittance; v2 in [BRC-150](./0150.md). |
@@ -167,7 +167,7 @@ Example (non-normative shape):
     "satoshis": 1,
     "outputDescription": "Collectable transfer",
     "basket": "1sat",
-    "tags": ["ordinal", "origin:<txid.vout>", "type:image/png"],
+    "tags": ["ordinal", "origin:<txid_vout>", "type:image/png"],
     "customInstructions": "{\"origin\":\"<txid_vout>\",\"name\":\"Example\",\"provenance\":{}}"
   }]
 }
@@ -189,7 +189,7 @@ To place an existing tip into basket `1sat`, use BRC-100 `internalizeAction` wit
     "protocol": "basket insertion",
     "insertionRemittance": {
       "basket": "1sat",
-      "tags": ["ordinal", "origin:<txid.vout>", "type:image/png"],
+      "tags": ["ordinal", "origin:<txid_vout>", "type:image/png"],
       "customInstructions": "{\"origin\":\"<txid_vout>\",\"name\":\"Example\"}"
     }
   }]

--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -46,7 +46,7 @@ Outputs that fail eligibility MAY still appear if a buggy sender used the basket
 * BRC-100 wire `outpoint` fields use **dot** form: `txid.vout` (see BRC-100 / [BRC-36](../outpoints/0036.md) practice).
 * 1Sat Ordinals / OrdFS commonly use **underscore** form: `txid_vout`.
 * Conforming implementations MUST treat `txid.vout` and `txid_vout` as the same outpoint when `txid` is 64 hex chars and `vout` is a non-negative decimal integer.
-* Inside this profile’s `customInstructions` object, `origin` SHOULD use underscore form for consistency with 1Sat indexers. Tags MAY use either form after the `origin:` prefix; readers MUST normalize before comparison.
+* Inside this profile’s `customInstructions` object, `origin` and `content` MUST use underscore form. Tag values for `origin:`, `content:`, and `collection:` (when the value is an outpoint) MUST use underscore form. Readers MUST normalize before comparison.
 
 ### Tags
 
@@ -59,9 +59,9 @@ Tags are optional BRC-46 / BRC-100 output tags used for filtering and display hi
 | `content:<outpoint>` | SHOULD when the tip is a derivative / reference inscription | Shared media outpoint for display (see `content` below). |
 | `type:<type>/<subtype>` | SHOULD when the content type is known | IANA media type of the **origin** inscription (envelope content-type), with parameters removed — the substring before the first `;` (e.g. `type:image/png` from `image/png; charset=binary`). |
 | `name:<string>` | MAY (legacy) | Short display name in a tag. New writers SHOULD put display name in `customInstructions` instead (see [Tags vs customInstructions](#tags-vs-custominstructions)). If written, implementations SHOULD truncate to ≤ 80 UTF-8 code units. |
-| `app:<string>` | MAY | Application / creator id for filtering (SHOULD truncate to ≤ 40). |
-| `collection:<id>` / `collectionId:<id>` | MAY | Collection filter keys (synonyms). |
-| `creator:<id>` / `author:<id>` | MAY | Creator filter keys (synonyms of / complements to `app:`). |
+| `app:<string>` | MAY | Application id for filtering (SHOULD truncate to ≤ 40). Distinct from `creator:`. |
+| `collection:<id>` | MAY | Collection id for filtering. |
+| `creator:<id>` | MAY | Creator filter key. Distinct from `app:`. |
 
 Rules:
 
@@ -206,12 +206,12 @@ Spending or revealing `1sat` basket outputs is **not** a [BRC-29](../payments/00
 * Not treat a general “pay” or auto-pay grant as authorization to spend `1sat` tips.
 * Not fund ordinary payment outputs from `1sat` basket UTXOs.
 
-Normative fine-grained asset permission schemes remain [BRC-99](../wallet/0099.md) territory and are out of scope for this profile.
+Normative module-mediated view and spend for basket `1sat` are defined in [BRC-165](./0165.md) and are out of scope for this profile.
 
 ### Compatibility
 
 * Wallets that do not implement this profile MUST still store and forward unknown baskets’ `customInstructions` and tags unchanged ([BRC-37](../outpoints/0037.md)).
-* This profile does not conflict with BRC-99 `p ` baskets; future permission-wrapped variants MAY wrap `1sat` semantics under a `p <scheme> …` name without invalidating this profile for the plain `1sat` basket.
+* This profile does not conflict with BRC-99 `p ` baskets. [BRC-165](./0165.md) defines scheme `1sat` view/spend routing without changing this profile’s storage basket name.
 * Marketplaces (e.g. OrdLock), BSV-20/21, and mint APIs are out of scope.
 
 ## Security considerations
@@ -239,4 +239,5 @@ Normative fine-grained asset permission schemes remain [BRC-99](../wallet/0099.m
 9. [BRC-150](./0150.md) — 1Sat Provenance Remittance for Basket `1sat`
 10. [BRC-160](./0160.md) — 1Sat Ordinals — Inscription Envelopes
 11. BRC-164 — Output Identity Tags for BRC-100 Wallets (`id:` list keys; not defined by this profile)
-12. 1Sat reference inscriptions — <https://docs.1satordinals.com/reference-inscriptions>
+12. [BRC-165](./0165.md) — P1Sat Permission Scheme for Basket `1sat`
+13. 1Sat reference inscriptions — <https://docs.1satordinals.com/reference-inscriptions>

--- a/tokens/0165.md
+++ b/tokens/0165.md
@@ -41,7 +41,7 @@ This scheme also claims the [BRC-98](../wallet/0098.md) protocol name **`p 1sat`
 ### Scheme identifier
 
 * **Scheme id:** `1sat` (no spaces; matches [BRC-123](../wallet/0123.md) id rules)
-* **BRC-98 protocol:** `[0, "p 1sat"]` (level 0; see [Module detection](#module-detection))
+* **BRC-98 probe protocol:** `[0, "p 1sat probe"]` (level 0; see [Module detection](#module-detection))
 * **BRC-99 basket form (view):** `p 1sat <scope>` (scope required; see [Scopes](#scopes))
 * **BRC-111 label form (spend):** `p 1sat input id <key>` (`<key>` = bare [BRC-164](../wallet/0164.md) list key)
 
@@ -49,13 +49,13 @@ Wallets that do not implement this scheme MUST reject operations under these ide
 
 ### Module detection
 
-Applications MAY detect whether scheme `1sat` is available by probing the [BRC-98](../wallet/0098.md) protocol this BRC claims.
+Applications MAY detect whether scheme `1sat` is available by probing a [BRC-98](../wallet/0098.md) protocol under this scheme. Per BRC-98, protocol names are `p <scheme-id> <rest>`; the rest token for this probe is **`probe`**.
 
 **Probe (application behavior):** call BRC-100 `getPublicKey` with:
 
 ```json
 {
-  "protocolID": [0, "p 1sat"],
+  "protocolID": [0, "p 1sat probe"],
   "keyID": "1sat-module-probe",
   "counterparty": "self",
   "seekPermission": false
@@ -64,8 +64,8 @@ Applications MAY detect whether scheme `1sat` is available by probing the [BRC-9
 
 Notes:
 
-* **Protocol claim:** security level **0**, protocol name **`p 1sat`**. Level 0 keeps the probe outside ordinary Level 1/2 protocol-permission UX when the wallet routes it to this scheme’s module ([BRC-43](../key-derivation/0043.md), [BRC-116](../wallet/0116.md)).
-* **Wallet behavior** for supported vs unsupported `p …` protocols and baskets is already defined by [BRC-98](../wallet/0098.md), [BRC-99](../wallet/0099.md), and [BRC-116](../wallet/0116.md) (route to a registered module, or reject if the scheme is not supported). This BRC does not alter those rules.
+* **Protocol claim:** security level **0**, protocol name **`p 1sat probe`**. Level 0 keeps the probe outside ordinary Level 1/2 protocol-permission UX when the wallet routes it to this scheme’s module ([BRC-43](../key-derivation/0043.md), [BRC-116](../wallet/0116.md)).
+* **Wallet behavior** for supported vs unsupported `p …` protocols and baskets is already defined by [BRC-98](../wallet/0098.md), [BRC-99](../wallet/0099.md), and [BRC-116](../wallet/0116.md) (route to a registered module by scheme id `1sat`, or reject if the scheme is not supported). This BRC does not alter those rules.
 * **Conforming module:** when the wallet routes this `getPublicKey` to the `1sat` module, the module SHOULD pass the request through (return a public key) so the probe succeeds without a user prompt.
 * **`keyID`:** `1sat-module-probe` is RECOMMENDED for interoperability among probers; it is not a special wallet-reserved id beyond ordinary BRC-43 key-id rules.
 * **`seekPermission: false`:** RECOMMENDED so capability detection does not open a permission UI.

--- a/tokens/0165.md
+++ b/tokens/0165.md
@@ -5,7 +5,7 @@ Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
 ## Abstract
 
-This BRC defines the **P1Sat** basket permission scheme for [BRC-100](../wallet/0100.md) wallets: scheme id **`1sat`** under [BRC-99](../wallet/0099.md) / [BRC-123](../wallet/0123.md).
+This BRC defines the **P1Sat** basket permission scheme for [BRC-100](../wallet/0100.md) wallets: scheme id **`1sat`** under [BRC-99](../wallet/0099.md) / [BRC-116](../wallet/0116.md).
 
 Storage of collectables remains the plain basket **`1sat`** ([BRC-147](./0147.md)). Applications request **view** access with a [BRC-99](../wallet/0099.md) basket `p 1sat <scope>` (scope names the **permission axis**; filter **values** ride ordinary `tags`). Applications request **spend** authorization by labeling `createAction` with `p 1sat input id <key>`, where `<key>` is the bare [BRC-164](../wallet/0164.md) list key for the held row. Conforming wallets route those requests to a scheme module, normalize storage to `1sat` where needed, apply view grants and per-action spend approval as specified below, and MUST NOT treat payment / auto-pay grants as item access.
 
@@ -15,7 +15,7 @@ This document does **not** redefine 1Sat chain theory, inscriptions, collections
 
 Plain [BRC-46](../wallet/0046.md) baskets only support coarse grant/deny. Collectables need finer app access — one collection, one app, one creator, or the full inventory — without inventing a storage basket per filter and without forcing inventory to live under a `p …` name.
 
-[BRC-99](../wallet/0099.md) reserves `p <scheme> …` for richer permission modules. This BRC registers scheme id `1sat` and separates storage from permission routing:
+[BRC-99](../wallet/0099.md) reserves `p <scheme> …` for richer permission modules. This BRC defines scheme id `1sat` and separates storage from permission routing:
 
 | Layer | Law |
 |-------|-----|
@@ -26,21 +26,20 @@ Plain [BRC-46](../wallet/0046.md) baskets only support coarse grant/deny. Collec
 
 ## Basket Namespace
 
-Per [BRC-123](../wallet/0123.md) §3.2:
+1. **Scheme ID:** `1sat` (no spaces; [BRC-99](../wallet/0099.md))
+2. **Basket name format:** `p 1sat <scope>` where `<scope>` is a fixed axis token from [Scopes](#scopes) (required). Basket names use only `[a-z0-9 ]` per [BRC-100](../wallet/0100.md). Filter **values** are not part of the basket name.
+3. **Wallet capability:** Must implement storage basket `1sat` per [BRC-147](./0147.md); must route `p 1sat …` basket operations and `p 1sat input id …` labels to this scheme’s module; must enforce view grants on list and per-action spend approval on labeled spends
+4. **Permission semantics:** See [View](#view-listoutputs) and [Spend](#spend-createaction)
 
-1. **Scheme ID:** `1sat`
-2. **Category:** Category 1 — Asset Permission Scheme
-3. **Basket name format:** `p 1sat <scope>` where `<scope>` is a fixed axis token from [Scopes](#scopes) (required). Basket names use only `[a-z0-9 ]` per [BRC-100](../wallet/0100.md). Filter **values** are not part of the basket name.
-4. **Wallet capability:** Must implement storage basket `1sat` per [BRC-147](./0147.md); must route `p 1sat …` basket operations and `p 1sat input id …` labels to this scheme’s module; must enforce view grants on list and per-action spend approval on labeled spends
-5. **Permission semantics:** See [View](#view-listoutputs) and [Spend](#spend-createaction)
+Module **presence detection** uses the [BRC-98](../wallet/0098.md) protocol **`p 1sat probe`** (security level **0**); see [Module detection](#module-detection). Wallets route by scheme id `1sat` ([BRC-116](../wallet/0116.md)). That probe is not the default key-derivation protocol for new inventory tips. New tip key derivation SHOULD follow [BRC-147](./0147.md) / wallet policy (e.g. plain protocol names such as `onesat`).
 
-This scheme also claims the [BRC-98](../wallet/0098.md) protocol name **`p 1sat`** (security level **0**). That protocol is used for **module presence detection** and module routing — not as the default key-derivation protocol for new inventory tips. New tip key derivation SHOULD follow [BRC-147](./0147.md) / wallet policy (e.g. plain protocol names such as `onesat`) and is not required to use `p 1sat`.
+[BRC-123](../wallet/0123.md) registry listing for this scheme is deferred (current §3.1 letter-first scheme ids do not admit `1sat`).
 
 ## Specification
 
 ### Scheme identifier
 
-* **Scheme id:** `1sat` (no spaces; matches [BRC-123](../wallet/0123.md) id rules)
+* **Scheme id:** `1sat` (no spaces; [BRC-99](../wallet/0099.md))
 * **BRC-98 probe protocol:** `[0, "p 1sat probe"]` (level 0; see [Module detection](#module-detection))
 * **BRC-99 basket form (view):** `p 1sat <scope>` (scope required; see [Scopes](#scopes))
 * **BRC-111 label form (spend):** `p 1sat input id <key>` (`<key>` = bare [BRC-164](../wallet/0164.md) list key)
@@ -263,7 +262,7 @@ Apps MAY still spend by outpoint without a `p 1sat input` label. That path does 
 3. [BRC-100: Wallet Interface](../wallet/0100.md)
 4. [BRC-111: Transaction Labels](../wallet/0111.md)
 5. [BRC-116: Wallet Permissions and Counterparty Trust](../wallet/0116.md)
-6. [BRC-123: Basket Permission Scheme Registry](../wallet/0123.md)
-7. [BRC-147: 1Sat Ordinals Basket Profile](./0147.md)
-8. [BRC-150: 1Sat Provenance Remittance](./0150.md)
-9. [BRC-164: Output Identity Tags](../wallet/0164.md)
+6. [BRC-147: 1Sat Ordinals Basket Profile](./0147.md)
+7. [BRC-150: 1Sat Provenance Remittance](./0150.md)
+8. [BRC-164: Output Identity Tags](../wallet/0164.md)
+9. [BRC-123: Basket Permission Scheme Registry](../wallet/0123.md) (registry listing deferred; see [Basket Namespace](#basket-namespace))

--- a/tokens/0165.md
+++ b/tokens/0165.md
@@ -199,7 +199,7 @@ p 1sat input id a1b2c3d4e5f60708
 
 Multiple such labels MAY appear when the action spends multiple tracked rows. Rows without a BRC-164 `id:` tag cannot use this form.
 
-**Other `input` payloads.** A label `p 1sat input <token>` whose single payload token is not the keyword `id` is outside this scheme’s held-tip permission model (e.g. naming a beefed external input). It is not a BRC-164 list key and is not further specified here. The normative spend path for wallet-held tips remains `p 1sat input id <key>`.
+**Other `input` payloads.** A label `p 1sat input <outpoint>` whose single payload outpoint is not the keyword `id` is outside this scheme’s permission model (e.g. naming a beefed external input). It is not a BRC-164 list key and is not further specified here. The normative spend path for wallet-held tips remains `p 1sat input id <key>`.
 
 #### Module behavior
 

--- a/tokens/0165.md
+++ b/tokens/0165.md
@@ -1,0 +1,269 @@
+# BRC-165: P1Sat Permission Scheme for Basket `1sat`
+
+David Case (david.case@shruggr.cloud)  
+Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
+
+## Abstract
+
+This BRC defines the **P1Sat** basket permission scheme for [BRC-100](../wallet/0100.md) wallets: scheme id **`1sat`** under [BRC-99](../wallet/0099.md) / [BRC-123](../wallet/0123.md).
+
+Storage of collectables remains the plain basket **`1sat`** ([BRC-147](./0147.md)). Applications request **view** access with a [BRC-99](../wallet/0099.md) basket `p 1sat <scope>` (scope names the **permission axis**; filter **values** ride ordinary `tags`). Applications request **spend** authorization by labeling `createAction` with `p 1sat input id <key>`, where `<key>` is the bare [BRC-164](../wallet/0164.md) list key for the held row. Conforming wallets route those requests to a scheme module, normalize storage to `1sat` where needed, apply view grants and per-action spend approval as specified below, and MUST NOT treat payment / auto-pay grants as item access.
+
+This document does **not** redefine 1Sat chain theory, inscriptions, collections, or provenance proofs. It does **not** replace [BRC-147](./0147.md) or retarget [BRC-150](./0150.md).
+
+## Motivation
+
+Plain [BRC-46](../wallet/0046.md) baskets only support coarse grant/deny. Collectables need finer app access — one collection, one app, one creator, or the full inventory — without inventing a storage basket per filter and without forcing inventory to live under a `p …` name.
+
+[BRC-99](../wallet/0099.md) reserves `p <scheme> …` for richer permission modules. This BRC registers scheme id `1sat` and separates storage from permission routing:
+
+| Layer | Law |
+|-------|-----|
+| Storage basket | `1sat` ([BRC-147](./0147.md)) |
+| View (list) | basket `p 1sat <scope>` ([Scopes](#scopes)); axis values in `tags`; other tags only narrow further |
+| Spend | `createAction` labels `p 1sat input id <key>` ([BRC-164](../wallet/0164.md)) |
+| Provenance | [BRC-150](./0150.md) on storage `1sat` |
+
+## Basket Namespace
+
+Per [BRC-123](../wallet/0123.md) §3.2:
+
+1. **Scheme ID:** `1sat`
+2. **Category:** Category 1 — Asset Permission Scheme
+3. **Basket name format:** `p 1sat <scope>` where `<scope>` is a fixed axis token from [Scopes](#scopes) (required). Basket names use only `[a-z0-9 ]` per [BRC-100](../wallet/0100.md). Filter **values** are not part of the basket name.
+4. **Wallet capability:** Must implement storage basket `1sat` per [BRC-147](./0147.md); must route `p 1sat …` basket operations and `p 1sat input id …` labels to this scheme’s module; must enforce view grants on list and per-action spend approval on labeled spends
+5. **Permission semantics:** See [View](#view-listoutputs) and [Spend](#spend-createaction)
+
+This scheme also claims the [BRC-98](../wallet/0098.md) protocol name **`p 1sat`** (security level **0**). That protocol is used for **module presence detection** and module routing — not as the default key-derivation protocol for new inventory tips. New tip key derivation SHOULD follow [BRC-147](./0147.md) / wallet policy (e.g. plain protocol names such as `onesat`) and is not required to use `p 1sat`.
+
+## Specification
+
+### Scheme identifier
+
+* **Scheme id:** `1sat` (no spaces; matches [BRC-123](../wallet/0123.md) id rules)
+* **BRC-98 protocol:** `[0, "p 1sat"]` (level 0; see [Module detection](#module-detection))
+* **BRC-99 basket form (view):** `p 1sat <scope>` (scope required; see [Scopes](#scopes))
+* **BRC-111 label form (spend):** `p 1sat input id <key>` (`<key>` = bare [BRC-164](../wallet/0164.md) list key)
+
+Wallets that do not implement this scheme MUST reject operations under these identifiers per [BRC-99](../wallet/0099.md) / [BRC-98](../wallet/0098.md).
+
+### Module detection
+
+Applications MAY detect whether scheme `1sat` is available by probing the [BRC-98](../wallet/0098.md) protocol this BRC claims.
+
+**Probe (application behavior):** call BRC-100 `getPublicKey` with:
+
+```json
+{
+  "protocolID": [0, "p 1sat"],
+  "keyID": "1sat-module-probe",
+  "counterparty": "self",
+  "seekPermission": false
+}
+```
+
+Notes:
+
+* **Protocol claim:** security level **0**, protocol name **`p 1sat`**. Level 0 keeps the probe outside ordinary Level 1/2 protocol-permission UX when the wallet routes it to this scheme’s module ([BRC-43](../key-derivation/0043.md), [BRC-116](../wallet/0116.md)).
+* **Wallet behavior** for supported vs unsupported `p …` protocols and baskets is already defined by [BRC-98](../wallet/0098.md), [BRC-99](../wallet/0099.md), and [BRC-116](../wallet/0116.md) (route to a registered module, or reject if the scheme is not supported). This BRC does not alter those rules.
+* **Conforming module:** when the wallet routes this `getPublicKey` to the `1sat` module, the module SHOULD pass the request through (return a public key) so the probe succeeds without a user prompt.
+* **`keyID`:** `1sat-module-probe` is RECOMMENDED for interoperability among probers; it is not a special wallet-reserved id beyond ordinary BRC-43 key-id rules.
+* **`seekPermission: false`:** RECOMMENDED so capability detection does not open a permission UI.
+* **Interpretation:** applications treat probe **success** (on a wallet that uses P-module routing) as evidence that scheme `1sat` is registered, and a **BRC-98/99 unsupported-scheme rejection** as evidence it is not. Bare wallets without a permissions manager may not give a reliable signal; applications SHOULD only enable module-mediated labels/baskets when they expect P-module routing.
+
+This probe does **not** grant view or spend rights. It does not change [BRC-111](../wallet/0111.md) label rules; spend labels under this scheme still follow BRC-111’s `p <scheme> <payload>` form as specified in [Spend](#spend-createaction).
+
+### Storage vs permissions
+
+1. Conforming wallets MUST file collectables in storage basket **`1sat`** ([BRC-147](./0147.md)).
+2. Permission basket ids are **`p 1sat <scope>`** only (scope required). They are routing names only; held tips remain in `1sat`.
+3. When a request uses a basket beginning with `p 1sat ` (after BRC-46 trim/lowercase), the wallet MUST:
+   * treat the request as scheme `1sat`;
+   * parse [scope](#scopes) from the basket name (reject if missing or unknown; values are not in the basket name);
+   * require axis tag value(s) on the request when the scope is not `all`;
+   * **normalize** the storage target to basket `1sat`;
+   * apply view permission for that scope and value(s) (prompt or prior grant) before returning outputs;
+   * enforce axis tags as a mandatory filter; other caller tags only narrow further.
+
+### View (`listOutputs`)
+
+#### Scopes
+
+After the scheme prefix `p 1sat`, a **scope is required**. The scope names a **permission axis** only. Filter values are not part of the basket name; they use ordinary output **tags**. The full basket name MUST stay within [BRC-100](../wallet/0100.md) `[a-z0-9 ]`.
+
+| Basket form | Scope | Meaning |
+|-------------|-------|---------|
+| `p 1sat all` | **all** | Entire storage `1sat` |
+| `p 1sat collection` | **collection** | Collection-scoped view; values from `collection:…` tags |
+| `p 1sat app` | **app** | App-scoped view; values from `app:…` tags |
+| `p 1sat creator` | **creator** | Creator-scoped view; values from `creator:…` tags |
+| `p 1sat id` | **id** | Single-row lookup; values from `id:…` tags ([BRC-164](../wallet/0164.md)) |
+
+Rules:
+
+1. Bare `p 1sat` (no scope token) MUST be rejected. Full inventory uses **`p 1sat all`** only.
+2. Scope is exactly one token after `p 1sat` (`all`, `collection`, `app`, `creator`, or `id`). Extra tokens in the basket name MUST be rejected.
+3. Unknown scope tokens MUST be rejected with a clear error (fail closed). Future axes are added by revising this table.
+4. For scopes **collection**, **app**, **creator**, and **id**, the request MUST include at least one tag with the matching prefix (`collection:`, `app:`, `creator:`, `id:`). The tag **value** (after the prefix) is the filter id. For **collection**, the value is a **collection id** per [BRC-147](./0147.md).
+5. For scope **all**, no axis tag is required. Caller tags are optional further filters only.
+6. Matching tags follow [BRC-147](./0147.md) / [BRC-164](../wallet/0164.md). Exact tag equality after normal wallet tag normalization.
+7. Scope **id** is a **targeted lookup**, not full-inventory access. It MUST NOT require grant **all**. Conforming wallets MUST allow `p 1sat id` + `id:<key>` through the module without a prior collection/app/creator/**all** grant (auto-allow this narrow query, or an equivalent one-shot / id-scoped grant). Results MUST still be limited to the requested `id:…` value(s). Spend targeting remains [Spend](#spend-createaction) (`p 1sat input id <key>`), not this scope alone.
+
+#### Request shape
+
+```json
+{
+  "basket": "p 1sat collection",
+  "tags": [
+    "collection:a1b2c3d4e5f6070890abcdef1234567890abcdef1234567890abcdef12345678_0",
+    "type:image/png"
+  ],
+  "tagQueryMode": "all",
+  "includeTags": true,
+  "includeCustomInstructions": true
+}
+```
+
+* **`basket`:** `p 1sat <scope>` as in [Scopes](#scopes) (axis only; scope required).
+* **`tags`:** for non-`all` scopes, MUST include the axis tag(s) carrying the filter value(s). Additional tags (e.g. `type:`) only narrow further.
+* **`tagQueryMode`:** applies to the caller’s tag set as constrained by [Scope ceiling](#scope-ceiling-and-tag-query).
+* Apps MAY still call `listOutputs` with plain basket `1sat`. That path is ordinary basket access ([BRC-46](../wallet/0046.md) / [BRC-116](../wallet/0116.md)), not this scheme, unless the wallet elects to route plain `1sat` through the same module as local policy.
+
+#### Normalization
+
+On `listOutputs` with basket `p 1sat <scope>`, conforming wallets MUST:
+
+1. Parse the scope ([Scopes](#scopes)); reject bare `p 1sat`, unknown scopes, and basket names that embed values after the scope token.
+2. For non-`all` scopes, require at least one matching axis tag on the request; reject if missing.
+3. Require a **view** grant covering that scope and the requested axis value(s) (or prompt to create one) — see [View grants](#view-grants).
+4. Rewrite the storage query basket to `1sat`.
+5. Enforce the granted axis tag value(s) as a **mandatory** filter on results (`tagQueryMode: "any"` MUST NOT drop them).
+6. Apply any additional non-axis caller tags only inside that ceiling.
+7. Return only outputs that satisfy the grant and the effective tag query.
+
+How the wallet enforces (4)–(6) (query rewrite, post-filter, or equivalent) is an implementation choice.
+
+Denial SHOULD use a distinct error so apps can distinguish “user denied item view” from generic basket denial.
+
+#### View grants
+
+Item view is **not** covered by ordinary payment / auto-pay grants.
+
+Each list request has one **scope**. The scope maps to a tag prefix (or to no prefix for `all`):
+
+| Scope | Required tag(s) on the request |
+|-------|--------------------------------|
+| `all` | none |
+| `collection` | one or more `collection:…` |
+| `app` | one or more `app:…` |
+| `creator` | one or more `creator:…` |
+| `id` | one or more `id:…` |
+
+The wallet queries storage basket `1sat` with those tags (plus any optional extra tags the caller adds). Grant check is on **this request’s scope and tag values**, not a multi-axis matrix.
+
+* **`p 1sat all`** — requires a standing grant for full inventory (or a prompt that creates one).  
+* **`p 1sat collection` / `app` / `creator`** — requires a standing grant that covers the requested tag value(s) for that scope (or a prompt). Grant **all** also covers these.  
+* **`p 1sat id`** — no standing inventory grant; knowing `id:<key>` is enough to look up that row (see [Scopes](#scopes)).
+
+When the user approves a collection/app/creator/all request, the wallet SHOULD persist a grant for that scope and those tag values (or upgrade to **all**). Storage layout is local.
+
+A later request MAY skip a new prompt when its scope and tag values are already covered by a stored grant (including grant **all** covering narrower scopes). Otherwise prompt or deny.
+
+##### Scope ceiling and tag query
+
+The scope’s required tags are mandatory on the result set. Optional extra tags (e.g. `type:image/png`) only narrow further. `tagQueryMode: "any"` MUST NOT drop the scope’s required tags.
+
+### Spend (`createAction`)
+
+Spend targeting under this scheme is built on [BRC-164](../wallet/0164.md) output identity tags. The held row MUST carry an `id:<key>` tag stamped by the holding wallet. The spend label names that key explicitly; the module resolves it back to the row with tag `id:<key>` under storage basket `1sat`.
+
+#### Label form
+
+**Held row (normative):**
+
+```
+p 1sat input id <key>
+```
+
+Rules:
+
+1. [BRC-111](../wallet/0111.md)-style P-label: scheme id `1sat`, payload `input id <key>`.
+2. **`<key>`** is the [BRC-164](../wallet/0164.md) list key — the substring after `id:` on the held output’s tags. Non-empty, no spaces, no `id:` prefix in the label.
+3. Storage basket is implied by the scheme: **`1sat`**.
+
+Example (row tagged `id:a1b2c3d4e5f60708`):
+
+```
+p 1sat input id a1b2c3d4e5f60708
+```
+
+Multiple such labels MAY appear when the action spends multiple tracked rows. Rows without a BRC-164 `id:` tag cannot use this form.
+
+**Other `input` payloads.** A label `p 1sat input <token>` whose single payload token is not the keyword `id` is outside this scheme’s held-tip permission model (e.g. naming a beefed external input). It is not a BRC-164 list key and is not further specified here. The normative spend path for wallet-held tips remains `p 1sat input id <key>`.
+
+#### Module behavior
+
+When `createAction` carries one or more `p 1sat input id <key>` labels, conforming wallets MUST:
+
+1. Route the call to the `1sat` permission module ([BRC-116](../wallet/0116.md)).
+2. Resolve each `<key>` to a held output in storage basket `1sat` via [BRC-164](../wallet/0164.md) (`id:<key>`).
+3. Obtain **user approval for this action’s spend** before spending those outputs. Payment / auto-pay MUST NOT satisfy this. Send approval is **per action** (inline prompt); this BRC does not define a standing/persisted “can send items” grant.
+4. On approval, authorize **only** the spend set the user approved. A later `createSignature` (or equivalent) MUST NOT expand that set without a new approval.
+
+Once an action is classified as a held-tip spend under this scheme (via `input id <key>` and successful resolution), payment auto-approve MUST NOT apply.
+
+#### Outpoint spend without labels
+
+Apps MAY still spend by outpoint without a `p 1sat input` label. That path does **not** enter this scheme via labels. Wallets SHOULD still refuse to spend storage `1sat` outputs under ordinary payment grants ([BRC-147](./0147.md) payment separation). Interoperable module-mediated spend targeting uses the input label form above.
+
+### Capabilities (summary)
+
+| Capability | Wire | Covers |
+|------------|------|--------|
+| **View** | `listOutputs` basket `p 1sat <scope>` | Listing storage `1sat` under the module |
+| **Send** | `createAction` labels `p 1sat input id …` | Per-action approval to spend labeled held rows (not a standing grant) |
+
+**Receive** / `internalizeAction` insertion into `1sat` remains ordinary basket insertion under [BRC-147](./0147.md) and wallet basket-access policy. Fine-grained receive grants are out of scope for this BRC.
+
+### Relationship to plain basket `1sat`
+
+| Operation | Plain `1sat` | `p 1sat …` / input labels |
+|-----------|--------------|-------------------------|
+| Storage of tips | Yes (normative) | Never |
+| `listOutputs` | Ordinary basket access | Module view + scope grants |
+| Spend targeting | Outpoint / local policy | `p 1sat input id <key>` ([BRC-164](../wallet/0164.md)) |
+
+### Out of scope
+
+* Origin / sat-ordering / transfer consensus rules
+* Inscription envelope bytes
+* Collection membership proofs
+* BSV-21 fungible storage and permissions
+* Marketplace lock templates
+* Labels other than `p 1sat input …` under scheme `1sat`
+* Fine-grained receive / `internalizeAction` grants
+
+## Security considerations
+
+* **Tag / grant spoofing** — View matching on tags is only as trustworthy as the holding wallet’s own stamps. Tags are claims; tip→origin proof is [BRC-150](./0150.md).
+* **Scheme bypass** — Filing collectables only in a non-`1sat` basket loses this profile’s storage contract.
+* **Payment separation** — Pay / auto-pay MUST NOT cover view under `p 1sat …` or spends authorized via `p 1sat input id …`.
+* **Scope ceiling** — Extra caller tags MUST NOT widen past the granted axis values.
+* **Approval binding** — After a spend is approved, signatures MUST NOT authorize a different spend set without a new approval.
+
+## Implementations
+
+* **1sat-sdk** — scheme module, input labels, scoped view
+* **HandCash Desktop / Mobile** — prior art for item view/send separation (storage `1sat`)
+
+## References
+
+1. [BRC-99: P Baskets](../wallet/0099.md)
+2. [BRC-98: P Protocols](../wallet/0098.md)
+3. [BRC-100: Wallet Interface](../wallet/0100.md)
+4. [BRC-111: Transaction Labels](../wallet/0111.md)
+5. [BRC-116: Wallet Permissions and Counterparty Trust](../wallet/0116.md)
+6. [BRC-123: Basket Permission Scheme Registry](../wallet/0123.md)
+7. [BRC-147: 1Sat Ordinals Basket Profile](./0147.md)
+8. [BRC-150: 1Sat Provenance Remittance](./0150.md)
+9. [BRC-164: Output Identity Tags](../wallet/0164.md)

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -17,4 +17,5 @@ BRC | Standard
 150  | [1Sat Provenance Remittance for Basket `1sat`](./0150.md)
 159  | [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./0159.md)
 160  | [1Sat Ordinals — Inscription Envelopes](./0160.md)
+165  | [P1Sat Permission Scheme for Basket `1sat`](./0165.md)
 226  | [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./0226.md)

--- a/wallet/0123.md
+++ b/wallet/0123.md
@@ -102,11 +102,8 @@ A scheme ID is considered registered when its defining BRC is merged into the BR
 | Scheme ID | Category | Defining BRC | Purpose | Example basket |
 |---|---|---|---|---|
 | `app` | *(Reserved)* | *(Future BRC)* | Application-scoped basket isolation | *(TBD)* |
-| `1sat` | 1 (Asset) | [BRC-165](../tokens/0165.md) | Collectable view via `p 1sat <scope>` (axis in basket; values in tags); spend via `p 1sat input id <key>`; storage stays `1sat` | `p 1sat collection` |
 
 The `app` scheme ID is reserved to allow a future specification to define application-scoped baskets where the originator's identity is encoded in the basket name. This supplements (rather than replaces) [BRC-116](./0116.md)<sup>1</sup> originator-based access control, which operates at the permission layer rather than the naming layer.
-
-The `1sat` scheme ID is defined by [BRC-165](../tokens/0165.md). Storage remains plain basket `1sat` ([BRC-147](../tokens/0147.md)); `p 1sat <scope>` names the view axis (`all` / `collection` / `app` / `creator` / `id`); filter values use ordinary tags (e.g. `collection:<outpoint>`, `id:<key>`). Spend authorization for held tips uses `p 1sat input id <key>`.
 
 ### 5. Validation Guidance
 

--- a/wallet/0123.md
+++ b/wallet/0123.md
@@ -102,8 +102,11 @@ A scheme ID is considered registered when its defining BRC is merged into the BR
 | Scheme ID | Category | Defining BRC | Purpose | Example basket |
 |---|---|---|---|---|
 | `app` | *(Reserved)* | *(Future BRC)* | Application-scoped basket isolation | *(TBD)* |
+| `1sat` | 1 (Asset) | [BRC-165](../tokens/0165.md) | Collectable view via `p 1sat <scope>` (axis in basket; values in tags); spend via `p 1sat input id <key>`; storage stays `1sat` | `p 1sat collection` |
 
 The `app` scheme ID is reserved to allow a future specification to define application-scoped baskets where the originator's identity is encoded in the basket name. This supplements (rather than replaces) [BRC-116](./0116.md)<sup>1</sup> originator-based access control, which operates at the permission layer rather than the naming layer.
+
+The `1sat` scheme ID is defined by [BRC-165](../tokens/0165.md). Storage remains plain basket `1sat` ([BRC-147](../tokens/0147.md)); `p 1sat <scope>` names the view axis (`all` / `collection` / `app` / `creator` / `id`); filter values use ordinary tags (e.g. `collection:<outpoint>`, `id:<key>`). Spend authorization for held tips uses `p 1sat input id <key>`.
 
 ### 5. Validation Guidance
 

--- a/wallet/0164.md
+++ b/wallet/0164.md
@@ -48,6 +48,10 @@ Conforming **tools and wallets that adopt this profile** SHOULD:
 
 Applications MAY read `id:<key>` from `listOutputs` (with `includeTags`) and reuse it in later filters or app state.
 
+### Related: spend labels ([BRC-165](../tokens/0165.md))
+
+[BRC-165](../tokens/0165.md) (P1Sat collectables) uses the bare `<key>` — not the full `id:<key>` tag string — in `createAction` labels of the form `p 1sat input id <key>`. The holding wallet resolves that key by querying tag `id:<key>` under basket `1sat`. Other asset schemes MAY use the same pattern under their own scheme ids. This BRC does not define those labels; it only supplies the list-key vocabulary they reference.
+
 ### Out of scope
 
 - Changing BRC-100 method schemas or WalletWire encodings
@@ -69,3 +73,4 @@ Applications MAY read `id:<key>` from `listOutputs` (with `includeTags`) and reu
 3. [BRC-46](./0046.md) — Wallet Transaction Output Tracking (Output Baskets)
 4. [BRC-153](./0153.md) — Action Reference Labels for BRC-100 Wallets
 5. [BRC-147](../tokens/0147.md) — 1Sat Ordinals Basket Profile
+6. [BRC-165](../tokens/0165.md) — P1Sat Permission Scheme (spend labels: `p 1sat input id <key>`)


### PR DESCRIPTION
## Summary

- Draft **BRC-165**: P1Sat permission scheme (BRC-99 scheme id `1sat`).
- **Storage** remains basket `1sat` ([BRC-147](./tokens/0147.md)).
- **View:** `listOutputs` basket `p 1sat <scope>` where scope is `all` | `collection` | `app` | `creator` | `id`; filter values on ordinary tags (e.g. `collection:<txid_vout>`, `id:<key>`). Scope required (bare `p 1sat` rejected). `id` lookup does not require grant-all.
- **Spend:** `createAction` labels `p 1sat input id <key>` (BRC-164); per-action approval, not a standing send grant. Pay/auto-pay MUST NOT cover item access.
- **Module probe:** `getPublicKey` with `[0, "p 1sat"]` (cites BRC-98/99/116; no new reject rules).
- Register `1sat` in [BRC-123](./wallet/0123.md); small clarifications on [BRC-147](./tokens/0147.md) (drop tag aliases; underscore writers for origin/content/collection keys; link 165) and [BRC-164](./wallet/0164.md) (see-also spend labels).

Authors: David Case; Brandon Cryderman (credit for HandCash item-access prior art and related drafts).

## Relationship to #221

Alternative draft to Brandon’s scope-in-basket BRC-165. This version keeps BRC-100 basket charset (`[a-z0-9 ]`), puts values in tags, and specifies spend labels via BRC-164.

## Test plan

- [ ] Spec read-through by wallet / 1sat-sdk folks
- [ ] Confirm no collision with BSV-21 drafts (#213 / #217)
- [ ] Align implementation (`@1sat/permission-module` scopes already track this draft)

Draft PR for feedback — not ready to merge.