### PR TITLE
BRC-175: 1Sat Fungible Basket Profile

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -120,6 +120,7 @@
 * [1Sat Provenance Remittance for Basket `1sat`](./tokens/0150.md)
 * [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 * [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
+* [1Sat Fungible Basket Profile for BRC-46 / BRC-100](./tokens/0166.md)
 * [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)
 
 ## Overlays

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -120,7 +120,7 @@
 * [1Sat Provenance Remittance for Basket `1sat`](./tokens/0150.md)
 * [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./tokens/0159.md)
 * [1Sat Ordinals — Inscription Envelopes](./tokens/0160.md)
-* [1Sat Fungible Basket Profile for BRC-46 / BRC-100](./tokens/0166.md)
+* [1Sat Fungible Basket Profile for BRC-46 / BRC-100](./tokens/0175.md)
 * [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)
 
 ## Overlays

--- a/tokens/0147.md
+++ b/tokens/0147.md
@@ -213,11 +213,13 @@ Normative fine-grained asset permission schemes remain [BRC-99](../wallet/0099.m
 * Wallets that do not implement this profile MUST still store and forward unknown baskets’ `customInstructions` and tags unchanged ([BRC-37](../outpoints/0037.md)).
 * This profile does not conflict with BRC-99 `p ` baskets; future permission-wrapped variants MAY wrap `1sat` semantics under a `p <scheme> …` name without invalidating this profile for the plain `1sat` basket.
 * Marketplaces (e.g. OrdLock), BSV-20/21, and mint APIs are out of scope.
+* **[BRC-175](./0175.md) fungibles** share the bare P2PKH tip-move shape with this profile. Chain-scan / instant-ingest MUST NOT place an output in basket `1sat` solely because its creating transaction spends a 1-sat input. Importers SHOULD require an inscribed non–`1sat-ft` ancestor (or equivalent remittance / provenance) before painting a collectable. An ancestor with content-type `application/1sat-ft+json` MUST NOT yield eligibility for this profile.
 
 ## Security considerations
 
 * **Tag / metadata spoofing** — Without provenance verification, a sender can attach another inscription’s `origin` and `name`. See [BRC-150](./0150.md). A forged `content` only mis-points display media; it does not prove tip→origin.
 * **Basket pollution** — Placing non-1-sat or non-ordinal outputs in `1sat` confuses list UIs; receivers should re-check `satoshis` and inscription rules.
+* **Fungible misfile** — Auto-importing every bare 1-sat that spends a 1-sat parent will file [BRC-175](./0175.md) transfer tips into `1sat`. Those tips then look burnable as junk NFTs. See Compatibility above.
 * **Burn** — Per 1Sat Ordinals, packing a sat into a multi-sat output ends that origin trail. Do not continue `origin:` claims across a burn.
 * **Indexer trust** — Display media URLs and collection metadata often come from indexers; this profile does not make indexers authoritative for tip→origin binding. Forwarding `content` reduces indexer dependence for derivative media.
 

--- a/tokens/0166.md
+++ b/tokens/0166.md
@@ -4,22 +4,24 @@ Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 
 ## Abstract
 
-This BRC defines the **fungible** application basket profile for 1Sat under [BRC-46](../wallet/0046.md) / [BRC-100](../wallet/0100.md). A fungible 1Sat token is a set of **1-satoshi tips that share one origin**. Token identity is that origin outpoint. In v1, **one tip is one unit**; balance is the count of held tips bound to the origin. Transfers **move tips** (P2PKH), the same custody pattern as collectables ([BRC-147](./0147.md)).
+This BRC defines the **fungible** application basket profile for 1Sat under [BRC-46](../wallet/0046.md) / [BRC-100](../wallet/0100.md). A fungible 1Sat token is a set of **1-satoshi tips that share one origin**. Token identity is that origin outpoint. Each tip carries a face value **`amt`** (token units). **Balance** is the sum of `amt` on bound tips held. Transfers **spend tip UTXOs and create new 1-sat tips** (recipients and change), funded with ordinary BSV dust — the same custody class as collectables ([BRC-147](./0147.md)), not a split of one physical satoshi across payees.
 
-Offline tip→origin proof reuses the [BRC-150](./0150.md) remittance format wherever a conforming lineage path exists. This profile adds shared-origin fungibility, a dedicated storage basket, mint-batch binding for genesis siblings, and open vs locked supply metadata.
+**Locked supply is optional:** the origin MAY set `supply: "locked"` with `max` (**total units**). When omitted, tips still bind via tip→origin rules with face-value `amt`; wallets MUST NOT invent a lock. Offline tip→origin proof reuses [BRC-150](./0150.md). Mint-batch attestation MAY bind same-tx genesis siblings until a transfer creates a 150 path. A tip with omitted `amt` MUST be treated as `amt = 1` (tip-count legacy).
 
 This BRC does not redefine 1Sat origin theory ([BRC-159](./0159.md)) or inscription envelopes ([BRC-160](./0160.md)).
 
 ## Motivation
 
-Collectables already interoperate as tip→origin assets with offline proof ([BRC-147](./0147.md), [BRC-150](./0150.md)). Fungible balances that re-inscribe protocol JSON each hop (e.g. BSV-21) do not share that transfer path and typically depend on indexers for discovery.
+Collectables already interoperate as tip→origin assets with offline proof ([BRC-147](./0147.md), [BRC-150](./0150.md)). Fungible balances that re-inscribe protocol JSON each hop do not share that transfer path and typically depend on indexers for discovery and settlement. Counting tips as units (without face-value `amt`) does not scale: moving *N* units costs *O(N)* tips.
 
-Wallets need a shared contract so that:
+Wallets and future **token markets** need a shared contract so that:
 
-1. Many tips may share one origin and count as fungible units.
-2. Fungible tips are not filed into NFT basket `1sat` (item accounting stays clean).
-3. Senders move tips and attach remittance; receivers verify without an indexer deciding custody.
-4. Mint may create an origin plus sibling tips in one transaction, with an explicit binding rule when those siblings are not ordinal descendants of the origin.
+1. Markets and wallets identify a token by **origin** (one id forever).
+2. Inventory is a set of **tip UTXOs** (listable, lockable, settleable like collectables).
+3. Large balances MAY sit in **one tip** (`amt` large); sends **split/merge** with change.
+4. Fungible tips are not filed into NFT basket `1sat`.
+5. Supply policy is readable from the **origin tip** without an indexer census.
+6. Custody never depends on a market overlay or indexer being online.
 
 ## Specification
 
@@ -27,140 +29,201 @@ Wallets need a shared contract so that:
 
 * The storage basket name is the UTF-8 string `1sat-ft`.
 * After [BRC-46](../wallet/0046.md) normalization (trim + lowercase), conforming use MUST use exactly `1sat-ft`.
-* This identifier does **not** use the [BRC-99](../wallet/0099.md) `p ` prefix. It is a standard application basket under BRC-46.
+* This identifier does **not** use the [BRC-99](../wallet/0099.md) `p ` prefix.
 * Outputs for this profile MUST NOT be placed in basket `1sat` ([BRC-147](./0147.md)).
+* Readers MAY accept a legacy alias basket during migration; writers MUST emit `1sat-ft`.
 
 ### Eligibility
 
-An output SHOULD be placed in basket `1sat-ft` only when **all** of the following hold:
+An output SHOULD be placed in basket `1sat-ft` only when **all** hold:
 
 1. `satoshis === 1`.
-2. The tip is intended as a unit of a fungible 1Sat token whose identity is a shared *origin* outpoint.
-3. The sender or importer reasonably believes the tip binds to that origin under this profile (genesis tip, mint-batch sibling, inductive remittance hop, and/or [BRC-150](./0150.md) lineage).
+2. The tip is a carrier for fungible units of a token whose identity is a shared origin outpoint.
+3. The tip **binds** to that origin under §Binding (below).
+4. The tip carries a valid first `ord` envelope ([BRC-160](./0160.md)) when presented as a token unit (genesis and mint-batch tips MUST; transferred tips SHOULD retain or re-attach envelope policy only via remittance if the spend strips the envelope — P2PKH tip moves are allowed; binding then relies on remittance + 150).
 
-Wallets MUST NOT place ordinary payment change or multi-sat outputs into `1sat-ft`.
+Wallets MUST NOT place ordinary payment change or multi-sat outputs into `1sat-ft`.  
+**Autodetect is not “any 1-sat output”:** `satoshis === 1` is necessary; basket + binding are required before counting units.
 
 ### Token identity and units
 
-* **Token id** = origin outpoint in underscore form `txid_vout` (same normalization rules as [BRC-147](./0147.md)).
-* **v1 unit** = one eligible tip bound to that origin.
-* **Balance** = number of such tips held. Decimals and multi-unit tips are out of scope for this version.
+* **Token id** = origin outpoint (`txid_vout` after normalize; same rules as [BRC-147](./0147.md)).
+* **Carrier** = 1-sat tip UTXO. Face value is **not** the satoshi amount.
+* **`amt`** = positive integer token units on that tip (decimal string in JSON).
+* **Balance** = sum of `amt` over bound tips held for that origin.
+* Missing `amt` ⇒ treat as `"1"` (legacy tip-count rows).
+* **`max`** (locked) = total units at genesis, **not** required tip count.
+* **Decimals** — Origin MAY reserve `dec`; readers that do not implement decimals MUST treat `amt` as integer units and MUST NOT invent fractional balances.
 
-### Outpoint encoding
+### Origin inscription (normative policy surface)
 
-Same as [BRC-147](./0147.md): wire `txid.vout`, 1Sat underscore form interchangeable after normalize.
+The **origin tip** (outpoint = token id) MUST carry an `ord` envelope whose body is UTF-8 JSON:
+
+```json
+{
+  "p": "1sat-ft",
+  "v": 1,
+  "amt": "1000",
+  "sym": "GOLD",
+  "name": "optional",
+  "supply": "locked",
+  "max": "1000"
+}
+```
+
+| Field | Requirement | Meaning |
+|-------|-------------|---------|
+| `p` | MUST | Profile id `1sat-ft`. |
+| `v` | MUST | Origin schema version. This BRC defines `1`. |
+| `amt` | MUST | Face value of **this** tip (genesis tip often holds the full issued amount). |
+| `supply` | MAY | `locked` freezes total units. Omit when no cap. `open` means uncapped (no local max). |
+| `max` | MUST when `supply` is `locked` | Total units. Decimal string of a positive integer. |
+| `sym` | SHOULD | Short symbol (≤ 32). |
+| `name` | MAY | Display name (≤ 80). |
+| `dec` | RESERVED | Future decimal places; ignore if unimplemented. |
+| `issuer` / `auth` | RESERVED | Future open-mint authority; ignore until defined. |
+
+Unknown fields MUST be preserved by wallets that round-trip remittance ([BRC-37](../outpoints/0037.md) spirit) and MUST be ignored for validation unless this BRC defines them.
+
+**Authority:** When locked, the origin inscription is the sole durable supply policy. Remittance MUST NOT contradict it (`supply` / `max` on tips SHOULD echo the origin when present; on conflict, **origin wins**). Wallets MUST NOT write `supply: locked` unless the origin defined it. Child tips MUST NOT claim `amt` that violates §Conservation.
+
+### Supply (optional lock)
+
+| State | Meaning |
+|-------|---------|
+| *(omitted)* / `open` | No declared unit cap. Hold/send still use `amt` + binding + conservation. |
+| `locked` | Genesis defines total units `max`. No further mint against this origin. |
+
+Conforming **locked mints** MUST:
+
+1. Create one or more 1-sat tips in the genesis transaction whose **`amt` values sum to `max`**, and
+2. Set origin `supply` to `locked` with that `max`.
+
+A single genesis tip with `amt = max` is the preferred compact locked mint. Unlocked mints MAY omit `supply`/`max` and issue any positive genesis `amt`.
+
+Conforming **receivers** MUST accept a tip only if it binds under §Binding. When the origin is locked, mint-batch / local holdings MUST respect `max`. Holders are **not** required to enumerate global circulating supply via an indexer. Markets MAY show indexer stats as convenience only (grade C).
+
+### Mint batch (genesis siblings)
+
+Optional. Genesis MAY create the origin tip and additional siblings in the **same transaction** (`randomizeOutputs: false` recommended so origin is `txid_0`).
+
+Sibling at `txid_vout` binds when:
+
+* same txid as origin,
+* remittance includes `"mint": { "batch": true, "vout": <vout> }`,
+* `origin` matches the genesis origin outpoint,
+* each sibling has a positive `amt`,
+* sum of all genesis tip `amt` values equals origin `max`, and
+* each output is 1 sat with a valid first `ord` envelope on genesis outputs.
+
+After the first transfer of a tip, senders SHOULD attach [BRC-150](./0150.md) provenance; receivers MUST prefer a verifying 150 package over mint-batch attestation alone.
+
+### Conservation (split / merge)
+
+Token units are conserved across spends:
+
+1. Select one or more **input tips** bound to the same origin.
+2. Let `S` = sum of input `amt`.
+3. Create one or more **output tips** (1 sat each), funded with ordinary BSV for dust + fees.
+4. Let `T` = sum of output `amt` for that origin in the same action.
+5. Receivers / wallets MUST require `T === S`. Change is an output tip back to the sender (or another allowed destination) with the residual `amt`.
+
+There is **no** requirement that one physical satoshi be “split” among recipients. The input tip UTXO(s) are spent; new 1-sat carriers are created. Multi-recipient pays = multiple new tips in one (or more) transactions.
+
+Merging (many inputs → fewer outputs) and splitting (few inputs → more outputs) use the same conservation rule.
+
+### Binding (when a tip counts)
+
+A tip **binds** to origin `O` if any of the following hold (checked in order):
+
+1. **Genesis** — tip outpoint equals `O`, and origin inscription parses as this profile.
+2. **BRC-150** — `customInstructions.provenance` verifies per [BRC-150](./0150.md) v2 to origin `O`.
+3. **Mint batch** — same-tx sibling attestation as above.
+4. **Parent hop** — remittance `parent` names a tip that itself binds to `O` (inductive), and this tip’s `amt` is consistent with a conserving spend of that parent (wallets SHOULD verify when parent spend data is available). Wallets SHOULD depth-limit and fail closed on cycles / missing parents.
+
+`mint.extend` without a future auth rule does **not** bind.
 
 ### Tags
 
-Tags are optional and **non-authoritative for asset identity**.
-
 | Tag | Requirement | Meaning |
 |-----|-------------|---------|
-| `1sat-ft` | SHOULD | Marks the output under this fungible profile. |
-| `ordinal` | SHOULD | Marks a 1-sat ordinal tip. |
-| `origin:<outpoint>` | SHOULD when origin is known | Claimed token origin (`dot` or `underscore`). |
-| `name:<string>` | MAY | Short display name (≤ 80 UTF-8 code units when writing). |
-| `sym:<string>` | MAY | Short ticker / symbol (≤ 32). |
-| `id:<key>` / `outid:<key>` | SHOULD for held rows | Local list/spend key ([BRC-164](../wallet/0164.md) practice). Not asset identity. |
+| `1sat-ft` | SHOULD | Profile marker. |
+| `ordinal` | SHOULD | 1-sat ordinal tip. |
+| `origin:<outpoint>` | SHOULD when known | Claimed origin. |
+| `name:<string>` / `sym:<string>` | MAY | Display claims. |
+| `id:` / `outid:` | SHOULD for held rows | Local list key ([BRC-164](../wallet/0164.md) practice). |
 
-Unknown tags MUST be preserved when transporting the output.
+Unknown tags MUST be preserved.
 
-### Custom instructions ([BRC-37](../outpoints/0037.md))
-
-When present for basket `1sat-ft`, `customInstructions` MUST be a UTF-8 JSON object serialized as a string. Conforming writers SHOULD emit:
+### Custom instructions (per tip)
 
 ```json
 {
   "p": "1sat-ft",
   "origin": "<txid_vout>",
-  "sym": "<optional>",
-  "name": "<optional>",
-  "supply": "open" | "locked",
-  "max": "<optional decimal string when locked>",
+  "amt": "400",
+  "sym": "<optional echo>",
+  "supply": "locked",
+  "max": "<echo when locked>",
   "mint": { "batch": true, "vout": 3 },
-  "parent": "<optional prior tip txid_vout>",
+  "parent": "<optional prior tip>",
   "provenance": { }
 }
 ```
 
-| Field | Type | Requirement | Meaning |
-|-------|------|-------------|---------|
-| `p` | string | SHOULD | Profile id `1sat-ft`. |
-| `origin` | string | MUST when known | Token origin, underscore form. |
-| `sym` / `name` | string | MAY | Display claims. |
-| `supply` | string | SHOULD on genesis remittance | `open` or `locked`. Default `open` if omitted. |
-| `max` | string | MAY when `supply` is `locked` | Declared supply cap (tip count). Mint policy attestation — not a global chain census. |
-| `mint` | object | MAY | Mint attestation (see below). |
-| `parent` | string | MAY | Prior tip outpoint this tip descends from by remittance hop. |
-| `provenance` | object | SHOULD when a [BRC-150](./0150.md) package can be built | Same v2 schema as BRC-150. |
-
-### Supply
-
-| State | Meaning |
-|-------|---------|
-| `open` | Further mint tips MAY claim this origin under issuer / minter policy. |
-| `locked` | Supply is closed; conforming minters MUST NOT create further tips for this origin. Optional `max` is the declared tip-count cap. |
-
-Supply fields are **mint policy remittance**. Holders verify their tips; they are not required to enumerate global supply via an indexer.
-
-### Mint batch (genesis siblings)
-
-A genesis mint MAY create the origin tip and additional 1-sat outputs in the **same transaction**.
-
-* Origin tip: outpoint equals `origin` (commonly `txid_0` when `randomizeOutputs` is false).
-* Sibling tip at `txid_vout` (vout ≠ origin vout) MAY bind to that origin when remittance includes:
-
-```json
-"mint": { "batch": true, "vout": <this output's vout> }
-```
-
-and `origin` matches the genesis origin outpoint on the same txid.
-
-Receivers MUST still require `satoshis === 1` and SHOULD require a valid first `ord` envelope on tips presented as units of the token ([BRC-160](./0160.md)).
-
-When a tip later gains a full [BRC-150](./0150.md) lineage path, wallets SHOULD prefer that proof over mint-batch attestation alone.
+| Field | Requirement | Meaning |
+|-------|-------------|---------|
+| `p` / `origin` | SHOULD / MUST when known | Profile + token id. |
+| `amt` | MUST when known | Face value of this tip (decimal string). Omit only for legacy `amt = 1`. |
+| `supply` / `max` | SHOULD when origin locked | Echo origin policy only — do not invent. |
+| `mint` | MAY | Genesis batch attestation. |
+| `parent` | MAY | Prior tip for inductive bind. |
+| `provenance` | SHOULD when buildable | BRC-150 v2 object. |
 
 ### Transfer
 
-1. Select one or more tips of the same origin.
-2. Spend each tip to a new 1-sat output paying the recipient (P2PKH or other eligible lock).
-3. File the new tip in basket `1sat-ft` with `origin:` tags and CI.
-4. Attach [BRC-150](./0150.md) `provenance` when a conforming path exists; otherwise set `parent` to the spent tip outpoint and preserve `origin` / supply fields.
-
-Peer delivery of remittance (messagebox / BRC-100 internalization) follows the same custody vs remittance split as collectables: chain tip is custody; remittance is identity.
+1. Select input tip(s) bound to the same origin with sufficient Σ `amt`.
+2. Build output tip(s): payee amounts + change; enforce §Conservation.
+3. Spend inputs; create new 1-sat outputs (BSV funds dust + fees).
+4. File under basket `1sat-ft` with tags + CI including `amt`.
+5. Attach BRC-150 when a path exists; else set `parent` to a spent tip and echo origin policy.
 
 ### Provenance scope
 
-[BRC-150](./0150.md) is written against basket `1sat`. For this profile:
+The BRC-150 v2 **object schema and verification rules** apply unchanged when present. Conforming wallets MUST accept 150 packages for `1sat-ft` tips. A future BRC-150 errata MAY list basket `1sat-ft` explicitly; until then this BRC imports the format by reference.
 
-* The **provenance object schema and verification rules** of BRC-150 v2 apply unchanged when present under `customInstructions.provenance`.
-* Conforming wallets MUST accept BRC-150 packages for `1sat-ft` tips the same way they do for `1sat` tips, modulo basket filing.
+### Open mint (reserved)
 
-A future errata to BRC-150 MAY explicitly list basket `1sat-ft` in scope; until then this BRC imports the format by reference.
+Post-genesis mint via `mint.extend` is **not binding** without a future **auth** rule on the origin. Uncapped (`supply` omitted / `open`) is not the same as free extend — new tips still need genesis, mint-batch, BRC-150, or a proven parent hop.
 
-### Listing
+### Market / overlay notes (informative)
 
-`listOutputs({ basket: "1sat-ft", … })` returns held tips. Wallets aggregate by normalized `origin` for UI balances. Tips that fail binding checks MUST NOT be counted in the spendable fungible balance (they MAY still be shown as unverified).
-
-## Implementation notes (informative)
-
-HandCash Desktop / Mobile implement tip list, tip-move send, and peer settle for this model. Mint / lock is performed by a separate mint application over BRC-100; the wallet holds and transfers. Early local storage may use an alias basket name during migration; interop writers SHOULD emit `1sat-ft`.
+| Concern | Approach |
+|---------|----------|
+| Token identity in a catalog | Origin outpoint |
+| Seller inventory | Bound tips in `1sat-ft` (UTXOs) with `amt` |
+| Listing lock | Existing OrdLock / marketplace patterns on tip UTXOs |
+| Settlement | Conserving tip spends to buyer (same as wallet send) |
+| Discovery / volume charts | Optional overlays (grade C) — never custody |
+| Scaling | Transfer cost ≈ tips spent/created, not unit count; prefer compact `amt` |
 
 ## Security considerations
 
-* **Tag spoofing** — `origin:` and `sym` are claims. Without mint-batch attestation, parent hop, or BRC-150 verification, wallets MUST treat identity as unproven.
-* **Mint-batch trust** — Same-tx batch binding is weaker than full ordinal lineage. Prefer BRC-150 once a path exists. Open-supply extensions MUST be policy-gated by the minter; holders cannot assume global uniqueness of tip count without additional conventions.
-* **Basket mix-up** — Filing fungible tips into `1sat` corrupts collectable inventory; filing collectables into `1sat-ft` corrupts balances. Eligibility rules above are intentional.
-* **Locked supply** — `locked` / `max` are remittance. They do not by themselves prevent a malicious minter from creating more tips on-chain; receivers SHOULD refuse tips that violate declared lock policy when that policy is known.
+* **Tag / CI spoofing** — Without binding (§Binding), identity is unproven. Markets MUST NOT treat unproven tips as inventory of origin `O`.
+* **`amt` inflation** — Receivers MUST enforce §Conservation when parent spend data is available; unbound or non-conserving tips MUST NOT increase spendable balance.
+* **Mint-batch weaker than 150** — Prefer 150 after first hop. Genesis envelopes + `max` + Σ `amt` bound the batch.
+* **Locked vs lying minter** — Origin `max` does not stop extra 1-sat outputs on-chain; conforming wallets **reject** tips that do not bind / conserve for that token id.
+* **Open mint** — Deferred precisely because unbounded extend claims are forgeable.
+* **Basket mix-up** — Do not file fungibles into `1sat` or collectables into `1sat-ft`.
 
 ## Relationship to other BRCs
 
 | BRC | Relationship |
 |-----|----------------|
-| [BRC-147](./0147.md) | Collectables profile; NFT basket `1sat` — complementary, not shared storage. |
-| [BRC-150](./0150.md) | Provenance remittance format imported for lineage hops. |
-| [BRC-159](./0159.md) / [BRC-160](./0160.md) | Origin theory and envelopes unchanged. |
-| [BRC-165](./0165.md) | P1Sat permissions for collectables; fungible permission scopes MAY follow later under scheme `1sat`. |
+| [BRC-147](./0147.md) | Collectables / NFT basket `1sat`. |
+| [BRC-150](./0150.md) | Provenance format for lineage hops. |
+| [BRC-159](./0159.md) / [BRC-160](./0160.md) | Origin theory / envelopes. |
+| [BRC-165](./0165.md) | P1Sat permissions for collectables; fungible scopes MAY follow. |
 
 ## Copyright
 

--- a/tokens/0166.md
+++ b/tokens/0166.md
@@ -1,0 +1,167 @@
+# BRC-166: 1Sat Fungible Basket Profile for BRC-46 / BRC-100
+
+Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
+
+## Abstract
+
+This BRC defines the **fungible** application basket profile for 1Sat under [BRC-46](../wallet/0046.md) / [BRC-100](../wallet/0100.md). A fungible 1Sat token is a set of **1-satoshi tips that share one origin**. Token identity is that origin outpoint. In v1, **one tip is one unit**; balance is the count of held tips bound to the origin. Transfers **move tips** (P2PKH), the same custody pattern as collectables ([BRC-147](./0147.md)).
+
+Offline tip→origin proof reuses the [BRC-150](./0150.md) remittance format wherever a conforming lineage path exists. This profile adds shared-origin fungibility, a dedicated storage basket, mint-batch binding for genesis siblings, and open vs locked supply metadata.
+
+This BRC does not redefine 1Sat origin theory ([BRC-159](./0159.md)) or inscription envelopes ([BRC-160](./0160.md)).
+
+## Motivation
+
+Collectables already interoperate as tip→origin assets with offline proof ([BRC-147](./0147.md), [BRC-150](./0150.md)). Fungible balances that re-inscribe protocol JSON each hop (e.g. BSV-21) do not share that transfer path and typically depend on indexers for discovery.
+
+Wallets need a shared contract so that:
+
+1. Many tips may share one origin and count as fungible units.
+2. Fungible tips are not filed into NFT basket `1sat` (item accounting stays clean).
+3. Senders move tips and attach remittance; receivers verify without an indexer deciding custody.
+4. Mint may create an origin plus sibling tips in one transaction, with an explicit binding rule when those siblings are not ordinal descendants of the origin.
+
+## Specification
+
+### Basket identifier
+
+* The storage basket name is the UTF-8 string `1sat-ft`.
+* After [BRC-46](../wallet/0046.md) normalization (trim + lowercase), conforming use MUST use exactly `1sat-ft`.
+* This identifier does **not** use the [BRC-99](../wallet/0099.md) `p ` prefix. It is a standard application basket under BRC-46.
+* Outputs for this profile MUST NOT be placed in basket `1sat` ([BRC-147](./0147.md)).
+
+### Eligibility
+
+An output SHOULD be placed in basket `1sat-ft` only when **all** of the following hold:
+
+1. `satoshis === 1`.
+2. The tip is intended as a unit of a fungible 1Sat token whose identity is a shared *origin* outpoint.
+3. The sender or importer reasonably believes the tip binds to that origin under this profile (genesis tip, mint-batch sibling, inductive remittance hop, and/or [BRC-150](./0150.md) lineage).
+
+Wallets MUST NOT place ordinary payment change or multi-sat outputs into `1sat-ft`.
+
+### Token identity and units
+
+* **Token id** = origin outpoint in underscore form `txid_vout` (same normalization rules as [BRC-147](./0147.md)).
+* **v1 unit** = one eligible tip bound to that origin.
+* **Balance** = number of such tips held. Decimals and multi-unit tips are out of scope for this version.
+
+### Outpoint encoding
+
+Same as [BRC-147](./0147.md): wire `txid.vout`, 1Sat underscore form interchangeable after normalize.
+
+### Tags
+
+Tags are optional and **non-authoritative for asset identity**.
+
+| Tag | Requirement | Meaning |
+|-----|-------------|---------|
+| `1sat-ft` | SHOULD | Marks the output under this fungible profile. |
+| `ordinal` | SHOULD | Marks a 1-sat ordinal tip. |
+| `origin:<outpoint>` | SHOULD when origin is known | Claimed token origin (`dot` or `underscore`). |
+| `name:<string>` | MAY | Short display name (≤ 80 UTF-8 code units when writing). |
+| `sym:<string>` | MAY | Short ticker / symbol (≤ 32). |
+| `id:<key>` / `outid:<key>` | SHOULD for held rows | Local list/spend key ([BRC-164](../wallet/0164.md) practice). Not asset identity. |
+
+Unknown tags MUST be preserved when transporting the output.
+
+### Custom instructions ([BRC-37](../outpoints/0037.md))
+
+When present for basket `1sat-ft`, `customInstructions` MUST be a UTF-8 JSON object serialized as a string. Conforming writers SHOULD emit:
+
+```json
+{
+  "p": "1sat-ft",
+  "origin": "<txid_vout>",
+  "sym": "<optional>",
+  "name": "<optional>",
+  "supply": "open" | "locked",
+  "max": "<optional decimal string when locked>",
+  "mint": { "batch": true, "vout": 3 },
+  "parent": "<optional prior tip txid_vout>",
+  "provenance": { }
+}
+```
+
+| Field | Type | Requirement | Meaning |
+|-------|------|-------------|---------|
+| `p` | string | SHOULD | Profile id `1sat-ft`. |
+| `origin` | string | MUST when known | Token origin, underscore form. |
+| `sym` / `name` | string | MAY | Display claims. |
+| `supply` | string | SHOULD on genesis remittance | `open` or `locked`. Default `open` if omitted. |
+| `max` | string | MAY when `supply` is `locked` | Declared supply cap (tip count). Mint policy attestation — not a global chain census. |
+| `mint` | object | MAY | Mint attestation (see below). |
+| `parent` | string | MAY | Prior tip outpoint this tip descends from by remittance hop. |
+| `provenance` | object | SHOULD when a [BRC-150](./0150.md) package can be built | Same v2 schema as BRC-150. |
+
+### Supply
+
+| State | Meaning |
+|-------|---------|
+| `open` | Further mint tips MAY claim this origin under issuer / minter policy. |
+| `locked` | Supply is closed; conforming minters MUST NOT create further tips for this origin. Optional `max` is the declared tip-count cap. |
+
+Supply fields are **mint policy remittance**. Holders verify their tips; they are not required to enumerate global supply via an indexer.
+
+### Mint batch (genesis siblings)
+
+A genesis mint MAY create the origin tip and additional 1-sat outputs in the **same transaction**.
+
+* Origin tip: outpoint equals `origin` (commonly `txid_0` when `randomizeOutputs` is false).
+* Sibling tip at `txid_vout` (vout ≠ origin vout) MAY bind to that origin when remittance includes:
+
+```json
+"mint": { "batch": true, "vout": <this output's vout> }
+```
+
+and `origin` matches the genesis origin outpoint on the same txid.
+
+Receivers MUST still require `satoshis === 1` and SHOULD require a valid first `ord` envelope on tips presented as units of the token ([BRC-160](./0160.md)).
+
+When a tip later gains a full [BRC-150](./0150.md) lineage path, wallets SHOULD prefer that proof over mint-batch attestation alone.
+
+### Transfer
+
+1. Select one or more tips of the same origin.
+2. Spend each tip to a new 1-sat output paying the recipient (P2PKH or other eligible lock).
+3. File the new tip in basket `1sat-ft` with `origin:` tags and CI.
+4. Attach [BRC-150](./0150.md) `provenance` when a conforming path exists; otherwise set `parent` to the spent tip outpoint and preserve `origin` / supply fields.
+
+Peer delivery of remittance (messagebox / BRC-100 internalization) follows the same custody vs remittance split as collectables: chain tip is custody; remittance is identity.
+
+### Provenance scope
+
+[BRC-150](./0150.md) is written against basket `1sat`. For this profile:
+
+* The **provenance object schema and verification rules** of BRC-150 v2 apply unchanged when present under `customInstructions.provenance`.
+* Conforming wallets MUST accept BRC-150 packages for `1sat-ft` tips the same way they do for `1sat` tips, modulo basket filing.
+
+A future errata to BRC-150 MAY explicitly list basket `1sat-ft` in scope; until then this BRC imports the format by reference.
+
+### Listing
+
+`listOutputs({ basket: "1sat-ft", … })` returns held tips. Wallets aggregate by normalized `origin` for UI balances. Tips that fail binding checks MUST NOT be counted in the spendable fungible balance (they MAY still be shown as unverified).
+
+## Implementation notes (informative)
+
+HandCash Desktop / Mobile implement tip list, tip-move send, and peer settle for this model. Mint / lock is performed by a separate mint application over BRC-100; the wallet holds and transfers. Early local storage may use an alias basket name during migration; interop writers SHOULD emit `1sat-ft`.
+
+## Security considerations
+
+* **Tag spoofing** — `origin:` and `sym` are claims. Without mint-batch attestation, parent hop, or BRC-150 verification, wallets MUST treat identity as unproven.
+* **Mint-batch trust** — Same-tx batch binding is weaker than full ordinal lineage. Prefer BRC-150 once a path exists. Open-supply extensions MUST be policy-gated by the minter; holders cannot assume global uniqueness of tip count without additional conventions.
+* **Basket mix-up** — Filing fungible tips into `1sat` corrupts collectable inventory; filing collectables into `1sat-ft` corrupts balances. Eligibility rules above are intentional.
+* **Locked supply** — `locked` / `max` are remittance. They do not by themselves prevent a malicious minter from creating more tips on-chain; receivers SHOULD refuse tips that violate declared lock policy when that policy is known.
+
+## Relationship to other BRCs
+
+| BRC | Relationship |
+|-----|----------------|
+| [BRC-147](./0147.md) | Collectables profile; NFT basket `1sat` — complementary, not shared storage. |
+| [BRC-150](./0150.md) | Provenance remittance format imported for lineage hops. |
+| [BRC-159](./0159.md) / [BRC-160](./0160.md) | Origin theory and envelopes unchanged. |
+| [BRC-165](./0165.md) | P1Sat permissions for collectables; fungible permission scopes MAY follow later under scheme `1sat`. |
+
+## Copyright
+
+Copyright (c) Brandon Cryderman / HandCash. Licensed under the Open BSV License.

--- a/tokens/0175.md
+++ b/tokens/0175.md
@@ -40,7 +40,7 @@ An output SHOULD be placed in basket `1sat-ft` only when **all** hold:
 1. `satoshis === 1`.
 2. The tip is a carrier for fungible units of a token whose identity is a shared origin outpoint.
 3. The tip **binds** to that origin under §Binding (below).
-4. The tip carries a valid first `ord` envelope ([BRC-160](./0160.md)) when presented as a token unit (genesis and mint-batch tips MUST; transferred tips SHOULD retain or re-attach envelope policy only via remittance if the spend strips the envelope — P2PKH tip moves are allowed; binding then relies on remittance + 150).
+4. The tip carries a valid first `ord` envelope ([BRC-160](./0160.md)). Genesis and mint-batch tips MUST. **New transfer colour tips MUST** (see §Transfer inscription). Legacy bare leftovers MAY exist; they bind only via lineage walk and MUST NOT invent `amt`.
 
 Wallets MUST NOT place ordinary payment change or multi-sat outputs into `1sat-ft`.  
 **Autodetect is not “any 1-sat output”:** `satoshis === 1` is necessary; basket + binding are required before counting units.
@@ -137,9 +137,10 @@ Merging (many inputs → fewer outputs) and splitting (few inputs → more outpu
 A tip **binds** to origin `O` if any of the following hold (checked in order):
 
 1. **Genesis** — tip outpoint equals `O`, and origin inscription parses as this profile.
-2. **BRC-150** — `customInstructions.provenance` verifies per [BRC-150](./0150.md) v2 to origin `O`.
-3. **Mint batch** — same-tx sibling attestation as above.
-4. **Parent hop** — remittance `parent` names a tip that itself binds to `O` (inductive), and this tip’s `amt` is consistent with a conserving spend of that parent (wallets SHOULD verify when parent spend data is available). Wallets MUST depth-limit inductive walks and MUST fail closed on cycles, missing parents, or parents that do not themselves bind. A `parent` claim alone MUST NOT bind.
+2. **Transfer inscription** — this tip’s first `ord` envelope is `application/1sat-ft+json` with a positive integer `amt`, and the spend-chain / BRC-150 walk binds to `O`. `amt` is taken from this envelope.
+3. **BRC-150** — `customInstructions.provenance` verifies per [BRC-150](./0150.md) v2 to origin `O`.
+4. **Mint batch** — same-tx sibling attestation as above.
+5. **Parent hop** — remittance `parent` names a tip that itself binds to `O` (inductive), and this tip’s `amt` is consistent with a conserving spend of that parent (wallets SHOULD verify when parent spend data is available). Wallets MUST depth-limit inductive walks and MUST fail closed on cycles, missing parents, or parents that do not themselves bind. A `parent` claim alone MUST NOT bind.
 
 `mint.extend` without a future auth rule does **not** bind.
 
@@ -180,27 +181,47 @@ Unknown tags MUST be preserved.
 | `parent` | MAY | Prior tip for inductive bind. |
 | `provenance` | SHOULD when buildable | BRC-150 v2 object. |
 
+### Transfer inscription
+
+Conforming senders MUST inscribe each new colour tip (payee and change) as `application/1sat-ft+json` over P2PKH. Body is UTF-8 JSON:
+
+```json
+{
+  "amt": "9000"
+}
+```
+
+| Field | Requirement | Meaning |
+|-------|-------------|---------|
+| `amt` | MUST | Face value of **this** tip (decimal string). |
+
+Origin is **not** written on the leftover. Identity is the spend-chain / [BRC-150](./0150.md) walk to the mint, same as [BRC-147](./0147.md). `amt` is on this tip so a split can be verified before the wallet shows it as true.
+
+Other 1-sat outputs in the same transaction are **not** carriers unless they carry this envelope.
+
+Remittance (`customInstructions`) MAY repeat `origin` + `amt` to speed import, same as 147. When remittance `amt` and the inscription disagree, **the inscription wins**. A tip with no envelope is legacy: scanners MUST walk spend-chain to an inscribed ancestor and MUST NOT invent `amt`.
+
 ### Transfer
 
 1. Select input tip(s) bound to the same origin with sufficient Σ `amt`.
 2. Build output tip(s): payee amounts + change; enforce §Conservation.
 3. Spend inputs; create new 1-sat outputs (BSV funds dust + fees).
-4. File under basket `1sat-ft` with tags + CI including `amt`.
-5. Attach BRC-150 when a path exists; else set `parent` to a spent tip and echo origin policy.
-
-**On-chain tip shape:** Genesis and mint-batch tips MUST carry the origin / sibling `ord` envelope. **Transferred tips MAY be bare P2PKH** (same custody shape as [BRC-147](./0147.md) tip moves). Face value and origin travel in remittance (`customInstructions`) and optional BRC-150 — they are **not** required to be re-inscribed each hop. Re-inscription of transfer tips is OPTIONAL and MUST NOT be relied on to protect pre–BRC-175 clients (see §Security).
+4. **Inscribe** each colour tip per §Transfer inscription.
+5. File under basket `1sat-ft` with tags + CI including `amt` (fast path).
+6. Attach BRC-150 when a path exists; else set `parent` to a spent tip and echo origin policy.
 
 ### Chain scan and basket separation
 
-Address / UTXO scan MAY surface 1-sat outs that spend 1-sat parents. Conforming wallets:
+Address / UTXO scan MAY surface 1-sat outs. Conforming wallets:
 
-* MUST NOT place such an output in basket `1sat` ([BRC-147](./0147.md)) solely because the creating transaction spends a 1-sat input — that shape is shared with this profile’s transfers.
-* MUST NOT place an output in basket `1sat-ft` until it **binds** under §Binding (remittance, BRC-150, genesis, or mint-batch). Unbound 1-sat outs SHOULD be held (not swept, not painted as collectables).
-* When walking tip lineage for discovery, an ancestor whose first `ord` envelope content-type is `application/1sat-ft+json` MUST be treated as this profile — not as a collectable mint.
+* An output whose own first `ord` envelope is `application/1sat-ft+json` MUST be this profile. Read `amt` from the body. Origin comes from the 150 / spend-chain walk. Remittance is a fast path only.
+* MUST NOT place a 1-sat output in basket `1sat` ([BRC-147](./0147.md)) solely because the creating transaction spends a 1-sat input.
+* MUST NOT place an output in basket `1sat-ft` until it **binds** under §Binding. Unbound 1-sat outs SHOULD be held (not swept, not painted as collectables).
+* When walking legacy bare-tip lineage, an ancestor whose first `ord` envelope content-type is `application/1sat-ft+json` MUST be treated as this profile — not as a collectable mint. Do not invent `amt` for that leftover.
 
 ### Peer capability (optional)
 
-Senders MAY advertise support for basket `1sat-ft` / this profile via identity or handle-resolve metadata, and MAY warn or refuse bare-address sends to peers that do not advertise it. Remittance delivery remains the preferred path for identified peers. Capability bits are **not** a custody requirement.
+Senders MAY advertise support for basket `1sat-ft` / this profile via identity or handle-resolve metadata, and MAY warn or refuse bare-address sends to peers that do not advertise it. Remittance is a fast path for identified peers; the inscription is custody. Capability bits are **not** a custody requirement.
 
 ### Provenance scope
 
@@ -229,13 +250,13 @@ Post-genesis mint via `mint.extend` is **not binding** without a future **auth**
 * **Locked vs lying minter** — Origin `max` does not stop extra 1-sat outputs on-chain; conforming wallets **reject** tips that do not bind / conserve for that token id.
 * **Open mint** — Deferred precisely because unbounded extend claims are forgeable.
 * **Basket mix-up** — Do not file fungibles into `1sat` or collectables into `1sat-ft`.
-* **Shared bare-transfer shape** — A bare 1-sat tip that spends a 1-sat parent is **not** sufficient evidence of a collectable. Wallets that auto-import that shape into basket `1sat` will misfile BRC-175 payee and change tips. Misfiled tips are burn-as-NFT risk on those clients. Conforming receive paths follow §Chain scan and basket separation; senders SHOULD prefer remittance / capability-aware peers. Re-inscribing every transfer does **not** fix pre–BRC-175 clients that classify unknown `ord` mimes as collectables.
+* **Legacy bare leftovers** — Older sends may be bare P2PKH. A bare 1-sat that spends a 1-sat parent is **not** a collectable. Walk lineage; FT mime ancestor ⇒ this profile, and do not invent `amt`. New conforming sends inscribe origin + amt so a scan can read the tip without remittance. Pre–BRC-175 clients that treat unknown `ord` mimes as collectables may still misfile inscribed tips; that is an old-client bug, not a reason to omit the envelope.
 
 ## Relationship to other BRCs
 
 | BRC | Relationship |
 |-----|----------------|
-| [BRC-147](./0147.md) | Collectables / NFT basket `1sat`. Shared bare tip-move shape; see §Chain scan and basket separation. |
+| [BRC-147](./0147.md) | Collectables / NFT basket `1sat`. Remittance is a fast path on both profiles; see §Chain scan. |
 | [BRC-150](./0150.md) | Provenance format for lineage hops. |
 | [BRC-159](./0159.md) / [BRC-160](./0160.md) | Origin theory / envelopes. |
 | [BRC-165](./0165.md) | P1Sat permissions for collectables; fungible scopes MAY follow. |

--- a/tokens/0175.md
+++ b/tokens/0175.md
@@ -139,7 +139,7 @@ A tip **binds** to origin `O` if any of the following hold (checked in order):
 1. **Genesis** — tip outpoint equals `O`, and origin inscription parses as this profile.
 2. **BRC-150** — `customInstructions.provenance` verifies per [BRC-150](./0150.md) v2 to origin `O`.
 3. **Mint batch** — same-tx sibling attestation as above.
-4. **Parent hop** — remittance `parent` names a tip that itself binds to `O` (inductive), and this tip’s `amt` is consistent with a conserving spend of that parent (wallets SHOULD verify when parent spend data is available). Wallets SHOULD depth-limit and fail closed on cycles / missing parents.
+4. **Parent hop** — remittance `parent` names a tip that itself binds to `O` (inductive), and this tip’s `amt` is consistent with a conserving spend of that parent (wallets SHOULD verify when parent spend data is available). Wallets MUST depth-limit inductive walks and MUST fail closed on cycles, missing parents, or parents that do not themselves bind. A `parent` claim alone MUST NOT bind.
 
 `mint.extend` without a future auth rule does **not** bind.
 
@@ -188,6 +188,20 @@ Unknown tags MUST be preserved.
 4. File under basket `1sat-ft` with tags + CI including `amt`.
 5. Attach BRC-150 when a path exists; else set `parent` to a spent tip and echo origin policy.
 
+**On-chain tip shape:** Genesis and mint-batch tips MUST carry the origin / sibling `ord` envelope. **Transferred tips MAY be bare P2PKH** (same custody shape as [BRC-147](./0147.md) tip moves). Face value and origin travel in remittance (`customInstructions`) and optional BRC-150 — they are **not** required to be re-inscribed each hop. Re-inscription of transfer tips is OPTIONAL and MUST NOT be relied on to protect pre–BRC-175 clients (see §Security).
+
+### Chain scan and basket separation
+
+Address / UTXO scan MAY surface 1-sat outs that spend 1-sat parents. Conforming wallets:
+
+* MUST NOT place such an output in basket `1sat` ([BRC-147](./0147.md)) solely because the creating transaction spends a 1-sat input — that shape is shared with this profile’s transfers.
+* MUST NOT place an output in basket `1sat-ft` until it **binds** under §Binding (remittance, BRC-150, genesis, or mint-batch). Unbound 1-sat outs SHOULD be held (not swept, not painted as collectables).
+* When walking tip lineage for discovery, an ancestor whose first `ord` envelope content-type is `application/1sat-ft+json` MUST be treated as this profile — not as a collectable mint.
+
+### Peer capability (optional)
+
+Senders MAY advertise support for basket `1sat-ft` / this profile via identity or handle-resolve metadata, and MAY warn or refuse bare-address sends to peers that do not advertise it. Remittance delivery remains the preferred path for identified peers. Capability bits are **not** a custody requirement.
+
 ### Provenance scope
 
 The BRC-150 v2 **object schema and verification rules** apply unchanged when present. Conforming wallets MUST accept 150 packages for `1sat-ft` tips. A future BRC-150 errata MAY list basket `1sat-ft` explicitly; until then this BRC imports the format by reference.
@@ -215,12 +229,13 @@ Post-genesis mint via `mint.extend` is **not binding** without a future **auth**
 * **Locked vs lying minter** — Origin `max` does not stop extra 1-sat outputs on-chain; conforming wallets **reject** tips that do not bind / conserve for that token id.
 * **Open mint** — Deferred precisely because unbounded extend claims are forgeable.
 * **Basket mix-up** — Do not file fungibles into `1sat` or collectables into `1sat-ft`.
+* **Shared bare-transfer shape** — A bare 1-sat tip that spends a 1-sat parent is **not** sufficient evidence of a collectable. Wallets that auto-import that shape into basket `1sat` will misfile BRC-175 payee and change tips. Misfiled tips are burn-as-NFT risk on those clients. Conforming receive paths follow §Chain scan and basket separation; senders SHOULD prefer remittance / capability-aware peers. Re-inscribing every transfer does **not** fix pre–BRC-175 clients that classify unknown `ord` mimes as collectables.
 
 ## Relationship to other BRCs
 
 | BRC | Relationship |
 |-----|----------------|
-| [BRC-147](./0147.md) | Collectables / NFT basket `1sat`. |
+| [BRC-147](./0147.md) | Collectables / NFT basket `1sat`. Shared bare tip-move shape; see §Chain scan and basket separation. |
 | [BRC-150](./0150.md) | Provenance format for lineage hops. |
 | [BRC-159](./0159.md) / [BRC-160](./0160.md) | Origin theory / envelopes. |
 | [BRC-165](./0165.md) | P1Sat permissions for collectables; fungible scopes MAY follow. |

--- a/tokens/0175.md
+++ b/tokens/0175.md
@@ -31,7 +31,7 @@ Wallets and future **token markets** need a shared contract so that:
 * After [BRC-46](../wallet/0046.md) normalization (trim + lowercase), conforming use MUST use exactly `1sat-ft`.
 * This identifier does **not** use the [BRC-99](../wallet/0099.md) `p ` prefix.
 * Outputs for this profile MUST NOT be placed in basket `1sat` ([BRC-147](./0147.md)).
-* Readers MAY accept a legacy alias basket during migration; writers MUST emit `1sat-ft`.
+* Writers and readers MUST use `1sat-ft` (no legacy basket alias).
 
 ### Eligibility
 

--- a/tokens/0175.md
+++ b/tokens/0175.md
@@ -1,4 +1,4 @@
-# BRC-166: 1Sat Fungible Basket Profile for BRC-46 / BRC-100
+# BRC-175: 1Sat Fungible Basket Profile for BRC-46 / BRC-100
 
 Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
 

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -17,5 +17,5 @@ BRC | Standard
 150  | [1Sat Provenance Remittance for Basket `1sat`](./0150.md)
 159  | [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./0159.md)
 160  | [1Sat Ordinals — Inscription Envelopes](./0160.md)
-166  | [1Sat Fungible Basket Profile for BRC-46 / BRC-100](./0166.md)
+175  | [1Sat Fungible Basket Profile for BRC-46 / BRC-100](./0175.md)
 226  | [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./0226.md)

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -17,4 +17,5 @@ BRC | Standard
 150  | [1Sat Provenance Remittance for Basket `1sat`](./0150.md)
 159  | [1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking](./0159.md)
 160  | [1Sat Ordinals — Inscription Envelopes](./0160.md)
+166  | [1Sat Fungible Basket Profile for BRC-46 / BRC-100](./0166.md)
 226  | [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./0226.md)


### PR DESCRIPTION
## Summary

Adds **BRC-175**: fungible 1Sat tokens as 1-sat tips sharing one origin, each with face-value **`amt`** (balance = Σ `amt`).

- Storage basket `1sat-ft` (separate from NFT `1sat`)
- Transfers spend tips and create payee (+ change) 1-sat tips with conserved `amt`; imports BRC-150 provenance
- **Locked supply optional** (`supply` + `max` on origin); omit when uncapped
- Mint-batch attestation for same-tx genesis siblings; missing `amt` ⇒ 1 (legacy)
- **Chain scan / basket separation:** bare 1-sat tip moves are shared with [BRC-147](./tokens/0147.md); MUST NOT auto-file into `1sat` on “spent a 1-sat parent” alone; FT lineage (`application/1sat-ft+json`) MUST NOT paint as NFT. Documents old-client misfile / burn risk. Cross-note added on BRC-147 Compatibility / Security.

Number: **175** (was briefly drafted as 166; 175 is free on upstream).

Implemented in HandCash wallet for hold/send/receive; mint via BRC-100 / Mint Studio.

## Test plan

- [ ] Spec review (David / 1Sat maintainers especially welcome on amt conservation + optional lock)
- [ ] Confirm basket name `1sat-ft` is acceptable
- [ ] Confirm number **175** is still free at merge time
- [ ] Review bare-transfer coexistence with BRC-147 ingest heuristics