### PR TITLE
Restore BRC-190 as the number for Access Gates for Metanet Rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ BRC | Standard
 143  | [Subtree Data Frame Format](./transactions/0143.md)
 144  | [Block Frame Format](./transactions/0144.md)
 145  | [Registry-Free Typed Content Anchor with On-Chain Code Provenance](./apps/0145.md)
-146  | [Access Gates for Metanet Rooms](./apps/0146.md)
+190  | [Access Gates for Metanet Rooms](./apps/0190.md)
 147  | [1Sat Ordinals Basket Profile for BRC-46 / BRC-100](./tokens/0147.md)
 148  | [Multicast Shard Domain Partitioning and the BEEF Object Plane](./transactions/0148.md)
 149  | [Multicast BEEF Object Frame Format](./transactions/0149.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,7 +13,7 @@
 * [The deployment-info.json Specification](./apps/0102.md)
 * [Auditable Real-time Inference Architecture (ARIA)](./apps/0122.md)
 * [Registry-Free Typed Content Anchor with On-Chain Code Provenance](./apps/0145.md)
-* [Access Gates for Metanet Rooms](./apps/0146.md)
+* [Access Gates for Metanet Rooms](./apps/0190.md)
 * [Verifiable Time Allocation](./apps/0168.md)
 * [Derived Collectibles](./apps/0210.md)
 * [Chat-Native Command Grammar for the Metanet](./apps/0218.md)

--- a/apps/0168.md
+++ b/apps/0168.md
@@ -404,7 +404,7 @@ The mechanism is worth its cost where a specific bounded claim is contested by a
 
 ### 11. Relationship to Other Documents
 
-Handles, resolution, messagebox delivery, attestation and delegation are [BRC-169](../peer-to-peer/0169.md); this document defines no addressing and no new certificate type beyond the countersignature of section 5.3, which is an ordinary BRC-52 certificate. The standing-authority list of section 6.4 is [BRC-218](./0218.md) section 5.19, and a conversational surface for allocating or granting is a matter for that document, as a custom verb under its section 8; no verb is defined or reserved here. A room may gate on contributed time under [BRC-146](./0146.md) by treating a disclosure as the fact a vouch gate reads, and this document neither requires nor endorses that.
+Handles, resolution, messagebox delivery, attestation and delegation are [BRC-169](../peer-to-peer/0169.md); this document defines no addressing and no new certificate type beyond the countersignature of section 5.3, which is an ordinary BRC-52 certificate. The standing-authority list of section 6.4 is [BRC-218](./0218.md) section 5.19, and a conversational surface for allocating or granting is a matter for that document, as a custom verb under its section 8; no verb is defined or reserved here. A room may gate on contributed time under [BRC-190](./0190.md) by treating a disclosure as the fact a vouch gate reads, and this document neither requires nor endorses that.
 
 ## Security Considerations
 
@@ -594,7 +594,7 @@ What remains is modest and, for a small number of real disputes, sufficient: a b
 - [BRC-52: Identity Certificates](../peer-to-peer/0052.md)
 - [BRC-87: Standardized Naming Conventions for BRC-22 Topic Managers and BRC-24 Lookup Services](../overlays/0087.md)
 - [BRC-169: Universal Handle Addressing and Resolution for the Metanet](../peer-to-peer/0169.md)
-- [BRC-146: Access Gates for Metanet Rooms](./0146.md)
+- [BRC-190: Access Gates for Metanet Rooms](./0190.md)
 - [BRC-218: Chat-Native Command Grammar for the Metanet](./0218.md)
 - [RFC 2119: Key words for use in RFCs to Indicate Requirement Levels](https://www.rfc-editor.org/rfc/rfc2119)
 - [RFC 8785: JSON Canonicalization Scheme (JCS)](https://www.rfc-editor.org/rfc/rfc8785)

--- a/apps/0190.md
+++ b/apps/0190.md
@@ -1,4 +1,4 @@
-# BRC-146: Access Gates for Metanet Rooms
+# BRC-190: Access Gates for Metanet Rooms
 
 Crumbs, zer0_dt_
 

--- a/apps/0210.md
+++ b/apps/0210.md
@@ -217,7 +217,7 @@ An asset object is `{ "storage": "inscribed" | "external", "digest": <64 lowerca
 3. The minting transaction MUST carry a [BRC-48](../scripts/0048.md) PushDrop output whose pushed fields, in order, are the ASCII string `derived-collectibles`, the ASCII string `1`, the 32-byte `scoreDigest`, and a location: either the outpoint of the inscription carrying the score bytes, or the ASCII string `inline` where the score is the work's own inscribed content.
 4. A client MUST recompute `scoreDigest` from the bytes it fetched and MUST refuse to render on a mismatch, per section 2.5. This is the document's own thesis applied to its first step: the score is not trusted, it is re-derived and compared.
 
-**Version.** A client meeting a `version` it does not implement MUST treat the work as unrenderable and say so, and MUST NOT render the subset of layers it recognises. Silently ignoring an unrecognised field produces a picture the author did not write, which is worse than no picture, and the same reasoning appears in [BRC-146](./0146.md) section 2.1. The cost is that a version bump is a hard break, so a later revision wanting a gradual path should add optional fields within version 1.
+**Version.** A client meeting a `version` it does not implement MUST treat the work as unrenderable and say so, and MUST NOT render the subset of layers it recognises. Silently ignoring an unrecognised field produces a picture the author did not write, which is worse than no picture, and the same reasoning appears in [BRC-190](./0190.md) section 2.1. The cost is that a version bump is a hard break, so a later revision wanting a gradual path should add optional fields within version 1.
 
 **Ceilings.** These are limits on the score, not on the client, and they exist because a bound every client picks for itself is a bound two clients disagree about. A client that refused a work another client rendered would break the determinism of section 2.2 as surely as a floating-point derivation would.
 
@@ -230,7 +230,7 @@ An asset object is `{ "storage": "inscribed" | "external", "digest": <64 lowerca
 | Inscribed asset size | 1 MiB |
 | Total inscribed asset size per score | 8 MiB |
 
-A score exceeding any ceiling is malformed and MUST be refused rather than truncated. The values are claimed rather than derived from anything, in the manner of BRC-146 section 2.1's sixteen-entry cap, and they are chosen so that a marketplace page holding a hundred works does a bounded amount of work per work.
+A score exceeding any ceiling is malformed and MUST be refused rather than truncated. The values are claimed rather than derived from anything, in the manner of BRC-190 section 2.1's sixteen-entry cap, and they are chosen so that a marketplace page holding a hundred works does a bounded amount of work per work.
 
 #### 2.7 A score is typed by derivation, not by allocation
 
@@ -276,7 +276,7 @@ The honest summary is that a work can be shown as it was, and the person who hel
 
 Every value in this document is derived, and derived values are not equally well known. A quantity recomputed from a block buried a year deep, one recomputed from a transfer six blocks old, one an indexer reported without the client checking, a date inferred from a height, and a price nobody can see are five different epistemic objects, and a client that renders them alike has told its viewer that they are the same.
 
-This section is the document's answer to its governing claim. Derivation yields approximation. The remedy is not to pretend otherwise but to carry the error term along with the value, in the manner of [BRC-146](./0146.md) section 3.1's three-state verdict and BRC-169 section 6.2's insistence that an unsigned exchange rate is the sender's assertion rather than evidence.
+This section is the document's answer to its governing claim. Derivation yields approximation. The remedy is not to pretend otherwise but to carry the error term along with the value, in the manner of [BRC-190](./0190.md) section 3.1's three-state verdict and BRC-169 section 6.2's insistence that an unsigned exchange rate is the sender's assertion rather than evidence.
 
 #### 3.1 The five classes
 
@@ -335,7 +335,7 @@ Height is exact, monotonic, and shared. The interval between heights is none of 
 
 The consequence is a rule and not a caution. **Where a score expresses a duration, it MUST express it in blocks**, and where a client presents a block quantity as a duration in days or years it MUST class it `estimated` per section 3.1 and MUST NOT present it as a date. A score that wants an event on a calendar date cannot have one; what it can have is an event at a height, and a client that renders "on 1 January 2050" from a height has invented a precision the chain does not carry.
 
-This is the same choice [BRC-146](./0146.md) section 2.4 makes for its notice period and for the same reason: two clients share a chain and do not share a clock.
+This is the same choice [BRC-190](./0190.md) section 2.4 makes for its notice period and for the same reason: two clients share a chain and do not share a clock.
 
 #### 4.2 The intervals height divides into
 
@@ -487,7 +487,7 @@ The quantities above are not equally trustworthy, and the confidence classes of 
 
 `hops`, `holders`, `returns` and `ecosystems` are cheap. One person with two keys can transfer a work between them for a fee, as many times as they like, and produce any value of `hops` they want in an afternoon. Nothing detects it: the keys are unrelated as far as the chain is concerned, and a marketplace sale between two wallets one person controls is indistinguishable from a sale between strangers.
 
-`age`, `tenure`, `longestTenure` and `shortestTenure` cannot be manufactured at all, because the only way to produce them is to wait. They are the provenance equivalent of [BRC-146](./0146.md) section 4.5's lock: what makes them worth reading is not that they are hard to forge but that forging them costs exactly what having them costs, which is time nobody gets back.
+`age`, `tenure`, `longestTenure` and `shortestTenure` cannot be manufactured at all, because the only way to produce them is to wait. They are the provenance equivalent of [BRC-190](./0190.md) section 4.5's lock: what makes them worth reading is not that they are hard to forge but that forging them costs exactly what having them costs, which is time nobody gets back.
 
 `valueMoved` and `lastPrice` are worse than cheap, they are usually wrong, which is why section 6.1 classes them `asserted`. A transfer's satoshi value is visible only where the sale settled on chain in one transaction; a gift moves for a dust output, a bundle prices five works as one, and anything settled off chain shows nothing.
 
@@ -555,7 +555,7 @@ A score MAY define a merge, in which two works are consumed and one is produced.
 
 A score MAY define a split only where the work was itself produced by a merge, and the split MUST produce the parents' records rather than halves of the child's. Splitting an unmerged work is not defined here: an object with one history has nothing to divide, and dividing the picture is a different operation from dividing the record.
 
-**Fractional ownership is not specified here.** A claim on part of a work is a custody arrangement, needing a custodian, a redemption path, and a rule for what happens when the arrangement ends, none of which this document provides and all of which [BRC-146](./0146.md) section 11 sets out for the analogous case. What this document can say is narrower and is worth saying: where a work's ownership becomes a set rather than a single key, every quantity in section 6.1 that reads "the owner" is undefined, and a score intended for fractional ownership MUST state what it reads instead.
+**Fractional ownership is not specified here.** A claim on part of a work is a custody arrangement, needing a custodian, a redemption path, and a rule for what happens when the arrangement ends, none of which this document provides and all of which [BRC-190](./0190.md) section 11 sets out for the analogous case. What this document can say is narrower and is worth saying: where a work's ownership becomes a set rather than a single key, every quantity in section 6.1 that reads "the owner" is undefined, and a score intended for fractional ownership MUST state what it reads instead.
 
 ### 7. Marks
 
@@ -650,11 +650,11 @@ The mechanism is what a client checks against the chain, so a score MUST name ex
 | `standalone`     | Publishes a [BRC-48](../scripts/0048.md) PushDrop output referencing the work's origin, signed by the holding key, at any height while they hold it | One extra transaction. Lets a holder mark when they have decided rather than when the chain forced them to.                                                                                                                                   |
 | `co-signed`      | Marks in the transfer, signed by both the outgoing and incoming holders                                                                             | Records a handover rather than a holder. Two parties agreed that this is what passed between them.                                                                                                                                            |
 | `countersigned`  | Marks, and a later holder attests it with a [BRC-52](../peer-to-peer/0052.md) certificate                                                           | A mark somebody else vouched for, distinguishable from one nobody did.                                                                                                                                                                        |
-| `burn-weighted`  | Accompanies the mark with satoshis paid to a provably unspendable output                                                                            | A costly signal in the strict sense: the amount is destroyed, so nobody profits from the mark existing. The construction is [BRC-146](./0146.md) section 2.4's, and its warning applies: an output whose key may exist is a gift, not a cost. |
+| `burn-weighted`  | Accompanies the mark with satoshis paid to a provably unspendable output                                                                            | A costly signal in the strict sense: the amount is destroyed, so nobody profits from the mark existing. The construction is [BRC-190](./0190.md) section 2.4's, and its warning applies: an output whose key may exist is a gift, not a cost. |
 | `delegated`      | An agent marks under a [BRC-169](../peer-to-peer/0169.md) section 9 delegation whose scope names the marking action                                 | Lets a custodian or an agent mark for a principal, attributably to both. Subject in full to that document's caps and expiry.                                                                                                                  |
 | `conversational` | Issues the mark through a chat command, as an ecosystem-custom verb under [BRC-218](./0218.md) section 8                                            | The friendliest surface and the least specified. No verb is claimed or reserved by this document.                                                                                                                                             |
 
-A score MAY additionally require a mark to be **timelocked**, in which case the marking output encumbers satoshis to the holder's own key until a stated height, and the mark is admitted only while that lock stands. This is the strongest available form and prices a mark in patience rather than in destruction, per [BRC-146](./0146.md) section 4.5. Its costs transfer too: a locked marker cannot leave, and a term cannot be shortened.
+A score MAY additionally require a mark to be **timelocked**, in which case the marking output encumbers satoshis to the holder's own key until a stated height, and the mark is admitted only while that lock stands. This is the strongest available form and prices a mark in patience rather than in destruction, per [BRC-190](./0190.md) section 4.5. Its costs transfer too: a locked marker cannot leave, and a term cannot be shortened.
 
 #### 7.5 When a holder may mark
 
@@ -689,7 +689,7 @@ This is [BRC-218](./0218.md) section 2.4's rule arriving in a different medium, 
 
 Every value in shared or local state MUST be derived in integer arithmetic. Floating-point arithmetic MUST NOT appear anywhere in a derivation.
 
-The failure this prevents is silent and total. Two clients deriving the same position from the same state will agree on integers and will eventually disagree on doubles, and the disagreement appears as a work that is subtly different in two wallets with no way to say which is right. [BRC-146](./0146.md)'s test vector for the same hazard is instructive: the bug is invisible in the cases where both answers agree, which is most of them.
+The failure this prevents is silent and total. Two clients deriving the same position from the same state will agree on integers and will eventually disagree on doubles, and the disagreement appears as a work that is subtly different in two wallets with no way to say which is right. [BRC-190](./0190.md)'s test vector for the same hazard is instructive: the bug is invisible in the cases where both answers agree, which is most of them.
 
 Where a score needs a ratio, it MUST express it as a pair of integers and compare by cross-multiplication. Where it needs a curve, the curve belongs to presentation.
 
@@ -727,7 +727,7 @@ It is not a proof of anything and section 3.4 forbids calling it one. What it is
 
 Every quantity in section 6 is derived by following a chain of transfers, which is what an indexer does. A client MUST NOT treat any indexer as authoritative, SHOULD prefer one it operates or trusts, and MUST NOT accept a score's nomination of one as binding. A value the client took from an indexer without re-deriving it is `witnessed` per section 3.1, and MUST be rendered as such.
 
-This is [BRC-146](./0146.md) section 4.1's rule and the reasoning transfers exactly: two honest indexers agree because they are reading the same chain, so naming one buys convenience rather than agreement, and a score able to bind every viewer to one indexer would let whoever controls it decide what the work looks like.
+This is [BRC-190](./0190.md) section 4.1's rule and the reasoning transfers exactly: two honest indexers agree because they are reading the same chain, so naming one buys convenience rather than agreement, and a score able to bind every viewer to one indexer would let whoever controls it decide what the work looks like.
 
 An unconfirmed transfer is not a transfer. A client MUST NOT advance a record on an unconfirmed spend, and MUST class as `probable` any value derived from data shallower than `settlementDepth`.
 
@@ -751,7 +751,7 @@ Points 6 and 7 are the ones most likely to be omitted and most likely to matter.
 
 ### 10. Not Specified Here
 
-**Enforcement, which is reserved rather than merely absent.** Nothing here is enforced by consensus. A score is a rule that conforming clients honour, exactly as [BRC-146](./0146.md) section 9 says of a gate, and a non-conforming client can render whatever it likes. That is sufficient for a work whose rules nobody gains by breaking, and insufficient wherever a state carries a payment, a royalty, or a mark whose absence somebody profits from.
+**Enforcement, which is reserved rather than merely absent.** Nothing here is enforced by consensus. A score is a rule that conforming clients honour, exactly as [BRC-190](./0190.md) section 9 says of a gate, and a non-conforming client can render whatever it likes. That is sufficient for a work whose rules nobody gains by breaking, and insufficient wherever a state carries a payment, a royalty, or a mark whose absence somebody profits from.
 
 The consensus-enforced form is therefore **reserved for a companion document**, in the manner of [BRC-218](./0218.md) section 6: a name held open for a specification rather than a name held closed. [BRC-226](../tokens/0226.md) already demonstrates the mechanism, which is an `OP_PUSH_TX` covenant compelling the transaction that spends a work to re-create it under stated rules, and a companion would have to settle four things this document deliberately does not touch. Which parts of a score the covenant binds, since binding all of it makes every render a consensus matter and binding none of it changes nothing. How a mark is admitted by script rather than by client convention, per section 7.3. What happens to a work whose covenant cannot be satisfied, which is an object nobody can move. And what the arrangement costs per transfer, since a covenant is paid for by whoever spends it and a work too expensive to move is a work nobody moves.
 
@@ -795,7 +795,7 @@ Nine, and none of them is small.
 
 **4. Cheap provenance is cheap, and the confidence classes do not catch it.** Section 6.2 is a recommendation, not a defence, and section 3's classes are orthogonal to it: a wash-traded `hops` count is `settled` and worthless at the same time. One person with two keys and a fee budget can drive `hops`, `holders` and `returns` to any value, and there is no detection available, because the chain cannot see that two keys are one person. Works reading only time-based quantities are immune.
 
-**5. Ownership is a key, not a person.** Everything in section 6 is about keys. A collector who rotates keys for good reasons appears as two holders and loses a tenure; one who consolidates two works into one wallet creates `kin` that never happened socially. [BRC-146](./0146.md) section 8 works through the same problem for access and recovers part of it with attestations; nothing equivalent is specified here, and a score reading `holders` should expect the count to be wrong in both directions.
+**5. Ownership is a key, not a person.** Everything in section 6 is about keys. A collector who rotates keys for good reasons appears as two holders and loses a tenure; one who consolidates two works into one wallet creates `kin` that never happened socially. [BRC-190](./0190.md) section 8 works through the same problem for access and recovers part of it with attestations; nothing equivalent is specified here, and a score reading `holders` should expect the count to be wrong in both directions.
 
 **6. Reorganisations change facts.** The `probable` class and the depth rules of 4.5 and 9.4 bound the exposure and do not remove it. A deep reorganisation would change a work's state retroactively, and the state a viewer saw beforehand would have been correct when they saw it and wrong afterwards. That is the chain's own condition, not this document's failure, and section 3.3 is the recommendation to show it rather than hide it.
 
@@ -817,7 +817,7 @@ Nine, and none of them is small.
 
 **Wash trading manufactures provenance.** Restating limitation 4 as a security property, because it is one: any score whose desirable state is reached by transferring has funded an attack on itself, and the attacker is often the holder. The same applies to section 3.3 if an unresolved state is made desirable, which is why 3.3(2) forbids it.
 
-**A work that renders its holders publishes a wallet.** A composition showing `ecosystems`, resolving holders to handles, or drawing a figure per holder is a public statement about who owns what, assembled from facts that were individually public and are considerably more sensitive in aggregate. This is [BRC-146](./0146.md)'s balance oracle in a different guise. A score naming holders MUST be understood as making that disclosure permanent, and a client SHOULD offer to render a work without holder identities.
+**A work that renders its holders publishes a wallet.** A composition showing `ecosystems`, resolving holders to handles, or drawing a figure per holder is a public statement about who owns what, assembled from facts that were individually public and are considerably more sensitive in aggregate. This is [BRC-190](./0190.md)'s balance oracle in a different guise. A score naming holders MUST be understood as making that disclosure permanent, and a client SHOULD offer to render a work without holder identities.
 
 **Indexer capture decides what the work looks like.** Section 9.4. An indexer that misreports a lineage changes the state every client relying on it derives, and the discrepancy is invisible to a viewer with one indexer. The `witnessed` class is what makes the dependency visible; comparing lineage digests per 8.3 is what makes it diagnosable.
 
@@ -1045,12 +1045,12 @@ almost every case.
 - [BRC-87: Standardized Naming Conventions for BRC-22 Topic Managers and BRC-24 Lookup Services](../overlays/0087.md)
 - [BRC-113: Merkle Proof Token](../tokens/0113.md)
 - [BRC-145: Registry-Free Typed Content Anchor with On-Chain Code Provenance](./0145.md)
-- [BRC-146: Access Gates for Metanet Rooms](./0146.md)
 - [BRC-147: 1Sat Ordinals Basket Profile for BRC-46 / BRC-100](../tokens/0147.md)
 - [BRC-150: 1Sat Provenance Remittance for Basket `1sat`](../tokens/0150.md)
 - [BRC-156: Latched 1Sat Provenance for Basket `1sat`](../tokens/0156.md)
 - [BRC-168: Verifiable Time Allocation](./0168.md)
 - [BRC-169: Universal Handle Addressing and Resolution for the Metanet](../peer-to-peer/0169.md)
+- [BRC-190: Access Gates for Metanet Rooms](./0190.md)
 - [BRC-218: Chat-Native Command Grammar for the Metanet](./0218.md)
 - [BRC-224: Block Media Format (BMF), Composable On-Chain Audio/Video](./0224.md)
 - [BRC-226: Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](../tokens/0226.md)

--- a/apps/README.md
+++ b/apps/README.md
@@ -7,7 +7,7 @@ BRC   | Standard
 102   | [The deployment-info.json Specification](./0102.md)
 122   | [Auditable Real-time Inference Architecture (ARIA)](./0122.md)
 145   | [Registry-Free Typed Content Anchor with On-Chain Code Provenance](./0145.md)
-146   | [Access Gates for Metanet Rooms](./0146.md)
+190   | [Access Gates for Metanet Rooms](./0190.md)
 168   | [Verifiable Time Allocation](./0168.md)
 210   | [Derived Collectibles](./0210.md)
 218   | [Chat-Native Command Grammar for the Metanet](./0218.md)

--- a/peer-to-peer/0169.md
+++ b/peer-to-peer/0169.md
@@ -733,7 +733,7 @@ Reassigning a role is a revocation followed by a fresh delegation. Organisation 
    2. Where it is unattributed, the **claim itself MUST still be shown**. An anonymous count is a rumour with a number on it; an anonymous reason is something the subject can answer and a reader can weigh.
    3. A client MUST NOT let a negative statement contribute to any indication that an identity is unverified, exactly as rule 6 forbids the positive case. Both are opinions about a person; verification is arithmetic about a key.
    4. Attributed and unattributed statements MUST be visually distinguishable, and a client MUST NOT imply that an unattributed one is attributable on request when it is not.
-8. **Attestations MUST be discoverable, not merely publishable.** Rules 3 to 7 say how a peer statement is made and what it means, and say nothing about how a third party finds the statements made *about* a handle. That is the half a relying party actually needs: a client asking "who has vouched for this identity" has no endpoint to ask. An ecosystem SHOULD answer that question for its own handles, at the resolution endpoint of section 5.7, as a list of attestation outpoints with their certifiers. Until an ecosystem does, any mechanism built on this section — including the access gates of [BRC-146](../apps/0146.md) — can be evaluated only by a party that already holds the attestations, which is to say by nobody who needed to ask.
+8. **Attestations MUST be discoverable, not merely publishable.** Rules 3 to 7 say how a peer statement is made and what it means, and say nothing about how a third party finds the statements made *about* a handle. That is the half a relying party actually needs: a client asking "who has vouched for this identity" has no endpoint to ask. An ecosystem SHOULD answer that question for its own handles, at the resolution endpoint of section 5.7, as a list of attestation outpoints with their certifiers. Until an ecosystem does, any mechanism built on this section — including the access gates of [BRC-190](../apps/0190.md) — can be evaluated only by a party that already holds the attestations, which is to say by nobody who needed to ask.
 9. Because organisations resolve identically to users, the address book doubles as a business directory.
 
 ## Security Considerations
@@ -804,7 +804,7 @@ Reassigning a role is a revocation followed by a fresh delegation. Organisation 
 - [BRC-104: HTTP Transport for BRC-103 Mutual Authentication](./0104.md)
 - [BRC-105: HTTP Service Monetization Framework](../payments/0105.md)
 - [BRC-125: PeerPay URI Scheme for BRC-29 Payments](../payments/0125.md)
-- [BRC-146: Access Gates for Metanet Rooms](../apps/0146.md)
+- [BRC-190: Access Gates for Metanet Rooms](../apps/0190.md)
 - [BRC-218: Chat-Native Command Grammar for the Metanet](../apps/0218.md)
 - [WhatsOnChain Exchange Rate API](https://docs.whatsonchain.com/exchange-rate)
 - [RFC 1123: Requirements for Internet Hosts](https://www.rfc-editor.org/rfc/rfc1123)


### PR DESCRIPTION
## What this does

The Access Gates document was submitted as BRC-190 in #191 and merged as **BRC-146**. Maintainers have since agreed that **190** is the official number. This moves the file back and repairs every inbound reference in the same commit, so no link is broken at any point.

- `apps/0146.md` → `apps/0190.md`, with the title line updated
- Index entries in `README.md`, `SUMMARY.md` and `apps/README.md`
- Inbound references in `peer-to-peer/0169.md` (2), `apps/0168.md` (2), `apps/0210.md` (14)
- BRC-210's reference list reordered, since 190 now sorts after 169 rather than before 147

146 is left unallocated. That is deliberate rather than an oversight, but happy to renumber something into it if you would rather not have a gap.

## It also fixes two dead links in a published standard

`apps/0218.md` links to `./0190.md` in section 11 and again in its reference list. That path has returned 404 since #191 merged under a different number, so BRC-218 has been shipping two broken references. They resolve correctly once this lands, with no edit to BRC-218 itself.

## Care taken

- Replacements are anchored to `0146.md` and `BRC-146`. A bare `0146` substitution would corrupt a SHA-256 in BRC-168's test vectors (`...b1b75801462117...` contains the string), and those bytes are untouched here.
- Reference lists in all three edited documents verified still ascending, per the repository's ordering convention.

## Separate finding, not touched by this PR

`apps/0227.md` cites "BRC-146" six times, but attributes to it the title *Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)*, which is **BRC-226**. Those are plain-text citations with no links, so they are unaffected by this rename, but they look like a typo for 226 and a naive find-and-replace would have made them worse. Left alone deliberately. Happy to fix in a follow-up if you agree with the reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)