### PR TITLE
BRC-230: Wallet Index Expansion Packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ BRC | Standard
 227  | [Frictionless On-Chain Onboarding via Pre-Funded Claimable Tokens](./apps/0227.md)
 228  | [Unlinkable Payments under the Identity Paradigm](./payments/0228.md)
 229  | [Wallet-Native Elliptic Curve Point Multiplication as a BRC-98 Module](./wallet/0229.md)
+230  | [Wallet Index Expansion Packs](./wallet/0230.md)
 369  | [Keyed Content and Conditional Key Release](./peer-to-peer/0369.md)
 
 ## License

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -54,6 +54,7 @@
 * [Output Identity Tags for BRC-100 Wallets](./wallet/0164.md)
 * [Wallet Permission Prompt Liveness Contract](./wallet/0219.md)
 * [Wallet-Native Elliptic Curve Point Multiplication as a BRC-98 Module](./wallet/0229.md)
+* [Wallet Index Expansion Packs](./wallet/0230.md)
 
 ## Transactions
 

--- a/wallet/0230.md
+++ b/wallet/0230.md
@@ -1,0 +1,347 @@
+# BRC-230: Wallet Index Expansion Packs
+
+Brandon Cryderman / HandCash (brandongcryderman@gmail.com)
+
+**Status:** Proposed
+
+## Abstract
+
+This BRC defines **Index Expansion Packs**: curated, public overlay indexes that a
+[BRC-100](./0100.md) wallet may download and retain locally so applications can
+browse large collections, social feeds, and other grade-**C** convenience catalogs
+without re-fetching the full remote index on every screen open.
+
+An expansion pack is identified by a signed or host-published **manifest** that
+names a [BRC-22](./../overlays/0022.md) topic, a [BRC-24](./../overlays/0024.md)
+lookup service, sync bounds, and optional preview media (BEEF, UHRP, or HTTPS).
+Installation is always **user-requested** through the wallet permission layer
+([BRC-116](./0116.md)); the wallet surfaces progress in Activity and stores entries
+in a dedicated local profile distinct from custody baskets `1sat` / `bsv21`.
+
+This document composes BRC-22, BRC-24, [BRC-87](./../overlays/0087.md),
+[BRC-88](./../overlays/0088.md), BRC-100, BRC-116, [BRC-164](./0164.md), and
+optional [BRC-167 CHIRP](./../overlays/0167.md) transport. It does not redefine
+overlay admission rules or on-chain custody.
+
+## Motivation
+
+Overlay lookup ([BRC-24](./../overlays/0024.md)) answers “what exists on the
+network right now?” Remote hosts are authoritative for **live** topical UTXO sets,
+but many product experiences need:
+
+1. **Large catalogs** — thousands of NFT listings, feed cards, or app-specific
+   rows where paging the overlay on every navigation is slow or expensive.
+2. **Developer-scoped taste** — a curator (app, collection, or operator) publishes
+   a bounded index slice the user opts into once.
+3. **Offline-friendly browsing** — show the last synced page set and preview art
+   while the wallet catches up in the background.
+4. **Clear trust boundaries** — local index rows are **not** custody; held
+   collectables remain in basket `1sat` ([BRC-147](./../tokens/0147.md)) with
+   [BRC-150](./../tokens/0150.md) authenticity.
+
+[BRC-35](./../overlays/0035.md) local KVStore solves wallet-local key/value tuples,
+not “mirror this overlay lookup into browsable cards.” [BRC-165](./../tokens/0165.md)
+P1Sat permissions gate **held** inventory, not public catalog mirrors. No
+existing BRC specifies install → sync → query → uninstall for overlay-backed
+expansion packs.
+
+## Terminology
+
+| Term | Meaning |
+|------|---------|
+| **Pack** | One installed expansion identified by `packId`. |
+| **Manifest** | JSON document describing overlay source, scope, and budgets. |
+| **Entry** | One locally cached row (listing, feed item, catalog card) keyed inside a pack. |
+| **Grade A** | Chain custody — unchanged; packs never substitute for held UTXOs. |
+| **Grade C** | Convenience oracle — overlay index + cached display metadata. |
+
+## Normative language
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**,
+and **MAY** are normative (RFC 2119 / RFC 8174).
+
+## Specification
+
+### 1. Manifest
+
+Install requests reference a manifest URL or inline manifest object.
+
+```json
+{
+  "v": 1,
+  "packId": "handcash.market.catalog",
+  "name": "HandCash Market",
+  "description": "Browse active 1Sat listings",
+  "iconUrl": "https://market.handcash.io/icon.png",
+  "curatorIdentityKey": "<33-byte-compressed-pubkey-hex>",
+  "overlayBaseUrl": "https://market.handcash.io",
+  "topic": "tm_1sat_market",
+  "lookupService": "ls_1sat_market",
+  "scope": {
+    "kind": "overlay-query",
+    "query": {}
+  },
+  "budget": {
+    "maxEntries": 5000,
+    "maxBytes": 52428800,
+    "maxBeefBytes": 1048576
+  },
+  "preview": {
+    "beefB64": "<optional base64 BEEF for icon>"
+  },
+  "updatePolicy": {
+    "mode": "onOpen",
+    "intervalSeconds": 0
+  }
+}
+```
+
+| Field | Requirement | Meaning |
+|-------|-------------|---------|
+| `v` | MUST | Manifest schema version. This BRC defines `1`. |
+| `packId` | MUST | Stable UTF-8 id, 1–128 chars, `[a-z0-9][a-z0-9.-]*`. |
+| `name` | MUST | User-facing pack title (≤ 80 UTF-8 code units). |
+| `description` | SHOULD | Short explanation shown in the install prompt. |
+| `iconUrl` | MAY | HTTPS preview when `preview.beefB64` absent. |
+| `curatorIdentityKey` | SHOULD | BRC-31 identity key of the pack publisher. |
+| `overlayBaseUrl` | MUST | HTTPS origin for BRC-24 `/lookup` (and optional `/submit`). |
+| `topic` | MUST | BRC-87 topic manager name (`tm_*`). |
+| `lookupService` | MUST | BRC-87 lookup service name (`ls_*`). |
+| `scope` | MUST | See §1.1. |
+| `budget` | MUST | Hard caps enforced by the wallet. |
+| `preview` | MAY | Optional BEEF-carried icon ([BRC-62](./../transactions/0062.md)). |
+| `updatePolicy` | SHOULD | `manual`, `onOpen`, or `interval` with `intervalSeconds ≥ 300`. |
+
+Unknown manifest keys MUST be preserved on round-trip and ignored by readers that
+do not understand them. Wallets MUST reject manifests with `v !== 1`.
+
+#### 1.1 Scope kinds
+
+| `scope.kind` | Meaning |
+|--------------|---------|
+| `overlay-query` | Pass `scope.query` verbatim to BRC-24 lookup (service = manifest `lookupService`). |
+| `collection` | Equivalent to `overlay-query` with `query.collectionId` set. |
+| `feed` | Curator-defined query template; `scope.query` MUST be stable for the pack id. |
+
+Wallets MUST NOT broaden `scope` beyond what the user approved in the install
+prompt. Apps MAY request a **narrower** query at read time only if the narrowed
+query is a sub-filter of the approved scope.
+
+#### 1.2 Budget enforcement
+
+When `budget.maxEntries`, `budget.maxBytes`, or `budget.maxBeefBytes` would be
+exceeded, sync MUST stop cleanly, mark the pack `partial`, and leave prior entries
+ intact. Wallets MUST NOT silently evict held custody outputs to satisfy pack budgets.
+
+### 2. Local storage profile
+
+Expansion entries live outside custody baskets.
+
+| Layer | Value |
+|-------|-------|
+| Storage basket | `index` |
+| Pack tag | `pack:<packId>` |
+| Entry tag | `entry:<stable-entry-key>` |
+| BRC-164 row id | SHOULD stamp `id:<entry-key>` for list/spend isolation |
+
+`customInstructions` for basket `index` MUST be UTF-8 JSON:
+
+```json
+{
+  "packId": "handcash.market.catalog",
+  "entryKey": "listing:abc123_0",
+  "name": "Fetch coin",
+  "imageUrl": "https://…",
+  "origin": "abc123_0",
+  "overlayOutpoint": "abc123_0",
+  "beefB64": "<optional row BEEF>",
+  "updatedAt": 1735689600
+}
+```
+
+Fields are **display claims** (grade C). Wallets MUST NOT treat `origin` or
+`overlayOutpoint` as proven held inventory without a separate custody import.
+
+### 3. Permission scheme (BRC-99)
+
+Scheme id: **`index`**
+
+| Request | Wire | Meaning |
+|---------|------|---------|
+| Install pack | `p index install <packId>` | One-time or durable allow to download/sync manifest scope. |
+| Read pack | `p index read <packId>` | List cached entries for one installed pack. |
+| Sync pack | `p index sync <packId>` | Refresh against overlay (may reuse install grant). |
+
+Install and sync MUST prompt unless a durable grant exists ([BRC-116](./0116.md)).
+Read MAY reuse the install grant. Send/list/buy of **held** items remain under
+P1Sat ([BRC-165](./../tokens/0165.md)) — expansion read grants MUST NOT imply
+`p 1sat all`.
+
+`metanet.groupPermissions` in the app manifest SHOULD declare:
+
+```json
+{
+  "protocol": "index",
+  "description": "Install public catalog indexes for offline browsing",
+  "scopes": ["install", "read", "sync"]
+}
+```
+
+### 4. BRC-100 methods
+
+Conforming wallets expose these **vendor extensions** on the BRC-100 bridge
+(in addition to standard methods). All require `originator` and MUST gate on the
+permission scheme in §3.
+
+#### 4.1 `installIndexExpansion`
+
+**Request**
+
+```json
+{
+  "manifest": { },
+  "manifestUrl": "https://app.example/index-pack.json"
+}
+```
+
+Exactly one of `manifest` or `manifestUrl` MUST be present. The wallet fetches and
+validates the manifest, shows an install prompt (name, curator, topic, budgets),
+then begins initial sync.
+
+**Response**
+
+```json
+{
+  "packId": "handcash.market.catalog",
+  "status": "installing",
+  "activityId": "<uuid>"
+}
+```
+
+#### 4.2 `listIndexExpansions`
+
+Returns installed packs and sync metadata.
+
+```json
+{
+  "packs": [
+    {
+      "packId": "handcash.market.catalog",
+      "name": "HandCash Market",
+      "status": "ready",
+      "entryCount": 842,
+      "bytesUsed": 12000000,
+      "lastSyncedAt": 1735689600,
+      "partial": false
+    }
+  ]
+}
+```
+
+`status`: `installing` | `ready` | `partial` | `failed` | `removed`.
+
+#### 4.3 `removeIndexExpansion`
+
+```json
+{ "packId": "handcash.market.catalog" }
+```
+
+Deletes local basket `index` rows tagged `pack:<packId>`. MUST NOT relinquish held
+custody in `1sat`.
+
+#### 4.4 `syncIndexExpansion`
+
+```json
+{
+  "packId": "handcash.market.catalog",
+  "force": false
+}
+```
+
+Runs overlay lookup + incremental merge. Respects `updatePolicy` unless
+`force: true` and the user approves sync.
+
+#### 4.5 `listIndexExpansionEntries`
+
+Query local cache (post-filtered to approved scope):
+
+```json
+{
+  "packId": "handcash.market.catalog",
+  "tags": ["collection:fetch"],
+  "limit": 50,
+  "offset": 0
+}
+```
+
+Response mirrors BRC-100 `listOutputs` shape for basket `index` rows.
+
+### 5. Activity contract
+
+Install and sync MUST emit Activity rows ([HandCash practice](https://handcash.io);
+normative fields below):
+
+| Field | Value |
+|-------|-------|
+| `kind` | `event` |
+| `method` | `index-install` or `index-sync` |
+| `status` | `pending` → `complete` \| `failed` |
+| `note` | Human-readable progress (`Downloading catalog…`, `842 listings cached`) |
+| `item` | Optional preview: `name`, `imageUrl` from manifest `preview` or `iconUrl` |
+
+Failures MUST set `failureReason`. Partial sync MUST still mark `complete` with
+`note` mentioning partial state; pack `partial: true` in `listIndexExpansions`.
+
+### 6. Sync algorithm (normative outline)
+
+1. Resolve overlay host via manifest `overlayBaseUrl` (SLAP/SHIP discovery MAY
+   precede this per [BRC-88](./../overlays/0088.md)).
+2. POST BRC-24 lookup with `{ "service": "<lookupService>", "query": <scope.query> }`.
+3. For each admitted output, map overlay context to an `entryKey` and merge into
+   basket `index` under tags `pack:<packId>` and `entry:<entryKey>`.
+4. Optionally fetch BEEF for preview rows within `budget.maxBeefBytes` ([BRC-62](./../transactions/0062.md)).
+5. Large manifests MAY use [BRC-167 CHIRP](./../overlays/0167.md) / [BRC-26 UHRP](./../overlays/0026.md)
+   when the curator publishes blob roots instead of inline JSON pages.
+6. Stop at budget caps; set `partial` when truncated.
+
+### 7. Trust and security
+
+1. Local pack entries are **grade C** — display and discovery only.
+2. Purchases, sends, and authenticity MUST use held custody + BRC-150 as today.
+3. Wallets MUST NOT execute scripts or spend UTXOs because a pack row exists.
+4. Manifests from untrusted origins MUST fail closed unless the user approves install.
+5. Cached BEEF is for preview/SPV hints; it MUST NOT override live overlay state for
+   settlement decisions.
+
+### 8. Reference profile — 1Sat Market catalog
+
+| Field | Value |
+|-------|-------|
+| `packId` | `handcash.market.catalog` |
+| `topic` | `tm_1sat_market` |
+| `lookupService` | `ls_1sat_market` |
+| `scope.kind` | `overlay-query` |
+| HandCash settlement | Unchanged — market BRC-100 methods remain host-gated |
+
+This profile is **informative**; the normative pack format is §1.
+
+## References
+
+- [BRC-22 Overlay submission](./../overlays/0022.md)
+- [BRC-24 Lookup services](./../overlays/0024.md)
+- [BRC-35 Layered KVStore](./../overlays/0035.md)
+- [BRC-62 BEEF](./../transactions/0062.md)
+- [BRC-87 Naming conventions](./../overlays/0087.md)
+- [BRC-88 Overlay sync architecture](./../overlays/0088.md)
+- [BRC-99 P Baskets](./0099.md)
+- [BRC-100 Wallet interface](./0100.md)
+- [BRC-116 Permissions](./0116.md)
+- [BRC-147 1Sat basket](./../tokens/0147.md)
+- [BRC-150 Provenance](./../tokens/0150.md)
+- [BRC-165 P1Sat permissions](./../tokens/0165.md)
+- [BRC-167 CHIRP](./../overlays/0167.md)
+- [HandCash market overlay draft](https://github.com/HandCash/handcash-market/blob/master/spec/BRC-XXX-1sat-market-offer-overlay.md)
+
+## Copyright
+
+Open BSV License.

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -41,3 +41,4 @@ BRC | Standard
 164  | [Output Identity Tags for BRC-100 Wallets](./0164.md)
 219  | [Wallet Permission Prompt Liveness Contract](./0219.md)
 229  | [Wallet-Native Elliptic Curve Point Multiplication as a BRC-98 Module](./0229.md)
+230  | [Wallet Index Expansion Packs](./0230.md)


### PR DESCRIPTION
## Summary

Proposes **BRC-230** — a wallet standard for **Index Expansion Packs**: user-approved, locally cached mirrors of public overlay lookup indexes (large NFT catalogs, feeds, curated discovery).

The spec composes existing BRCs without redefining custody or overlay admission:

- **Manifest** — pack id, BRC-87 topic/lookup service, scope query, storage budgets, optional BEEF preview
- **Local profile** — basket `index` with `pack:<packId>` / `entry:<key>` tags and grade-**C** display metadata in `customInstructions`
- **Permissions** — BRC-99 scheme `index` (`p index install|read|sync <packId>`) gated by BRC-116
- **BRC-100 extensions** — `installIndexExpansion`, `listIndexExpansions`, `removeIndexExpansion`, `syncIndexExpansion`, `listIndexExpansionEntries`
- **Trust** — pack rows are convenience/oracle only; held inventory and BRC-150 authenticity are unchanged

Includes an informative reference profile for the HandCash Market 1Sat catalog (`handcash.market.catalog`).

**Author:** Brandon Cryderman / HandCash (brandongcryderman@gmail.com)

## Motivation

BRC-35 local KV and BRC-165 P1Sat permissions do not cover “install this overlay slice for offline browsing.” Apps today re-fetch full remote indexes on every navigation. This BRC gives wallets a standard install → sync → query → uninstall path with explicit user consent and budget caps.

## Test plan

- [ ] Maintainer review of BRC number assignment (230 follows wallet 229)
- [ ] Cross-reference links resolve in `wallet/0230.md`
- [ ] `README.md`, `SUMMARY.md`, and `wallet/README.md` index entries match
- [ ] Overlay/wallet/token references align with merged BRC-22/24/87/88/99/100/116/147/150/165 text


Made with [Cursor](https://cursor.com)