### PR TITLE
BRC-176: BSV-21 Validity Proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ BRC | Standard
 172  | [Giving an AI Agent Control of a Delivery Vehicle Without Giving It a Wallet](./state-machines/0172.md)
 173  | [Bitcoin Script to and from Bitcoin BASIC — a compiler and a decompiler](./scripts/0173.md)
 174  | [Consensus-Unique Name Tokens — Identity Binding and Verified Resolution](./tokens/0174.md)
+176  | [BSV-21 — Validity Proofs](./tokens/0176.md)
 190  | [Access Gates for Metanet Rooms](./apps/0190.md)
 210  | [Derived Collectibles](./apps/0210.md)
 218  | [Chat-Native Command Grammar for the Metanet](./apps/0218.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -127,6 +127,7 @@
 * [BSV-21 Basket Profile for BRC-46 / BRC-100](./tokens/0163.md)
 * [P1Sat Permission Scheme for Basket `1sat`](./tokens/0165.md)
 * [Consensus-Unique Name Tokens — Identity Binding and Verified Resolution](./tokens/0174.md)
+* [BSV-21 — Validity Proofs](./tokens/0176.md)
 * [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./tokens/0226.md)
 
 ## Overlays

--- a/tokens/0161.md
+++ b/tokens/0161.md
@@ -36,6 +36,7 @@ BSV-21 builds on an earlier **BSV-20** inscription format, which is **deprecated
 | UTXOs as tokens (philosophy) | [BRC-45](./0045.md) |
 | 1Sat origin and sat ordering | [BRC-159](./0159.md) |
 | Inscription envelopes | [BRC-160](./0160.md) |
+| Offline BEEF validity proofs | [BRC-176](./0176.md) |
 
 This BRC does **not** define marketplace locks, overlay topic naming, or BRC-100 basket profiles for tokens.
 
@@ -337,3 +338,4 @@ Out: 300 + 400
 3. [BRC-159](./0159.md) — 1Sat Ordinals — Single-Satoshi Tokens and Origin Tracking
 4. [BRC-160](./0160.md) — 1Sat Ordinals — Inscription Envelopes
 5. B protocol (Bitcom `19HxigV4QyBv3tHpQVcUEQyq1pzZVdoAut`)
+6. [BRC-176](./0176.md) — BSV-21 Validity Proofs

--- a/tokens/0162.md
+++ b/tokens/0162.md
@@ -67,6 +67,7 @@ Rules:
 * A script is a BSV-21 binary token output when the prefix matches this layout (including a valid payload push — `OP_0` or CBOR map). Tag, id, and amount define the role; map **contents** do not affect balance or authority admission.
 * The tag push is the only protocol marker.
 * A decoder consumes the prefix; everything after it is ordinary locking-script content for whatever spend path the output uses.
+* Binary wins: when a script carries a valid binary prefix, it is a BSV-21 binary output, even if the remainder of the script also parses as a [BRC-161](./0161.md) JSON inscription. Such a JSON inscription is locking-script content and is ignored for token purposes.
 
 ### Token identification
 

--- a/tokens/0162.md
+++ b/tokens/0162.md
@@ -36,6 +36,7 @@ This document defines a **binary** prefix: tag, token id, amount, and optional p
 | UTXOs as tokens (philosophy) | [BRC-45](./0045.md) |
 | Outpoint formats | [BRC-36](../outpoints/0036.md) |
 | JSON inscription encoding | [BRC-161](./0161.md) |
+| Offline BEEF validity proofs | [BRC-176](./0176.md) |
 
 This BRC does **not** define marketplace locks, overlay topic naming, or BRC-100 basket profiles.
 
@@ -306,3 +307,4 @@ Out: value 1_000_000 + authority
 2. [BRC-36](../outpoints/0036.md) — Outpoints
 3. [BRC-45](./0045.md) — UTXOs as tokens
 4. [BRC-161](./0161.md) — BSV-21 Fungible Tokens (JSON / Legacy)
+5. [BRC-176](./0176.md) — BSV-21 Validity Proofs

--- a/tokens/0163.md
+++ b/tokens/0163.md
@@ -8,7 +8,7 @@ This BRC defines the **application basket profile** for [BRC-161](./0161.md) BSV
 
 It does **not** redefine BSV-21 token economics (deploy, auth, mint, transfer, burn). Those live in [BRC-161](./0161.md) (JSON) and [BRC-162](./0162.md) (binary).
 
-**Trust model:** holders verify *their* tips (local history / remittance / BEEF for the outs they hold). Issuers are trusted for mint policy. Global supply-cap / world-conservation proofs are **not** required by this profile.
+**Trust model:** holders verify *their* tips (local history / remittance / [BRC-176](./0176.md) BEEF for the outs they hold). Issuers are trusted for mint policy. Global supply-cap / world-conservation proofs are **not** required by this profile.
 
 ## Motivation
 
@@ -182,7 +182,7 @@ A conforming transfer of held `bsv21` value SHOULD use BRC-100 `createAction` wi
 1. One or more **inputs** spending value tips (`satoshis === 1`) whose token id matches the token being sent (CI / script / tags).
 2. One or more **outputs** with `satoshis: 1`, `basket: "bsv21"`, filter tags (at least `bsv21:<tokenId>`), and `customInstructions` with load-bearing fields (`id`, `amt`, …) plus derivation when this wallet locks the output.
 3. Output amounts MUST NOT exceed input amounts for that token id under [BRC-161](./0161.md) conservation (excess burns). Change SHOULD return to the sender as another `bsv21` output when needed.
-4. Prefer supplying `inputBEEF` / BEEF for spent tips when available so the receiver can validate the spend graph ([BRC-62](../transactions/0062.md), [BRC-95](../transactions/0095.md)).
+4. Prefer supplying a [BRC-176](./0176.md) validity packet (`inputBEEF` / Atomic BEEF) for spent tips when available so the receiver can prove those outs without an indexer.
 5. When an icon outpoint is known for the token, SHOULD merge the **icon inscription transaction** into that BEEF so the receiver can decode ticker media offline (see Icon media).
 6. Action `labels` MAY include `bsv21`; labels are non-normative for balances. Held spends MAY use [BRC-164](../wallet/0164.md) list keys in labels when a permission module is present; that is out of scope for this profile’s remittance rules.
 
@@ -248,9 +248,10 @@ Spending or revealing `bsv21` basket outputs is **not** a [BRC-29](../payments/0
 
 1. [BRC-161](./0161.md) — BSV-21 Fungible Tokens (JSON / Legacy)
 2. [BRC-162](./0162.md) — BSV-21 Fungible Tokens (Binary)
-3. [BRC-147](./0147.md) — 1Sat Ordinals Basket Profile
-4. [BRC-164](../wallet/0164.md) — Output Identity Tags (`id:`)
-5. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions
-6. [BRC-46](../wallet/0046.md) — Output Baskets
-7. [BRC-100](../wallet/0100.md) — Wallet-to-Application Interface
-8. [BRC-159](./0159.md) / [BRC-160](./0160.md) — 1Sat carrier (not FT admission)
+3. [BRC-176](./0176.md) — BSV-21 Validity Proofs
+4. [BRC-147](./0147.md) — 1Sat Ordinals Basket Profile
+5. [BRC-164](../wallet/0164.md) — Output Identity Tags (`id:`)
+6. [BRC-37](../outpoints/0037.md) — Basket and Custom Instructions
+7. [BRC-46](../wallet/0046.md) — Output Baskets
+8. [BRC-100](../wallet/0100.md) — Wallet-to-Application Interface
+9. [BRC-159](./0159.md) / [BRC-160](./0160.md) — 1Sat carrier (not FT admission)

--- a/tokens/0176.md
+++ b/tokens/0176.md
@@ -1,0 +1,231 @@
+# BRC-176: BSV-21 — Validity Proofs
+
+Open Protocol Labs (info@opl.dev)
+
+**Authors:** David Case (dcase@opl.dev)
+
+**Contributors:** Luke Rohenaz (luke@opl.dev), Kurt Wuckert Jr. (kurt@opl.dev), Michael Boyd (root@opl.dev), Dan Wagner (dan@opl.dev)
+
+## Abstract
+
+This BRC defines an offline-verifiable **packet** that proves one or more transaction outputs are valid [BRC-161](./0161.md) / [BRC-162](./0162.md) BSV-21 tokens.
+
+The packet is a [BRC-62](../transactions/0062.md) BEEF. Delivery is **transaction-level** ([BRC-95](../transactions/0095.md) Atomic BEEF encoding) when proving outputs of one transaction, or [BRC-158](../transactions/0158.md) Outpoint BEEF when proving a single outpoint. Completeness and validation are **this** profile — not Atomic BEEF’s SPV-minimal ancestor set.
+
+[BRC-161](./0161.md) / [BRC-162](./0162.md) say when an output of one transaction is valid given valid inputs. This document says which transactions must be in the bag, and how to check those inputs by walking the bag.
+
+## Motivation
+
+BSV-21 balances live in UTXOs. A receiver who is handed a tip (or several tips in one transaction) needs to check that each claimed output is really a token of the named id and amount — without a global indexer.
+
+1Sat solves the analogous problem with a linear tip→origin walk ([BRC-159](./0159.md)) and a remittance bag ([BRC-150](./0150.md)). BSV-21 is different:
+
+* Identity is the **deploy outpoint**, not a sat origin.
+* Splits and merges make the ancestry a **DAG**, not a path.
+* Validity is **per token id per transaction** (conservation / authority), not sat ordering.
+* Funding inputs are irrelevant. Token-input source **bodies** are not.
+
+Atomic BEEF is an SPV package: mined ancestors may be reduced to merkle proofs, and transactions outside the subject’s SPV graph are stripped. Those bodies are not extraneous here. This profile keeps them.
+
+## Relationship to other documents
+
+| Concern | Document |
+|---------|----------|
+| Token id, ops, per-tx validation (JSON) | [BRC-161](./0161.md) |
+| Same model, binary prefix | [BRC-162](./0162.md) |
+| Basket `bsv21` remittance / tags | [BRC-163](./0163.md) |
+| BEEF / Atomic BEEF / Outpoint BEEF encodings | [BRC-62](../transactions/0062.md), [BRC-95](../transactions/0095.md), [BRC-158](../transactions/0158.md) |
+| 1Sat tip→origin (not used for BSV-21 validity) | [BRC-159](./0159.md) |
+
+## Specification
+
+### What is proven
+
+Given a packet and a set of **subject outpoints**, a successful verify means: each subject output is a valid BSV-21 output under [BRC-161](./0161.md) / [BRC-162](./0162.md), of the token id and amount carried on that output, funded by a valid deploy (and, for mints, a valid authority) **present in the packet**.
+
+The packet proves **local lineage** of the subjects. It does not prove that the issuer minted nothing else, and it does not prove UTXO set membership.
+
+### Packet
+
+The body is a [BRC-62](../transactions/0062.md) BEEF (V1 or V2). Envelope:
+
+| Envelope | When | Subject |
+|----------|------|---------|
+| Atomic BEEF (`0x01010101` + txid) | Proving one or more outputs of **one** transaction | That transaction id |
+| Outpoint BEEF (`0x16a7beef` + txid + vout) | Proving **one** outpoint | That outpoint |
+| Bare BEEF | Otherwise (several transactions’ outputs in one bag) | Caller names the subject outpoints |
+
+Atomic BEEF **encoding** is reused. These [BRC-95](../transactions/0095.md) rules **do not** apply:
+
+* Fail if a transaction is not an SPV ancestor of the subject.
+* Omit a transaction body once a merkle proof exists.
+
+[BRC-96](../transactions/0096.md) txid-only entries are not a transaction body. Missing body → that hop cannot be proven.
+
+### Completeness
+
+Let `S` be the subject outpoints. Let `T` be the set of token ids those outputs name (deploy outputs contribute their own outpoint as id).
+
+The BEEF MUST contain a **full transaction body** for:
+
+1. Every transaction that has a subject outpoint.
+2. Recursively, the source transaction of every **BSV-21 input of a token id in `T`** spent in those transactions, until each lineage reaches its **deploy**.
+
+It need **not** contain source transactions of non-token inputs (funding, fees, other protocols).
+
+Extra transactions MAY be present. They MUST NOT cause the packet to fail.
+
+To prove even a single transfer output of a transaction, the bag MUST still include **every** same-id token input of that transaction — conservation is per token id, not per vout.
+
+### Decode
+
+Each output is decoded as BSV-21 JSON ([BRC-161](./0161.md)) or binary ([BRC-162](./0162.md)). Either encoding is a BSV-21 output. Unrecognized scripts are ignored.
+
+Normalized record:
+
+| Encoding | Fields | `id` | Kind | `amt` |
+|----------|--------|------|------|-------|
+| JSON `deploy+mint` | — | this outpoint | `deploy-value` | `amt` |
+| JSON `deploy+auth` | — | this outpoint | `deploy-auth` | 0 |
+| JSON `mint` | `id` | field | `mint` | `amt` |
+| JSON `transfer` | `id` | field | `transfer` | `amt` |
+| JSON `burn` | `id` | field | `burn` | `amt` |
+| JSON `auth` | `id` | field | `auth` | 0 |
+| Binary, empty id, amt > 0 | — | this outpoint | `deploy-value` | amount |
+| Binary, empty id, amt = 0 | — | this outpoint | `deploy-auth` | 0 |
+| Binary, id, amt = 0 | 36-byte id | that outpoint | `auth` | 0 |
+| Binary, id, amt > 0 | 36-byte id | that outpoint | `value` | amount |
+
+Token ids compare in underscore form `txid_vout` ([BRC-161](./0161.md)).
+
+### Validation
+
+Parse the envelope; load the BEEF. Structural failure → unproven.
+
+`prove(outpoint)` means: this output is a valid BSV-21 token of the `id` and `amt` on its script. That is conservation (or a mint from proven authority) **at this hop**, with every value/auth input itself proven, back to a **deploy**. A deploy in the bag is not enough.
+
+Walk **backward**. A same-id token input counts only if `prove` succeeds on it. Deploy → genesis, done.
+
+Missing source body → that input counts as nothing (funding is often absent; a missing *token* input fails closed). Bitcoin transactions cannot cycle; if `prove` re-enters an outpoint still on the stack, the bag is malformed → unproven.
+
+Conservation is per token id in the transaction: proving one transfer uses the other same-id output **amounts** on that tx. It does not prove those siblings unless they are subjects too.
+
+```
+function prove(outpoint, beef):
+    if outpoint is already on the prove stack: fail          // malformed BEEF
+
+    tx = load outpoint's transaction from beef
+    if missing: fail
+
+    token = decodeBsv21(tx.outputs[outpoint.vout])
+    if token is none: fail
+    if token is a deploy: return ok                          // genesis
+
+    I = 0
+    hasAuth = false
+    for each input of tx:
+        sourceTx = load input's source transaction from beef
+        if missing: continue
+        spent = decodeBsv21(sourceTx.outputs[input.vout])
+        if spent is none: continue
+        if spent is a deploy:
+            spent.id = input's source outpoint
+        if spent.id != token.id: continue                    // other token / funding
+        if prove(input's source outpoint, beef) fails: continue
+
+        if spent is authority: hasAuth = true
+        else if spent is burn: continue
+        else: I += spent.amt
+
+    // O = same-id amounts this tx moves (not mints). Valid only if I >= O.
+    O = 0
+    for each output of tx:
+        created = decodeBsv21(output)
+        if created is none: continue
+        if created is a deploy:
+            created.id = this output's outpoint
+        if created.id != token.id: continue
+        if created is transfer or burn:
+            O += created.amt
+        else if created is binary value and not hasAuth:
+            O += created.amt
+
+    if token is transfer or burn or (binary value and not hasAuth):
+        if I < O: fail
+        return ok
+    if token is mint or auth or (binary value and hasAuth):
+        if not hasAuth: fail
+        return ok
+    fail
+```
+
+On failure, the named subjects are **unproven**. On success, each subject’s decoded `id` and `amt` are proven for that outpoint.
+
+### What this document does not cover
+
+* Unspent status / UTXO set membership
+* Global circulating supply
+* Basket remittance, tags, display fields — [BRC-163](./0163.md)
+* 1Sat sat ordering — [BRC-159](./0159.md)
+
+## Examples
+
+**Fixed-supply transfer (one parent):**
+
+```
+deploy+mint 10_000 at D
+  → transfer 4_900 + transfer 5_100
+```
+
+Packet for the 4_900 tip: subject tx + deploy tx. `I = 10_000 >= 10_000`, so that transfer is valid (the 5_100 sibling is used only for the conservation check).
+
+**Merge — both branches required:**
+
+```
+D 10_000
+  → A 6_000 + B 4_000
+      → M 10_000   (spends A and B)
+```
+
+Packet for `M` MUST include `M`, `A`’s tx, `B`’s tx, and `D`. Omitting `B`: `I = 6_000`, `O = 10_000` → unproven. Spend-as-input of `A` alone is not enough.
+
+**Mint:**
+
+```
+deploy+auth at D
+  → mint 1_000_000 + auth     (spends D)
+```
+
+Packet for the mint: subject tx + `D`. `hasAuth` from a proven `deploy-auth`. Value inputs are not required.
+
+**Over-transfer (fail):**
+
+```
+In:  500
+Out: 300 + 400 transfer
+```
+
+`I < O` → neither transfer is valid.
+
+## Security considerations
+
+* **Claims** — A sender `id` / `amt` / `sym` string is not this packet.
+* **Issuer mint policy** — Authority mints are valid if the auth lineage reaches `deploy+auth`. This does not cap global supply.
+* **Unspent status** — Not in scope. Same UTXO checks as any BSV payment.
+
+## Implementations
+
+* [b-open-io/1sat-stack](https://github.com/b-open-io/1sat-stack)
+* [b-open-io/1sat-sdk](https://github.com/b-open-io/1sat-sdk)
+
+## References
+
+1. [BRC-161](./0161.md) — BSV-21 Fungible Tokens (JSON / Legacy)
+2. [BRC-162](./0162.md) — BSV-21 Fungible Tokens (Binary)
+3. [BRC-163](./0163.md) — BSV-21 Basket Profile
+4. [BRC-62](../transactions/0062.md) — BEEF
+5. [BRC-95](../transactions/0095.md) — Atomic BEEF
+6. [BRC-96](../transactions/0096.md) — BEEF V2 Txid Only
+7. [BRC-158](../transactions/0158.md) — Outpoint BEEF
+8. [BRC-159](./0159.md) — 1Sat origin tracking
+9. [BRC-150](./0150.md) — 1Sat provenance remittance

--- a/tokens/0176.md
+++ b/tokens/0176.md
@@ -47,18 +47,22 @@ The packet proves **local lineage** of the subjects. It does not prove that the 
 
 ### Packet
 
-The body is a [BRC-62](../transactions/0062.md) BEEF (V1 or V2). Envelope:
+There is one packet: a [BRC-62](../transactions/0062.md) BEEF (V1 or V2) plus a **scope** — the set of subject outpoints the packet is verified against. The envelope only determines how the scope travels: embedded, or supplied by the caller.
 
-| Envelope | When | Subject |
-|----------|------|---------|
-| Atomic BEEF (`0x01010101` + txid) | Proving one or more outputs of **one** transaction | That transaction id |
-| Outpoint BEEF (`0x16a7beef` + txid + vout) | Proving **one** outpoint | That outpoint |
-| Bare BEEF | Otherwise (several transactions’ outputs in one bag) | Caller names the subject outpoints |
+| Envelope | When | Scope |
+|----------|------|-------|
+| Atomic BEEF (`0x01010101` + txid) | Proving one or more outputs of **one** transaction | Embedded: outputs of that transaction id |
+| Outpoint BEEF (`0x16a7beef` + txid + vout) | Proving **one** outpoint | Embedded: that outpoint |
+| Bare BEEF | Otherwise (several transactions’ outputs in one bag) | Out-of-band: caller names the subject outpoints |
 
-Atomic BEEF **encoding** is reused. These [BRC-95](../transactions/0095.md) rules **do not** apply:
+The verify result is always bound to the scope, however it arrived. A caller MUST prove exactly the outpoints it intends to accept; a proof obtained for one scope says nothing about any other outpoint.
+
+Atomic BEEF **encoding** is reused — only its byte framing. These [BRC-95](../transactions/0095.md) rules **do not** apply to a BRC-176 packet:
 
 * Fail if a transaction is not an SPV ancestor of the subject.
 * Omit a transaction body once a merkle proof exists.
+
+A BRC-176 packet MUST NOT be validated, stripped, or round-tripped as ordinary BRC-95 Atomic BEEF: BRC-95 body omission would remove the token-parent bodies this profile requires, and BRC-95 ancestor rejection would reject packets that are complete under this profile.
 
 [BRC-96](../transactions/0096.md) txid-only entries are not a transaction body. Missing body → that hop cannot be proven.
 
@@ -81,6 +85,8 @@ To prove even a single transfer output of a transaction, the bag MUST still incl
 
 Each output is decoded as BSV-21 JSON ([BRC-161](./0161.md)) or binary ([BRC-162](./0162.md)). Either encoding is a BSV-21 output. Unrecognized scripts are ignored.
 
+An output that parses under both encodings resolves to binary — [BRC-162](./0162.md) recognition rules.
+
 Normalized record:
 
 | Encoding | Fields | `id` | Kind | `amt` |
@@ -102,11 +108,15 @@ Token ids compare in underscore form `txid_vout` ([BRC-161](./0161.md)).
 
 Parse the envelope; load the BEEF. Structural failure → unproven.
 
+Before any token rule is evaluated, the BEEF itself MUST be valid under [BRC-62](../transactions/0062.md) / [BRC-95](../transactions/0095.md) / [BRC-158](../transactions/0158.md): every txid MUST match its raw transaction body, every included merkle path MUST verify against its trusted header (for unmined transactions, against the caller's trust anchor), and unmined descendants MUST chain to proven ancestors. BSV-21 admission is evaluated only over that verified transaction set. A self-consistent synthetic DAG is not a proof.
+
+Implementations MAY impose resource limits (transaction count, packet size, recursion depth). A tripped limit MUST be reported as unproven, failing closed for the affected subjects.
+
 `prove(outpoint)` means: this output is a valid BSV-21 token of the `id` and `amt` on its script. That is conservation (or a mint from proven authority) **at this hop**, with every value/auth input itself proven, back to a **deploy**. A deploy in the bag is not enough.
 
 Walk **backward**. A same-id token input counts only if `prove` succeeds on it. Deploy → genesis, done.
 
-Missing source body → that input counts as nothing (funding is often absent; a missing *token* input fails closed). Bitcoin transactions cannot cycle; if `prove` re-enters an outpoint still on the stack, the bag is malformed → unproven.
+Missing source body → that input counts as nothing. A missing body can only reduce `I`, never increase `O`: omitting a same-id parent may produce false negatives (unproven), but can never produce a false positive. Missing non-token/funding parents are irrelevant to BSV-21 lineage. Bitcoin transactions cannot cycle; if `prove` re-enters an outpoint still on the stack, the bag is malformed → unproven.
 
 Conservation is per token id in the transaction: proving one transfer uses the other same-id output **amounts** on that tx. It does not prove those siblings unless they are subjects too.
 
@@ -159,7 +169,7 @@ function prove(outpoint, beef):
     fail
 ```
 
-On failure, the named subjects are **unproven**. On success, each subject’s decoded `id` and `amt` are proven for that outpoint.
+On failure, the named subjects are **unproven**. On success, what is proven for each subject is the record `(outpoint, id, amt)` decoded from its own script in the verified packet — not any externally supplied claim about that outpoint.
 
 ### What this document does not cover
 

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -22,4 +22,5 @@ BRC | Standard
 163  | [BSV-21 Basket Profile for BRC-46 / BRC-100](./0163.md)
 165  | [P1Sat Permission Scheme for Basket `1sat`](./0165.md)
 174  | [Consensus-Unique Name Tokens — Identity Binding and Verified Resolution](./0174.md)
+176  | [BSV-21 — Validity Proofs](./0176.md)
 226  | [Miner-Enforced Resale-Royalty Covenant Tokens (OP_PUSH_TX)](./0226.md)

--- a/transactions/0158.md
+++ b/transactions/0158.md
@@ -27,6 +27,6 @@ David Case (david.case@shruggr.cloud)
 ## Notes (informative)
 
 * The embedded BEEF MAY include transactions that are not ancestors of the subject tx (e.g. funding spent beside a 1Sat tip). That is intentional for profiles such as [BRC-150](../tokens/0150.md).
-* Completeness is profile-defined. Outpoint BEEF alone does not define sat ordering or inscription rules — see [BRC-159](../tokens/0159.md) / [BRC-160](../tokens/0160.md) / [BRC-150](../tokens/0150.md).
+* Completeness is profile-defined. Outpoint BEEF alone does not define sat ordering, inscription rules, or BSV-21 admission — see [BRC-159](../tokens/0159.md) / [BRC-160](../tokens/0160.md) / [BRC-150](../tokens/0150.md) / [BRC-176](../tokens/0176.md).
 * Bundle size grows with whatever the profile requires. For 1Sat tip→origin remittance, prefer extending a prior package and omitting oversized bags rather than dropping required input sources; see [BRC-150](../tokens/0150.md) (*Scalability*).
 * Do not nest this envelope inside BRC-150 `beefB64`. Basket remittance stays the JSON object; Outpoint BEEF is a parallel binary wire format (gateways, other transports).


### PR DESCRIPTION
Adds BRC-176: an offline-verifiable BEEF packet and validation walk for proving one or more BSV-21 outpoints.

Companion to BRC-161/162 (token rules) and BRC-163 (basket). Packet is Atomic BEEF at transaction level, or Outpoint BEEF for a single outpoint. Completeness requires token-parent bodies — Atomic BEEF's SPV-minimal stripping does not apply.