### PR TITLE
docs(BRC-169): same-block alias order by block index, not txid

### DIFF
--- a/peer-to-peer/0169.md
+++ b/peer-to-peer/0169.md
@@ -370,7 +370,7 @@ An advertisement is **valid** when its signature verifies, field 5 equals the cu
 **Conflict resolution.** When more than one valid advertisement claims the same alias:
 
 1. The client MUST surface the conflict rather than resolving it silently.
-2. The client SHOULD prefer the advertisement whose token was confirmed in the earliest block, and MUST break a remaining tie by the lowest block index of that token in the block. This makes aliases first-come, first-served in miner order. A transaction identifier MUST NOT be used as the tie-break: it is grindable, so a later same-block advertiser could otherwise front-run an earlier claim. The alternative, treating any conflict as fatal, would let anyone permanently disable any alias for the cost of one transaction.
+2. The client SHOULD prefer the advertisement whose token was confirmed in the earliest block, and MUST break a remaining tie by the lowest block index of that token in the block. This makes aliases first-come, first-served. The alternative, treating any conflict as fatal, would let anyone permanently disable any alias for the cost of one transaction.
 3. The client MUST allow the user to pin an alias to a specific domain, and a pin MUST override the ordering rule.
 4. Where an alias remains ambiguous or unpinned and the client is unwilling to apply the ordering rule, the fully-qualified domain MUST be displayed and used instead.
 

--- a/peer-to-peer/0169.md
+++ b/peer-to-peer/0169.md
@@ -370,7 +370,7 @@ An advertisement is **valid** when its signature verifies, field 5 equals the cu
 **Conflict resolution.** When more than one valid advertisement claims the same alias:
 
 1. The client MUST surface the conflict rather than resolving it silently.
-2. The client SHOULD prefer the advertisement whose token was confirmed in the earliest block, and MUST break a remaining tie by the lexicographically lowest transaction identifier. This makes aliases first-come, first-served. The alternative, treating any conflict as fatal, would let anyone permanently disable any alias for the cost of one transaction.
+2. The client SHOULD prefer the advertisement whose token was confirmed in the earliest block, and MUST break a remaining tie by the lowest block index of that token in the block. This makes aliases first-come, first-served in miner order. A transaction identifier MUST NOT be used as the tie-break: it is grindable, so a later same-block advertiser could otherwise front-run an earlier claim. The alternative, treating any conflict as fatal, would let anyone permanently disable any alias for the cost of one transaction.
 3. The client MUST allow the user to pin an alias to a specific domain, and a pin MUST override the ordering rule.
 4. Where an alias remains ambiguous or unpinned and the client is unwilling to apply the ordering rule, the fully-qualified domain MUST be displayed and used instead.
 

--- a/peer-to-peer/0169.md
+++ b/peer-to-peer/0169.md
@@ -370,7 +370,7 @@ An advertisement is **valid** when its signature verifies, field 5 equals the cu
 **Conflict resolution.** When more than one valid advertisement claims the same alias:
 
 1. The client MUST surface the conflict rather than resolving it silently.
-2. The client SHOULD prefer the advertisement whose token was confirmed in the earliest block, and MUST break a remaining tie by the lowest block index of that token in the block. This makes aliases first-come, first-served. The alternative, treating any conflict as fatal, would let anyone permanently disable any alias for the cost of one transaction.
+2. The client SHOULD prefer the advertisement whose token was confirmed in the earliest block, then the lowest transaction index in that block, then the lowest output index of the token. This makes aliases first-come, first-served. The alternative, treating any conflict as fatal, would let anyone permanently disable any alias for the cost of one transaction.
 3. The client MUST allow the user to pin an alias to a specific domain, and a pin MUST override the ordering rule.
 4. Where an alias remains ambiguous or unpinned and the client is unwilling to apply the ordering rule, the fully-qualified domain MUST be displayed and used instead.
 


### PR DESCRIPTION
## Problem

BRC-169 §5.5 broke same-block alias conflicts on lexicographic txid, which is grindable.

## Change

Same-block tie-break is the lowest block index of the token in the block.